### PR TITLE
ca-certificates: version bump

### DIFF
--- a/crypto/ca-certificates/DETAILS
+++ b/crypto/ca-certificates/DETAILS
@@ -1,11 +1,11 @@
           MODULE=ca-certificates
-         VERSION=20121105
+         VERSION=20121114
           SOURCE=${MODULE}_$VERSION.tar.gz
          SOURCE2=$MODULE-update.patch.bz2
 SOURCE_DIRECTORY=$BUILD_DIRECTORY/$MODULE-$VERSION
       SOURCE_URL=http://ftp.debian.org/debian/pool/main/c/$MODULE
      SOURCE2_URL=$PATCH_URL
-      SOURCE_VFY=sha1:ffebbdfc8f634df99d0795d909a6a073f6c8e9ce
+      SOURCE_VFY=sha1:abc3b25006fea83ae8ea141b21d22a7069e2863b
      SOURCE2_VFY=sha1:cef03ad446f6f13aaacd05bae3c7ad8e9cff304b
         WEB_SITE=http://packages.qa.debian.org/c/ca-certificates.html
          ENTERED=20100405


### PR DESCRIPTION
ca-certificates seems to be another one of those packages like
timezone-data where the old version is deleted when a new version comes
out.
