### PR TITLE
libpng: major bump to 1.6.x series FOR TESTING

### DIFF
--- a/graphics/libpng/BUILD
+++ b/graphics/libpng/BUILD
@@ -1,9 +1,3 @@
-(
+OPTS+=" --disable-static"  &&
 
-  patch_it $SOURCE_CACHE/$SOURCE2 1  &&
-
-  OPTS+=" --disable-static"  &&
-
-  default_build
-
-) > $C_FIFO 2>&1
+default_build

--- a/graphics/libpng/DETAILS
+++ b/graphics/libpng/DETAILS
@@ -1,15 +1,12 @@
           MODULE=libpng
-         VERSION=1.2.46
-          SOURCE=$MODULE-$VERSION.tar.gz
-         SOURCE2=$MODULE-$VERSION-pngrutil.patch.gz
+         VERSION=1.6.3
+          SOURCE=$MODULE-$VERSION.tar.xz
    SOURCE_URL[0]=$SFORGE_URL/$MODULE
    SOURCE_URL[1]=ftp://ftp.simplesystems.org/pub/libpng/png/src
-     SOURCE2_URL=$PATCH_URL
-      SOURCE_VFY=sha1:d5f3a2439b0b6d85a26499b2be09918eb54ea13a
-     SOURCE2_VFY=sha1:8d664bf51b73d0e4b9622d80ce91a1aaa8fde752
+      SOURCE_VFY=sha1:adc60a2c117a0929e18bf357e0a1e6115a9e3b76
         WEB_SITE=http://www.libpng.org/pub/png/libpng.html
          ENTERED=20010922
-         UPDATED=20120304
+         UPDATED=20130902
            SHORT="Library that supports the PNG graphics format"
 
 cat << EOF


### PR DESCRIPTION
Don't pull this to master unless you made sure it works with about _everything_.

This likely breaks a lot of apps. I already fixed quite a number of them, but
at least netpbm still fails.

1.6 hides some internals of libpng which were actively used by
other projects before.
