### PR TITLE
bridge-utils: fix BUILD so that bridge-utils compiles.

### DIFF
--- a/net/bridge-utils/BUILD
+++ b/net/bridge-utils/BUILD
@@ -1,5 +1,7 @@
 (
 
+  OPTS+=" --with-linux-headers=/usr/include"
+
   autoconf &&
 
   default_build


### PR DESCRIPTION
If it uses the Linux headers from /usr/src/linux, it fails to compile
properly.  Using the Linux headers in /usr/include, it works.

Hat tip to the Gentoo guys for figuring that one out.
