### PR TITLE
libvdpau: fix BUILD with libtool 2.4.4

### DIFF
--- a/video/libvdpau/BUILD
+++ b/video/libvdpau/BUILD
@@ -1,5 +1,6 @@
 (
 
+  aclocal && 
   ./autogen.sh --build=$BUILD  \
                --prefix=/usr   \
   $OPTS                       &&


### PR DESCRIPTION
I did a fresh install Lunar today. libvdpau failed because libtool 2.4.4 told me to regenerate aclocal.m4.  