### PR TITLE
lzip: version bump

### DIFF
--- a/archive/lzip/BUILD
+++ b/archive/lzip/BUILD
@@ -1,14 +1,10 @@
-(
+./configure --build=$BUILD             \
+            --prefix=/usr              \
+            --infodir=/usr/share/info  \
+            --mandir=/usr/share/man    \
+            --sysconfdir=/etc          \
+            $OPTS                     &&
 
-  ./configure --build=$BUILD             \
-              --prefix=/usr              \
-              --infodir=/usr/share/info  \
-              --mandir=/usr/share/man    \
-              --sysconfdir=/etc
-              $OPTS                     &&
-
-  make &&
-  prepare_install &&
-  make install-strip 
-
-) > $C_FIFO 2>&1
+make &&
+prepare_install &&
+make install-strip

--- a/archive/lzip/DETAILS
+++ b/archive/lzip/DETAILS
@@ -1,11 +1,11 @@
           MODULE=lzip
-         VERSION=1.14
+         VERSION=1.15
           SOURCE=$MODULE-$VERSION.tar.gz
       SOURCE_URL=http://download.savannah.gnu.org/releases/lzip
-      SOURCE_VFY=sha1:ee54a3f39f7bf96ec677765f88b8458d0988bf10
+      SOURCE_VFY=sha1:a79d062d72071b5bb2bb7ef50dda6ac408c24192
         WEB_SITE=http://nongnu.askapache.com/lzip/manual/lzip_manual.html
          ENTERED=20091122
-         UPDATED=20130309
+         UPDATED=20131227
            SHORT="lossless data compressor"
 
 cat << EOF

--- a/archive/lzip/PRE_BUILD
+++ b/archive/lzip/PRE_BUILD
@@ -1,0 +1,4 @@
+default_pre_build &&
+sedit "s/^CPPFLAGS=/\0\${CPPFLAGS}/;
+       s/^CXXFLAGS=\(.*\)$/CXXFLAGS=\${CXXFLAGS:-\1}/;
+       s/^LDFLAGS=/\0\${LDFLAGS}/" configure


### PR DESCRIPTION
- The old version isn't available for download anymore.
- fixes a missing \ in configure command
- use selected build flags
