### PR TITLE
opal: version bump to 3.10.10

### DIFF
--- a/net/opal/DETAILS
+++ b/net/opal/DETAILS
@@ -1,14 +1,14 @@
           MODULE=opal
-         VERSION=3.10.7
+         VERSION=3.10.10
           SOURCE=$MODULE-$VERSION.tar.xz
          SOURCE2=opal-3.10.7-ffmpeg-0.11.patch
       SOURCE_URL=$GNOME_URL/sources/$MODULE/${VERSION%.*}
      SOURCE2_URL=$PATCH_URL
-      SOURCE_VFY=sha1:e48d3295a73d6c3254823f09eb00a266916de94d
+      SOURCE_VFY=sha1:51cddcee0bdfe61dd0025ff6548d18e6aa0c255e
      SOURCE2_VFY=sha1:549e903e2ffd9fc6640c8b9f60c51a8d8d832e4e
         WEB_SITE=http://www.ekiga.org
          ENTERED=20070316
-         UPDATED=20121020
+         UPDATED=20130428
            SHORT="Open Phone Abstraction Library"
 
 cat << EOF


### PR DESCRIPTION
This updates opal to the latest version. No changelog was provided.
