### PR TITLE
firefox: Bump to 31.0. The make was failing on some js and could not fin...

### DIFF
--- a/web/firefox/BUILD
+++ b/web/firefox/BUILD
@@ -34,10 +34,6 @@ if [ -n "${MAKES}" ]; then
   echo "mk_add_options MOZ_MAKE_FLAGS='-j${MAKES}'" >> mozconfig
 fi &&
 
-if module_installed qt4 ; then
-  echo "ac_add_options --with-qtdir=/usr" >> mozconfig
-fi &&
-
 #Finally, the build!
 if [ "$PGO" == "y" ] ; then
   #CCache breaks the pgo build

--- a/web/firefox/CONFIGURE
+++ b/web/firefox/CONFIGURE
@@ -1,2 +1,3 @@
 mquery PGO "Build with Profile Guided Optimization? (Requires firefox to be compiled within a running instance of X)"  y  ""  "--disable-tests"
 mquery SAFE "Enable safe browsing (anti-phishing)?"  y  "--enable-safe-browsing"  "--disable-safe-browsing"
+

--- a/web/firefox/DEPENDS
+++ b/web/firefox/DEPENDS
@@ -6,6 +6,7 @@ depends nss
 depends curl
 depends alsa-lib
 depends libvpx
+depends cairo
 
 optional_depends "freetype2"        "--enable-tree-freetype" "--disable-tree-freetype" "For freetype font support"
 optional_depends "Python"           ""  ""  "Needed to do a Profile Guided Optimization build"
@@ -28,8 +29,10 @@ optional_depends "libjpeg-turbo"    "--with-system-jpeg" "--without-system-jpeg"
 
 # https://bugzilla.mozilla.org/show_bug.cgi?id=512940
 # Comment 9:  "System SQLite isn't supported by Mozilla (in fact we discourage its use)"
-#optional_depends "sqlite"  "--enable-system-sqlite"  "--disable-system-sqlite"   "Use system sqlite (discouraged)"
+optional_depends "sqlite"  "--enable-system-sqlite"  "--disable-system-sqlite"   "Use system sqlite ${PROBLEM_COLOR}(discouraged)${DEFAULT_COLOR}"
 
 
 # This seems to break mozilla, most other distros do not use this.
 #  optional_depends "gnome-vfs"        "--enable-gnomevfs"  "--disable-gnomevfs"  "For Gnome VFS support"
+
+optional_depends "qt4" "--with-qtdir=/usr"  " " "for qt support."

--- a/web/firefox/mozconfig
+++ b/web/firefox/mozconfig
@@ -29,7 +29,8 @@ ac_add_options --disable-crashreporter
 ac_add_options --disable-necko-wifi
 ac_add_options --disable-gnomevfs
 ac_add_options --without-system-libevent
-ac_add_options --enable-replace-malloc
+
+# Enabling this causes the make to fail on java script. No work around found.
 ac_add_options --disable-shared-js
 
 #Causes make failure


### PR DESCRIPTION
...d/determine

a fix, disabling shared js skirted around this issue.

Added some if/then logic should qt4 be installed.

Commented out the sqlite in DEPENDS. AFAIK that is still valid.

Re-enabled cairo, compiled fine and haven't found any issues.

Only one thing I have found and this existed in the 29 version that was in moonbase. Firefox would silently crash. The most reliable way for me to do this; login my gmail account and just wait a hand full or so seconds, boom. Forgot to bookmark them but a preliminary search appears to indicate a problem with gtk2 and zero width pixels. Apparently this is not an issue with firefox-bin?
