### PR TITLE
ImageMagick: bump to version 6.9.0-2

### DIFF
--- a/graphics/ImageMagick/DETAILS
+++ b/graphics/ImageMagick/DETAILS
@@ -3,14 +3,14 @@
 # should version bump to x.y.(z-1)-(highest). That version is always
 # kept on the ftp.imagemagick.org site and should be considered STABLE!!!
           MODULE=ImageMagick
-         VERSION=6.9.0-0
+         VERSION=6.9.0-2
           SOURCE=$MODULE-$VERSION.tar.xz
    SOURCE_URL[0]=http://mirrors-usa.go-parts.com/mirrors/ImageMagick
    SOURCE_URL[1]=http://mirror.checkdomain.de/imagemagick
    SOURCE_URL[2]=ftp://ftp.nluug.nl/pub/ImageMagick
    SOURCE_URL[3]=http://mirrors-ru.go-parts.com/mirrors/ImageMagick
    SOURCE_URL[4]=ftp://gd.tuwien.ac.at/pub/graphics/ImageMagick
-      SOURCE_VFY=sha256:12331c904c691cb128865fdc97e5f8a2654576f9b032e274b74dd7617aa1b9b6
+      SOURCE_VFY=sha256:ce7ced11cc1019cd37518ebc4ea03ffaff8e6891aaf41a05615689dafe854ff6
         WEB_SITE=http://www.imagemagick.org
          ENTERED=20010922
          UPDATED=20141227


### PR DESCRIPTION
The ImageMagick guys seem to have removed earlier versions.
