### PR TITLE
firefox: version bump (non-bin)

### DIFF
--- a/web/firefox/DETAILS
+++ b/web/firefox/DETAILS
@@ -1,14 +1,14 @@
           MODULE=firefox
-         VERSION=27.0
+         VERSION=27.0.1
           SOURCE=$MODULE-$VERSION.source.tar.bz2
    SOURCE_URL[0]=ftp://ftp.uni-erlangen.de/pub/mozilla.org/firefox/releases/$VERSION/source
    SOURCE_URL[1]=ftp://mozilla.isc.org/pub/mozilla.org/firefox/releases/$VERSION/source
    SOURCE_URL[2]=ftp://ftp.mozilla.org/pub/firefox/releases/$VERSION/source
-      SOURCE_VFY=sha1:ec2031385237e30be829817ac79caa8e80cc2a14
+      SOURCE_VFY=sha1:29dc759e36f2b9381e80ac48ce59635ea25033dc
 SOURCE_DIRECTORY=$BUILD_DIRECTORY/mozilla-release
         WEB_SITE=http://www.mozilla.org/projects/firefox
          ENTERED=20110814
-         UPDATED=20140206
+         UPDATED=20140309
            SHORT="A speedy, full-featured web browser"
 
 cat << EOF


### PR DESCRIPTION
Updated firefox source version from 27.0 to 27.0.1, which fixes two bugs. Just a bugfix version bump. Nothing changed in build-scripts.
