### PR TITLE
ca-certificates: bump version

### DIFF
--- a/crypto/ca-certificates/BUILD
+++ b/crypto/ca-certificates/BUILD
@@ -1,7 +1,3 @@
-(
-
-  patch_it $SOURCE_CACHE/$SOURCE2 1  &&
-
   make             &&
   prepare_install  &&
   install -d -m755 /{etc/ca-certificates/updates.d,usr/{sbin,share/ca-certificates},etc/ssl/certs}  &&
@@ -18,5 +14,3 @@
   ln -sf /etc/ssl/certs /etc/pki/tls/certs &&
   ln -sf /etc/ssl/certs /usr/share/ssl/certs &&
   ln -sf /etc/ssl/certs/ca-{certificates,bundle}.crt
-
-) > $C_FIFO 2>&1

--- a/crypto/ca-certificates/DETAILS
+++ b/crypto/ca-certificates/DETAILS
@@ -1,15 +1,15 @@
           MODULE=ca-certificates
-         VERSION=20130610
+         VERSION=20130906
           SOURCE=${MODULE}_$VERSION.tar.gz
          SOURCE2=$MODULE-update.patch.bz2
-SOURCE_DIRECTORY=$BUILD_DIRECTORY/$MODULE-$VERSION
+SOURCE_DIRECTORY=$BUILD_DIRECTORY/$MODULE
       SOURCE_URL=http://ftp.debian.org/debian/pool/main/c/$MODULE
      SOURCE2_URL=$PATCH_URL
-      SOURCE_VFY=sha1:6fdd45fcad49d57ac3b0598a57e168870092057c
+      SOURCE_VFY=sha1:7f197c1bf7c7fc82e9f8f2fec6d8cc65f6a6187b
      SOURCE2_VFY=sha1:cef03ad446f6f13aaacd05bae3c7ad8e9cff304b
         WEB_SITE=http://packages.qa.debian.org/c/ca-certificates.html
          ENTERED=20100405
-         UPDATED=20130612
+         UPDATED=20130930
            SHORT="common CA certificates"
 
 cat << EOF

--- a/crypto/ca-certificates/PRE_BUILD
+++ b/crypto/ca-certificates/PRE_BUILD
@@ -1,0 +1,3 @@
+default_pre_build &&
+
+patch_it $SOURCE2 1


### PR DESCRIPTION
The old file was deleted from the servers, so this bump also fixes the module.
