### PR TITLE
zfs-git: new module, tracking the git version of the zfs module.

### DIFF
--- a/zbeta/zfs-git/BUILD
+++ b/zbeta/zfs-git/BUILD
@@ -1,0 +1,26 @@
+cd "$SPL_PATH" &&
+./autogen.sh &&
+OPTS+=" --with-linux=/usr/src/linux --with-linux-obj=/usr/src/linux" \
+default_config &&
+make ${MAKES:+-j${MAKES}} &&
+
+cd "$ZFS_PATH" &&
+./autogen.sh &&
+OPTS+=" --with-linux=/usr/src/linux --with-linux-obj=/usr/src/linux --with-spl=$SPL_PATH" default_config &&
+make ${MAKES:+-j${MAKES}} &&
+
+prepare_install &&
+
+# SPL and ZFS try to install files on top of each other and fail, so do
+# this hack to work around it.
+cd "$SPL_PATH"                       &&
+mkdir -p pkg                         &&
+make install DESTDIR="$SPL_PATH/pkg" &&
+cd "$SPL_PATH/pkg"                   &&
+cp -av * /                           &&
+
+cd "$ZFS_PATH" &&
+mkdir -p pkg         &&
+make install DESTDIR="$ZFS_PATH/pkg" &&
+cd "$ZFS_PATH/pkg" &&
+cp -av * /

--- a/zbeta/zfs-git/CONFLICTS
+++ b/zbeta/zfs-git/CONFLICTS
@@ -1,0 +1,1 @@
+conflicts zfs

--- a/zbeta/zfs-git/DETAILS
+++ b/zbeta/zfs-git/DETAILS
@@ -1,0 +1,20 @@
+          MODULE=zfs-git
+         VERSION=0.6.2-dev
+          SOURCE=$MODULE-$VERSION.tar.gz
+         SOURCE2=spl-$VERSION.tar.gz
+SOURCE_DIRECTORY=$BUILD_DIRECTORY/$MODULE
+      SOURCE_URL=git://github.com/zfsonlinux/zfs.git
+     SOURCE2_URL=git://github.com/zfsonlinux/spl.git
+        WEB_SITE=http://www.zfsonlinux.org/
+         LICENSE=cddl
+         ENTERED=20130212
+         UPDATED=20130329
+           SHORT="The ZFS file system"
+
+cat << EOF
+ZFS is an advanced file system and volume manager which was originally
+developed for Solaris. It has been successfully ported to FreeBSD and
+now there is a functional Linux ZFS kernel port too. The port currently
+includes a fully functional and stable SPA, DMU, and ZVOL with a ZFS
+Posix Layer (ZPL) on the way.
+EOF

--- a/zbeta/zfs-git/POST_INSTALL
+++ b/zbeta/zfs-git/POST_INSTALL
@@ -1,0 +1,1 @@
+depmod -a

--- a/zbeta/zfs-git/PRE_BUILD
+++ b/zbeta/zfs-git/PRE_BUILD
@@ -1,0 +1,10 @@
+BASE="$BUILD_DIRECTORY/$MODULE" &&
+mkdir -p "$BASE"                &&
+cd "$BASE"                      &&
+
+unpack "$SOURCE"  &&
+unpack "$SOURCE2" &&
+ZFS_PATH="$SOURCE_DIRECTORY/${SOURCE%.tar.gz}"  &&
+SPL_PATH="$SOURCE_DIRECTORY/${SOURCE2%.tar.gz}" &&
+
+sedit "s:/bin/cp:/usr/bin/cp:" {$ZFS_PATH,$SPL_PATH}/module/Makefile.in


### PR DESCRIPTION
While the zfs on Linux guys haven't been exactly diligent in making new
releases (they're quite careful about making sure their official
releases are stable), they have been updating their code in git to
reflect changes to the kernel API.

So for people who are feeling adventurous, there's now a zfs-git module.
