### PR TITLE
cairo: libpng is non optional

### DIFF
--- a/graphics/cairo/DEPENDS
+++ b/graphics/cairo/DEPENDS
@@ -1,9 +1,5 @@
 depends  pixman
-
-optional_depends "libpng"                                               \
-                 "--enable-png --enable-svg"                            \
-                 "--disable-png --disable-svg"                          \
-                 "for PNG functions and SVG backend (recommended)"
+depends  libpng
 
 optional_depends "zlib"                                                 \
                  "--enable-ps --enable-pdf"                             \


### PR DESCRIPTION
Building cairo without libpng generates compile errors.
