### PR TITLE
bump version sun-jdk to 1.7.0_51

### DIFF
--- a/compilers/sun-jdk/DETAILS
+++ b/compilers/sun-jdk/DETAILS
@@ -1,12 +1,12 @@
           MODULE=sun-jdk
-         VERSION=7u45
-        FVERSION=$VERSION-b18
-        DVERSION=1.7.0_45
+         VERSION=7u51
+        FVERSION=$VERSION-b13
+        DVERSION=1.7.0_51
 SOURCE_DIRECTORY=$BUILD_DIRECTORY/jdk$DVERSION
         WEB_SITE=http://www.oracle.com/technetwork/java/javase/downloads/index.html
          LICENSE="proprietary"
          ENTERED=20070210
-         UPDATED=20130806
+         UPDATED=20140309
            SHORT="SUN java runtime environment"
 FUZZY=off
 LDD_CHECK=off

--- a/compilers/sun-jdk/PRE_BUILD
+++ b/compilers/sun-jdk/PRE_BUILD
@@ -26,9 +26,9 @@ if [ "$JCE_SHA1_VFY" != "$JCE_SHA1_TST" ]; then
 fi &&
 
 if [ "$bits" = i586 ]; then
-   JDK_SHA1_VFY="c555fcff8c916bef39697c5e1bf059eeacbe3647"
+   JDK_SHA1_VFY="6cc2a9c41fa1fe9f4b713077b2e71a61c00071d9"
 else
-   JDK_SHA1_VFY="1c8cb229e2f7f0a3e5e798a3008c5a1f7c604934"
+   JDK_SHA1_VFY="bee3b085a90439c833ce18e138c9f1a615152891"
 fi &&
 
 JDK_SHA1_TST=`sha1sum $JDK_ARCHIVE | awk '{print $1}'` &&


### PR DESCRIPTION
Oracle Java JDK version bump to 1.7.0_51, released on 16th January 2014
