### PR TITLE
Added setuptools to pyopenssl as dependency

### DIFF
--- a/python/pyopenssl/DEPENDS
+++ b/python/pyopenssl/DEPENDS
@@ -1,2 +1,3 @@
+depends setuptools
 depends openssl
 depends Python


### PR DESCRIPTION
setuptools is needed by pyopenssl in order to install it. Added it as dependency.
