### PR TITLE
zfs: bump to 0.6.1, and build improved (albeit not exactly clean)

### DIFF
--- a/zbeta/zfs/BUILD
+++ b/zbeta/zfs/BUILD
@@ -1,5 +1,6 @@
 SPLDIR=$BUILD_DIRECTORY/spl-$VERSION
 
+cd $BUILD_DIRECTORY && unpack $SOURCE2 &&
 cd $SPLDIR &&
 default_config &&
 make ${MAKES:+-j${MAKES}} &&
@@ -8,6 +9,16 @@ OPTS="$OPTS --with-spl=$SPLDIR" default_config &&
 make ${MAKES:+-j${MAKES}} &&
 prepare_install &&
 cd $SPLDIR &&
-make install &&
+mkdir pkg &&
+
+# SPL and ZFS try to install files on top of themselves and fail, so do
+# this hack to work around it.
+make install DESTDIR=$(cd pkg; pwd) &&
+cd pkg &&
+tar cf - . | ( cd /; tar xf - ) &&
 cd $SOURCE_DIRECTORY &&
-make install
+mkdir pkg &&
+make install DESTDIR=$(cd pkg; pwd) &&
+cd pkg && tar cf - . | (cd /;tar xf -) &&
+depmod -a &&
+rm -rf $SPLDIR

--- a/zbeta/zfs/DETAILS
+++ b/zbeta/zfs/DETAILS
@@ -1,15 +1,15 @@
           MODULE=zfs
-         VERSION=0.6.0-rc14
+         VERSION=0.6.1
           SOURCE=$MODULE-$VERSION.tar.gz
          SOURCE2=spl-$VERSION.tar.gz
       SOURCE_URL=http://archive.zfsonlinux.org/downloads/zfsonlinux/$MODULE/
      SOURCE2_URL=http://archive.zfsonlinux.org/downloads/zfsonlinux/spl/
-      SOURCE_VFY=sha1:9f2e0236a8fd09d4021af582c5e88fdbe4ded51f
-     SOURCE2_VFY=sha1:e979bb5a6318b7e3d2a0d4039c6183cf293b6292
+      SOURCE_VFY=sha1:5c465e21e106ea3329c943802c0bf145b3b8f939
+     SOURCE2_VFY=sha1:76e54a735d8d3d9e8ae1ea713ba23ac3a96351cc
         WEB_SITE=http://www.zfsonlinux.org/
          LICENSE=cddl
          ENTERED=20130212
-         UPDATED=20130212
+         UPDATED=20130329
            SHORT="The ZFS file system"
 
 cat << EOF


### PR DESCRIPTION
There are some hacky things I had to do to deal with how zfs
comes in two very closely intertwined packages, and the exact
same version of both packages have to be installed at the same
time.

The install scripts within the packages also have some high weirdnesses
where they try to install stuff within their own build directory.
Fortunately they're using standard autoconf makefiles so this can
be worked around by abusing DESTDIR so that doesn't happen.  I'm
not the biggest fan of doing it that way, but at least it seems to work.
