### PR TITLE
Bitlbee: bump to 3.2.1

### DIFF
--- a/chat/bitlbee/DETAILS
+++ b/chat/bitlbee/DETAILS
@@ -1,8 +1,8 @@
           MODULE=bitlbee
-         VERSION=3.2
+         VERSION=3.2.1
           SOURCE=$MODULE-$VERSION.tar.gz
       SOURCE_URL=http://get.bitlbee.org/src/
-      SOURCE_VFY=sha1:21e17f082c776566429603b1e8c966983a75ac9e
+      SOURCE_VFY=sha1:954471ab87206826c072f31b3def40a1be5a78f5
         WEB_SITE=http://www.bitlbee.org/
          ENTERED=20100917
          UPDATED=20130117


### PR DESCRIPTION
bitlbee version 3.2 uses the old protocol for Twitter, which Twitter has discontinued.  3.2.1 fixes that.
