### PR TITLE
fail2ban: new module.

### DIFF
--- a/security/fail2ban/BUILD
+++ b/security/fail2ban/BUILD
@@ -1,0 +1,7 @@
+(
+
+  python setup.py build_ext -i  &&
+  prepare_install               &&
+  python setup.py install
+
+) > $C_FIFO 2>&1

--- a/security/fail2ban/DETAILS
+++ b/security/fail2ban/DETAILS
@@ -1,0 +1,16 @@
+          MODULE=fail2ban
+         VERSION=0.8.13
+          SOURCE=${MODULE}-${VERSION}.tar.gz
+      SOURCE_URL=https://github.com/fail2ban/fail2ban/releases/download/$VERSION/
+      SOURCE_VFY=sha256:854e641b194fa76e2b9579e4440e9b6dad4055bdd316b109df639658bfc7007f
+        WEB_SITE="http://www.find2ban.org/"
+         ENTERED=20140806
+         UPDATED=20140806
+           SHORT="Log file scanner to detect malicious activity"
+cat << EOF
+Fail2ban scans log files (e.g. /var/log/apache/error_log) and bans IPs
+that show the malicious signs -- too many password failures, seeking for
+exploits, etc. Generally Fail2Ban is then used to update firewall rules
+to reject the IP addresses for a specified amount of time, although any
+arbitrary other action (e.g. sending an email) could also be configured. 
+EOF

--- a/security/fail2ban/systemd.d/fail2ban.service
+++ b/security/fail2ban/systemd.d/fail2ban.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Fail2ban security service
+After=syslog.target network.target
+
+[Service]
+Type=forking
+PIDFile=/var/run/fail2ban/fail2ban.pid
+ExecStartPre=/usr/bin/newaliases
+ExecStart=/usr/bin/fail2ban-client start
+ExecReload=/usr/bin/fail2ban-client reload
+ExecStop=/usr/bin/fail2ban-client stop
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Fail2ban scans log files (e.g. /var/log/apache/error_log) and bans IPs
that show the malicious signs -- too many password failures, seeking for
exploits, etc. Generally Fail2Ban is then used to update firewall rules
to reject the IP addresses for a specified amount of time, although any
arbitrary other action (e.g. sending an email) could also be configured.
