### PR TITLE
libnotify: version bumped after _years_

### DIFF
--- a/libs/libnotify/DETAILS
+++ b/libs/libnotify/DETAILS
@@ -1,11 +1,11 @@
           MODULE=libnotify
-         VERSION=0.5.2
-          SOURCE=$MODULE-$VERSION.tar.bz2
+         VERSION=0.7.5
+          SOURCE=$MODULE-$VERSION.tar.xz
       SOURCE_URL=http://ftp.gnome.org/pub/GNOME/sources/libnotify/${VERSION%.*}/
-      SOURCE_VFY=sha1:bb088a318cfccb4261674065838860fa940fc04a
+      SOURCE_VFY=sha1:729d1382617fee7e82eac17d808c11469ab2b7e1
         WEB_SITE=http://www.galago-project.org/
          ENTERED=20060526
-         UPDATED=20070309
+         UPDATED=20120929
            SHORT="the desktop notification framework library"
 
 cat << EOF


### PR DESCRIPTION
I didn't check most dependents, but ekiga needs the new version to build
