### PR TITLE
Update DETAILS in order to fit the 5.2 museum

### DIFF
--- a/compilers/php5/DETAILS
+++ b/compilers/php5/DETAILS
@@ -2,13 +2,7 @@
          VERSION=5.2.17
           SOURCE=php-$VERSION.tar.bz2
 SOURCE_DIRECTORY=$BUILD_DIRECTORY/php-$VERSION
-   SOURCE_URL[0]=http://www.php.net/distributions
-   SOURCE_URL[1]=http://uk2.php.net/distributions
-   SOURCE_URL[2]=http://us2.php.net/distributions
-   SOURCE_URL[3]=http://uk.php.net/distributions
-   SOURCE_URL[4]=http://nl.php.net/distributions
-   SOURCE_URL[5]=http://de.php.net/distributions
-   SOURCE_URL[6]=http://fr.php.net/distributions
+   SOURCE_URL[0]=http://museum.php.net/php5
       SOURCE_VFY=sha1:d68f3b09f766990d815a3c4c63c157db8dab8095
         WEB_SITE=http://www.php.net
          ENTERED=20040919


### PR DESCRIPTION
PHP5.2 is now unmaintained and sources have been moved from official mirrors to the museum download center. SOURCE_URLs have been fixed.
