### PR TITLE
Please pull gurgitate-mail 1.10.9

### DIFF
--- a/mail/gurgitate-mail/DETAILS
+++ b/mail/gurgitate-mail/DETAILS
@@ -1,12 +1,12 @@
           MODULE=gurgitate-mail
-         VERSION=1.10.5
+         VERSION=1.10.9
           SOURCE=$MODULE-$VERSION.tar.gz
 SOURCE_DIRECTORY=$BUILD_DIRECTORY/$MODULE
-      SOURCE_URL=http://lart.ca/software/$MODULE/
-      SOURCE_VFY=sha1:08cd58d925c75df92af3e9e7f79201d906226154
+      SOURCE_URL=http://www.lart.ca/software/$MODULE/
+      SOURCE_VFY=sha1:d3f8e9d7ff125ce1dcd32aaa8978bdf777242cfc
         WEB_SITE=http://gurgitate-mail.lart.ca/wiki/show/HomePage
          ENTERED=20050922
-         UPDATED=20101227
+         UPDATED=20130604
            SHORT="A highly-configurable mail delivery agent"
 
 cat << EOF


### PR DESCRIPTION
And this removes the last reason we have for not upgrading ruby to 2.0.
