### PR TITLE
libmtp: fix udev rules in case there is no valid ~/.mtpz-data

### DIFF
--- a/libs/libmtp/PRE_BUILD
+++ b/libs/libmtp/PRE_BUILD
@@ -1,0 +1,6 @@
+default_pre_build &&
+
+# make sure these warnings are not written to stdout
+# because they would later pollute mtp-hotplug's output
+# and break the generated udev-rules file
+sedit "s@LIBMTP_INFO@LIBMTP_ERROR@" src/mtpz.c


### PR DESCRIPTION
They managed to output error messages to stdout, which mustn't go there. In
some cases the output is supposed to be a valid udev-rules file.
