### PR TITLE
Added missing dependency for VBox 4.3.6 release

### DIFF
--- a/virtual/VirtualBox/DEPENDS
+++ b/virtual/VirtualBox/DEPENDS
@@ -10,6 +10,7 @@ depends libcap
 depends makeself
 depends %CDR
 depends curl
+depends libvpx
 
 optional_depends qt4        "" "--disable-qt"        "for UI (recommended)"
 optional_depends lvm2       "" "--disable-devmapper" "for device mapper support"


### PR DESCRIPTION
Added missing dependency libvpx in DEPENDS script for the 4.3.6 release
