### PR TITLE
docker: version bumped to 1.4.1

### DIFF
--- a/virtual/docker/DETAILS
+++ b/virtual/docker/DETAILS
@@ -1,13 +1,13 @@
           MODULE=docker
-         VERSION=1.3.2
-DOCKER_GITCOMMIT=fa7b24f
+         VERSION=1.4.1
+DOCKER_GITCOMMIT=5bc2ff8
           SOURCE=$MODULE-$VERSION.tar.gz
  SOURCE_URL_FULL=https://github.com/docker/docker/archive/v${VERSION}.tar.gz
-      SOURCE_VFY=sha256:9e81c0ef309fbe3298ba1a9b0f2783ee88d7f412cb03b6605c6d8bb497a452fb
+      SOURCE_VFY=sha256:34300e214e5d2f1633d9650be16bce86d635d72596faa575912fecefda612835
 SOURCE_DIRECTORY=$BUILD_DIRECTORY/$MODULE-$VERSION
         WEB_SITE=http://www.docker.io/
          ENTERED=20140607
-         UPDATED=20141126
+         UPDATED=20150101
            SHORT="Pack, ship and run any application as a lightweight container"
 
 GARBAGE=off


### PR DESCRIPTION
Docker requires a newer version of btrfs-progs. This pull-request depends on https://github.com/lunar-linux/moonbase-core/pull/794