### PR TITLE
libvirt: ROLLING BACK the COMPLETE UNTESTED BLIND BUMP

### DIFF
--- a/virtual/libvirt/DETAILS
+++ b/virtual/libvirt/DETAILS
@@ -1,12 +1,12 @@
           MODULE=libvirt
-         VERSION=1.2.7
+         VERSION=1.2.6
           SOURCE=$MODULE-$VERSION.tar.gz
       SOURCE_URL=http://libvirt.org/sources
 SOURCE_DIRECTORY=$BUILD_DIRECTORY/$MODULE-$VERSION
-      SOURCE_VFY=sha256:3dfb462cba1188d2c9ba700e1927fa0dbd71f20afdf81ab0c43b27b7fe77defc
+      SOURCE_VFY=sha256:38a224559a1d04e5d4163c5c1b810df1f29804ebbb1f057d4abcb41a9e5d5dea
         WEB_SITE=http://libvirt.org
          ENTERED=20130202
-         UPDATED=20140805
+         UPDATED=20140811
            SHORT="API for controlling virtualization engines"
 
 cat <<EOF


### PR DESCRIPTION
Seriously, why even bother with the pull request method of submitting
changes when nobody's going to bother testing any of the commits
submitted?  If you're just going to blindly merge stuff without making
sure it works, just don't.

See also: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=757609

Version 1.2.7 of libvirt COMPLETELY FAILS TO WORK if you have qemu
guests.  This isn't a soft failure.  It's a grave, serious, hard
failure.  And yet for some reason, this utterly broken bump was blithely
accepted as being Just Fine, apparently by a bunch of people who don't
even use libvirt so they just said oh hey, new version?  Cool, that must
be Obviously Better.

It's not.

Testing, guys, let's try doing that for once.
