### PR TITLE
vala: For some reason, 0.26.1 has been withdrawn.

### DIFF
--- a/compilers/vala/DETAILS
+++ b/compilers/vala/DETAILS
@@ -1,8 +1,8 @@
           MODULE=vala
-         VERSION=0.26.1
+         VERSION=0.26.0
           SOURCE=$MODULE-$VERSION.tar.xz
       SOURCE_URL=$GNOME_URL/sources/$MODULE/${VERSION%.*}
-      SOURCE_VFY=sha256:8407abb19ab3a58bbfc0d288abb47666ef81f76d0540258c03965e7545f59e6b
+      SOURCE_VFY=sha256:c1d0a6a485d5cbfbe027483adfc5f7c80c2404b692375be80d75193d915dcd2f
         WEB_SITE=http://live.gnome.org/Vala
          ENTERED=20020714
          UPDATED=20141013


### PR DESCRIPTION
So this rolls back the version bump.
