### PR TITLE
mongodb: Version bumped to 2.4.7

### DIFF
--- a/sql/mongodb/DEPENDS
+++ b/sql/mongodb/DEPENDS
@@ -2,3 +2,5 @@ depends boost
 depends scons
 depends libpcap
 depends pcre
+optional_depends openssl "--ssl" "" "for SSL support"
+optional_depends cyrus-sasl "--use-sasl-client" "" "for SASL auth support in the client library"

--- a/sql/mongodb/DETAILS
+++ b/sql/mongodb/DETAILS
@@ -1,5 +1,5 @@
           MODULE=mongodb
-         VERSION=2.4.5
+         VERSION=2.4.7
           SOURCE=$MODULE-src-r$VERSION.tar.gz
          SOURCE2=mongodb.conf-0.3
          SOURCE3=mongodb-2.4.5-fix-scons.patch
@@ -9,13 +9,13 @@
      SOURCE3_URL=$PATCH_URL
      SOURCE4_URL=$PATCH_URL
 SOURCE_DIRECTORY=$BUILD_DIRECTORY/$MODULE-src-r$VERSION
-      SOURCE_VFY=sha256:b576cbc2c813144b8a8774a7232b78bd0b005e2e6fa7428e7fa1e426c7a28705
+      SOURCE_VFY=sha256:69e3cf697225efa2e6e65f5cfdc31742f3e4b2e069c27d84fc713abe0bf67ca7
      SOURCE2_VFY=sha256:29e47681c4a9325a8288e3f5c3591138f08bce36178c21a0a4b41bf4b05922dc
      SOURCE3_VFY=sha256:166eaad8412c0479c0800ffecb15fbdd536caadb1b199d0e91555eb3d80d6af5
      SOURCE4_VFY=sha256:8907e4be5546ec7ea0146989d4d64d115b66a893adb7f1015ceba67e297c7dd0
         WEB_SITE=http://www.mongodb.org/
          ENTERED=20101205
-         UPDATED=20130719
+         UPDATED=20131027
            SHORT="A scalable, high-performance, key-value store, document-oriented database"
 cat << EOF
 MongoDB bridges the gap between key-value stores (which are fast and


### PR DESCRIPTION
Added options to enable ssl and sasl-client.
