### PR TITLE
whois: bump to 5.1.3

### DIFF
--- a/net/whois/DETAILS
+++ b/net/whois/DETAILS
@@ -1,8 +1,8 @@
           MODULE=whois
-         VERSION=5.1.2
+         VERSION=5.1.3
           SOURCE=${MODULE}_$VERSION.tar.xz
       SOURCE_URL=ftp://ftp.debian.org/debian/pool/main/w/$MODULE
-      SOURCE_VFY=sha1:627c7437f663657db903e0cf4ee0cc1369f63e96
+      SOURCE_VFY=sha256:65ad18fb369827aa12733b88006a0398c88f29ba2bd53732033a7668d70bd64a
         WEB_SITE=http:rwh//www.linux.it/~md/software
          ENTERED=20011228
          UPDATED=20140508


### PR DESCRIPTION
Also, apparently 5.1.2 has been removed from the source repository
altogether, which is odd.  Maybe there was a horrible security hole
in it.
