### PR TITLE
portmap: added systemd support and moved it to /usr

### DIFF
--- a/net/portmap/BUILD
+++ b/net/portmap/BUILD
@@ -1,6 +1,7 @@
 (
 
   sedit "/#include <tcpd.h>/d" pmap_check.c &&
+  sedit 's;}/sbin;}/usr/sbin;g' Makefile &&
 
   make NO_TCP_WRAPPER=1    &&
   prepare_install          &&

--- a/net/portmap/init.d/portmap
+++ b/net/portmap/init.d/portmap
@@ -4,7 +4,7 @@
 #
 # chkconfig: 345 11 89
 # description: the portmapper is the RPC port broker
-# processname: /sbin/portmap
+# processname: /usr/sbin/portmap
 #
 
 . /lib/lsb/init-functions

--- a/net/portmap/systemd.d/portmap.service
+++ b/net/portmap/systemd.d/portmap.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=RPC Port Mapper
+After=network.target
+
+[Service]
+ExecStart=/usr/sbin/portmap -d
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
If we're supposed to be putting stuff into /usr, we should actually do so, I think.
