### PR TITLE
git: version bump to 2.2.1

### DIFF
--- a/devel/git/DETAILS
+++ b/devel/git/DETAILS
@@ -1,11 +1,11 @@
           MODULE=git
-         VERSION=2.2.0
+         VERSION=2.2.1
           SOURCE=$MODULE-$VERSION.tar.xz
          SOURCE2=$MODULE-manpages-$VERSION.tar.xz
       SOURCE_URL=http://www.kernel.org/pub/software/scm/git/
      SOURCE2_URL=http://www.kernel.org/pub/software/scm/git/
-      SOURCE_VFY=sha256:3b87774672bbf35b4d33991dc5119d4eff47c3679e27185312a2b8b36fdad314
-     SOURCE2_VFY=sha256:4b53648e3550adaf745323649af82c9c11634d909b7ddfa5c3661ab9991204ec
+      SOURCE_VFY=sha256:09422dc9a0bdddf6bdd5b8634c71e1ed3125256c47424e6a2687701e764ef450
+     SOURCE2_VFY=sha256:00f8357fd8ab9e3b397dd087b20d405ed141765d04f3f2162e65fdec7cb1e538
         WEB_SITE=http://git-scm.com
          ENTERED=20050707
          UPDATED=20141127


### PR DESCRIPTION
The git client has a fairly nasty vulnerability where attackers
can inject arbitrary shell script code into you .git/config, if
you're unlucky enough to be using git in a case-insensitive or
case-normalizing filesystem.  Which, okay, true, doesn't really
affect Linux that much, but it certainly affects OS X and Windows
users.

If you're using the Windows version of Lunar, then you have my
congratulations, because I don't think anyone's ever done that.
I'm pretty sure that there aren't many OSX/Lunar users out there
either.  But it's probably a good idea to keep up to date with
the latest security patches, for whatever reason.
