### PR TITLE
dash: A quick, basic, no-frills shell.

### DIFF
--- a/shells/dash/DETAILS
+++ b/shells/dash/DETAILS
@@ -1,0 +1,16 @@
+          MODULE=dash
+         VERSION=0.5.8
+          SOURCE=$MODULE-$VERSION.tar.gz
+      SOURCE_URL=http://gondor.apana.org.au/~herbert/dash/files/
+      SOURCE_VFY=sha256:c6db3a237747b02d20382a761397563d813b306c020ae28ce25a1c3915fac60f
+        WEB_SITE=http://gondor.apana.org.au/~herbert/dash/
+         ENTERED=20141004
+         UPDATED=20141004
+           SHORT="Small, fast, basic implementation of /bin/sh"
+           PSAFE=no
+cat << EOF
+DASH is a POSIX-compliant implementation of /bin/sh that aims to
+be as small as possible. It does this without sacrificing speed
+where possible. In fact, it is significantly faster than bash (the
+GNU Bourne-Again SHell) for most tasks.
+EOF


### PR DESCRIPTION
What with a whole collection of security holes in bash recently, I
think that a small, simple, secure shell might be a better
candidate for /bin/sh.  So I'm offering the /bin/sh that some
other distros use to try out for a while.

It installs as /usr/bin/dash for the moment, making it /bin/sh is
something only recommended for adventurous people who don't mind
potentially breaking their system.
