### PR TITLE
freetype2: version bumped to 2.5.2

### DIFF
--- a/graphics/freetype2/BUILD
+++ b/graphics/freetype2/BUILD
@@ -1,25 +1,2 @@
-(
-
-  patch_it $SOURCE_CACHE/$SOURCE2 1  &&
-
-  sed -i -r 's:.*(#.*SYSTEM_ZLIB.*) .*:\1:' \
-    include/freetype/config/ftoption.h  &&
-
-  sed -i -r 's:.*(#.*SUBPIXEL_RENDERING.*) .*:\1:' \
-    include/freetype/config/ftoption.h  &&
-
-  sed -i -r 's:.*(#.*INCREMENTAL.*) .*:\1:' \
-    include/freetype/config/ftoption.h  &&
-
-  sed -i 's@^#define\ TT_CONFIG_OPTION_UNPATENTED_HINTING@#undef\ TT_CONFIG_OPTION_UNPATENTED_HINTING@' \
-    include/freetype/config/ftoption.h  &&
-
-  sed -i -r 's:.*(#.*USE_BZIP2.*) .*:\1:' \
-    include/freetype/config/ftoption.h  &&
-
-  sed -i 's@^#\ AUX@AUX@' modules.cfg  &&
-
-  default_build  &&
-  ln -sf /usr/include/freetype2/freetype /usr/include/freetype
-
-) > $C_FIFO 2>&1
+default_build  &&
+ln -sf /usr/include/freetype2/freetype /usr/include/freetype

--- a/graphics/freetype2/DETAILS
+++ b/graphics/freetype2/DETAILS
@@ -1,16 +1,19 @@
           MODULE=freetype2
-         VERSION=2.5.0.1
+         VERSION=2.5.2
           SOURCE=freetype-$VERSION.tar.bz2
-         SOURCE2=freetype-2.3.11-lunar.patch.bz2
+         SOURCE2=freetype-2.2.1-enable-valid.patch
+         SOURCE3=freetype-2.5.1-enable-spr.patch
 SOURCE_DIRECTORY=$BUILD_DIRECTORY/freetype-$VERSION
    SOURCE_URL[0]=$SFORGE_URL/freetype
    SOURCE_URL[1]=http://savannah.nongnu.org/download/freetype
      SOURCE2_URL=$PATCH_URL
-      SOURCE_VFY=sha1:4bbd8357b4b723e1ff38414a9eaf50bf99dacb84
-     SOURCE2_VFY=sha1:7135d66d1495446882ec940041246712aa6145c7
-        WEB_SITE=http://www.freetype.org
+     SOURCE3_URL=$PATCH_URL
+      SOURCE_VFY=sha1:72731cf405b9f7c0b56d144130a8daafa262b729
+     SOURCE2_VFY=sha1:f279d922a873d62a8af50bfc873051839d194dca
+     SOURCE3_VFY=sha1:13ee8d558593db991ad29fa090b461f914536104
+        WEB_SITE=http://www.freetype.org/
          ENTERED=20010922
-         UPDATED=20130625
+         UPDATED=20140118
            SHORT="A free, quality, portable font engine"
 
 cat << EOF

--- a/graphics/freetype2/PRE_BUILD
+++ b/graphics/freetype2/PRE_BUILD
@@ -1,0 +1,5 @@
+default_pre_build &&
+patch_it $SOURCE2 1 &&
+patch_it $SOURCE3 1 &&
+sed -i -r 's:.*(#.*SYSTEM_ZLIB.*) .*:\1:' include/config/ftoption.h &&
+sed -i -r 's:.*(#.*USE_BZIP2.*) .*:\1:' include/config/ftoption.h


### PR DESCRIPTION
Re-worked the module slightly. Some of the seds are now part of two of the
patches. A couple of old seds was invalid and 
TT_CONFIG_OPTION_UNPATENTED_HINTING was not a recommended setting unless you
use a few specific asian fonts, for the rest it will just cause issues 
instead.
