### PR TITLE
slim: make the first item in sessions always an empty default

### DIFF
--- a/x11-utils/slim/PRE_BUILD
+++ b/x11-utils/slim/PRE_BUILD
@@ -10,6 +10,9 @@ sedit '126 i target_link_libraries(libslim ${PAM_LIBRARY})' CMakeLists.txt &&
 # fix their broken sample configuration
 sedit 's/^sessions.*/#\0/; T; a sessiondir /usr/share/xsessions' slim.conf &&
 
+# provide simple default session support
+sedit '/sessions\.clear()/ a sessions.push_back(pair<string,string>("default",""));' cfg.cpp &&
+
 # don't install systemd files here
 # we provide them separately
 sedit '/systemd/ d' CMakeLists.txt


### PR DESCRIPTION
This solution is specific to lunar and authored by me. It is much less
intrusive than all the patches I looked at.

However, if a user doesn't handle an empty session parameter in his ~/.xinitrc
script and starts a default in this case, this (first) entry will break down
and he will have to select a different one.
