### PR TITLE
httpd: roll back MAJOR version change to 2.4, bump to 2.2.25

### DIFF
--- a/web/httpd/DETAILS
+++ b/web/httpd/DETAILS
@@ -1,11 +1,11 @@
           MODULE=httpd
-         VERSION=2.4.4
+         VERSION=2.2.25
           SOURCE=$MODULE-$VERSION.tar.bz2
       SOURCE_URL=http://www.apache.org/dist/$MODULE
-      SOURCE_VFY=sha1:0c5ab7f876aa10fbe8bfab2c34f8dd3dc76db16c
+      SOURCE_VFY=sha1:e34222d1a8de38825397a1c70949bcc5836a1236
         WEB_SITE=http://www.apache.org
          ENTERED=20020710
-         UPDATED=20130629
+         UPDATED=20130719
            SHORT="A popular HTTP server"
 
 cat << EOF


### PR DESCRIPTION
Bumping to version 2.4 of httpd is a HUGE change and breaks MANY
people's servers.  Don't do that.  This is the second time I've had to
do this exact same commit.  Stop just bumping to whatever the biggest
number is by reflex.  Apache 2.4 is different enough that it practically
justifies a new module.

Stop breaking people's servers.  For crying out loud.  And if you don't
actually USE a major piece of software which you think it might be fun
to bump, DON'T BUMP IT!
