### PR TITLE
nspr: version bumped to 4.10.2

### DIFF
--- a/libs/nspr/DETAILS
+++ b/libs/nspr/DETAILS
@@ -1,12 +1,11 @@
           MODULE=nspr
-         VERSION=4.10
+         VERSION=4.10.2
           SOURCE=$MODULE-$VERSION.tar.gz
       SOURCE_URL=http://ftp.mozilla.org/pub/mozilla.org/$MODULE/releases/v${VERSION}/src
-      SOURCE_VFY=sha1:10dbf68c07497dab30be09db526931c885d5a7e9
+      SOURCE_VFY=sha1:650e4aa35d58624bc1083ed585c81c4af09cf23c
         WEB_SITE=http://www.mozilla.org/projects/nspr
          ENTERED=20100104
-         UPDATED=20130731
-           PSAFE="no"
+         UPDATED=20140118
            SHORT="Netscape Portable Runtime (NSPR)"
 
 cat << EOF


### PR DESCRIPTION
Module seem to be PSAFE now.
