### PR TITLE
slim: build fixes

### DIFF
--- a/x11-utils/slim/DETAILS
+++ b/x11-utils/slim/DETAILS
@@ -1,11 +1,17 @@
           MODULE=slim
          VERSION=1.3.6
           SOURCE=$MODULE-$VERSION.tar.gz
+         SOURCE2=$MODULE-1.3.6-library-order.patch
+	 SOURCE3=$MODULE-1.3.6-nopam-fix.patch
       SOURCE_URL=http://download.berlios.de/$MODULE
+     SOURCE2_URL=$PATCH_URL
+     SOURCE3_URL=$PATCH_URL
       SOURCE_VFY=sha1:9407ea2ee7b2ed649f17a8ddbf1f7b26a7c7b9fb
+     SOURCE2_VFY=sha1:3da73dbbd46700ecb2f4bfe00ad62891cac8f5b5
+     SOURCE3_VFY=sha1:cc9ed4519ff543168f74e86e526e64cf501dbf51
         WEB_SITE=http://slim.berlios.de/
          ENTERED=20051121
-         UPDATED=20131005
+         UPDATED=20131024
            SHORT="Simple Login Manager"
 LUNAR_RESTART_SERVICES=off
 

--- a/x11-utils/slim/PRE_BUILD
+++ b/x11-utils/slim/PRE_BUILD
@@ -1,0 +1,8 @@
+default_pre_build &&
+
+patch_it $SOURCE2 1 &&
+patch_it $SOURCE3 1 &&
+
+# don't install systemd files here
+# we provide them separately
+sedit '/systemd/ d' CMakeLists.txt


### PR DESCRIPTION
Two patches are pretty obvious. The library order is needed to build
successfully with -Wl,--as-needed
