### PR TITLE
chromium: version bumped to 40.0.2214.91

### DIFF
--- a/web/chromium/BUILD
+++ b/web/chromium/BUILD
@@ -1,4 +1,3 @@
-
 # Lets do some ffmpeg stuff
   pushd third_party/ffmpeg > /dev/null &&
     chromium/scripts/build_ffmpeg.py linux ${FFMPEG_OPTS} --branding=Chrome &&
@@ -12,13 +11,14 @@
 
   # This is the make step. According to its --help the default -j is
   # derived from your number of CPUs.
-  ninja -v -C out/Release chrome chrome_sandbox &&
+  ninja -v -C out/Release chrome chrome_sandbox chromedriver &&
 
   prepare_install &&
 
   # installing
   install -D out/Release/chrome ${CHROMIUM_HOME}/chrome &&
   install -Dm4755 -o root -g root out/Release/chrome_sandbox ${CHROMIUM_HOME}/chrome-sandbox &&
+  install -D out/Release/chromedriver ${CHROMIUM_HOME}/chromedriver &&
 
   cp out/Release/{*.pak,libffmpegsumo.so,libpdf.so,*.TOC} ${CHROMIUM_HOME} &&
 

--- a/web/chromium/DEPENDS
+++ b/web/chromium/DEPENDS
@@ -2,7 +2,6 @@ depends zlib
 depends minizip
 depends ninja
 depends snappy
-depends protobuf
 depends gperf
 depends re2
 depends xdg-utils

--- a/web/chromium/DETAILS
+++ b/web/chromium/DETAILS
@@ -1,14 +1,14 @@
           MODULE=chromium
-         VERSION=40.0.2175.0
+         VERSION=40.0.2214.91
           SOURCE=$MODULE-$VERSION.tar.xz
          SOURCE2=chromium-system-jinja-r7.patch
       SOURCE_URL=https://gsdview.appspot.com/chromium-browser-official/
      SOURCE2_URL=http://sources.gentoo.org/cgi-bin/viewvc.cgi/gentoo-x86/www-client/chromium/files/
-      SOURCE_VFY=sha1:d132c962e9612e4cde823722d3477c2feb7d9520
+      SOURCE_VFY=sha256:f72fda9ff1ea256ab911610ee532eadf8303137d431f2481d01d3d60e5e64149
      SOURCE2_VFY=sha1:c24d14029714d2295f3220a7173a5a7362f578a2
         WEB_SITE=http://www.chromium.org/Home
          ENTERED=20100104
-         UPDATED=20141002
+         UPDATED=20150125
            SHORT="Open-source version of Google Chrome web browser"
 
 cat << EOF

--- a/web/chromium/PRE_BUILD
+++ b/web/chromium/PRE_BUILD
@@ -1,5 +1,9 @@
   default_pre_build &&
 
+  # Fix some ICU issues in the bundled one; header files get picked up
+  # from here instead of the system ones.
+  find third_party/icu -type f \! -regex '.*\.\(gyp\|gypi\|isolate\)' -delete &&
+
   patch_it $SOURCE2 0 &&
 
   export CHROMIUM_HOME=/usr/lib/$MODULE &&
@@ -45,98 +49,21 @@
     FFMPEG_OPTS+=" ia32"
   fi &&
 
-# Removing some bundled stuff.
-  build/linux/unbundle/remove_bundled_libraries.py \
-   'base/third_party/dmg_fp' \
-   'base/third_party/dynamic_annotations' \
-   'base/third_party/icu' \
-   'base/third_party/nspr' \
-   'base/third_party/superfasthash' \
-   'base/third_party/symbolize' \
-   'base/third_party/valgrind' \
-   'base/third_party/xdg_mime' \
-   'base/third_party/xdg_user_dirs' \
-   'breakpad/src/third_party/curl' \
-   'chrome/third_party/mozilla_security_manager' \
-   'courgette/third_party' \
-   'crypto/third_party/nss' \
-   'net/third_party/mozilla_security_manager' \
-   'net/third_party/nss' \
-   'third_party/adobe' \
-   'third_party/WebKit' \
-   'third_party/angle' \
-   'third_party/angle/src/third_party/compiler' \
-   'third_party/brotli' \
-   'third_party/cacheinvalidation' \
-   'third_party/cld_2' \
-   'third_party/cros_system_api' \
-   'third_party/cython/python_flags.py' \
-   'third_party/dom_distiller_js' \
-   'third_party/dom_distiller_js/package/proto_gen/third_party/dom_distiller_js' \
-   'third_party/ffmpeg' \
-   'third_party/fips181' \
-   'third_party/flot' \
-   'third_party/hunspell' \
-   'third_party/iccjpeg' \
-   'third_party/jstemplate' \
-   'third_party/khronos' \
-   'third_party/leveldatabase' \
-   'third_party/libaddressinput' \
-   'third_party/libjingle' \
-   'third_party/libphonenumber' \
-   'third_party/libsrtp' \
-   'third_party/libusb' \
-   'third_party/libvpx' \
-   'third_party/libvpx/source/libvpx/third_party/x86inc' \
-   'third_party/libwebm' \
-   'third_party/libxml/chromium' \
-   'third_party/libXNVCtrl' \
-   'third_party/libyuv' \
-   'third_party/lss' \
-   'third_party/lzma_sdk' \
-   'third_party/mesa' \
-   'third_party/modp_b64' \
-   'third_party/mt19937ar' \
-   'third_party/npapi' \
-   'third_party/opus' \
-   'third_party/ots' \
-   'third_party/pdfium' \
-   'third_party/pdfium/third_party/logging.h' \
-   'third_party/pdfium/third_party/macros.h' \
-   'third_party/pdfium/third_party/numerics' \
-   'third_party/pdfium/third_party/template_util.h' \
-   'third_party/polymer' \
-   'third_party/qcms' \
-   'third_party/readability' \
-   'third_party/sfntly' \
-   'third_party/skia' \
-   'third_party/smhasher' \
-   'third_party/sqlite' \
-   'third_party/tcmalloc' \
-   'third_party/tlslite' \
-   'third_party/trace-viewer' \
-   'third_party/trace-viewer/third_party/jszip' \
-   'third_party/trace-viewer/third_party/tvcm' \
-   'third_party/trace-viewer/third_party/tvcm/third_party/d3' \
-   'third_party/trace-viewer/third_party/tvcm/third_party/gl-matrix' \
-   'third_party/trace-viewer/third_party/tvcm/third_party/polymer' \
-   'third_party/undoview' \
-   'third_party/usrsctp' \
-   'third_party/webdriver' \
-   'third_party/webrtc' \
-   'third_party/widevine' \
-   'third_party/x86inc' \
-   'third_party/zlib/google' \
-   'url/third_party/mozilla' \
-   'v8/src/third_party/kernel' \
-   'v8/src/third_party/valgrind' \
-   'v8/third_party/fdlibm' \
-  --do-remove &&
+
+# Google API keys (see http://www.chromium.org/developers/how-tos/api-keys)
+# The keys below are for Lunar Linux use ONLY. If you are maintaining chromium for
+# another distribution, please get your own set of keys.
+google_api_key=AIzaSyDhObDIVsBGV5fleLgLq6ZpfKldIVMvrG4 &&
+google_default_client_id=1081365520390-t7vsmo6kde87fvbjoue2ea412vsjkvu0.apps.googleusercontent.com &&
+google_default_client_secret=mz6fvViZFucQ5QVggWaqOjYX &&
 
 # chrome-sandbox is hardcoded so using anything but that won't work
 # Let chromium find the usb id paths on launch instead of compiling
 # in the path.
-  OPTS+=" -Dproprietary_codecs=1                                \
+  OPTS+=" -Dgoogle_api_key=$google_api_key \
+          -Dgoogle_default_client_id=$google_default_client_id \
+          -Dgoogle_default_client_secret=$google_default_client_secret \
+          -Dproprietary_codecs=1                                \
           -Dwerror=                                             \
           -Ddisable_fatal_linker_warnings=1                     \
           -Dlinux_sandbox_path=${CHROMIUM_HOME}/chrome-sandbox  \
@@ -160,7 +87,7 @@
           -Duse_system_libxslt=1                                \
           -Duse_system_minizip=1                                \
           -Duse_system_nspr=1                                   \
-          -Duse_system_protobuf=1                               \
+          -Duse_system_protobuf=0                               \
           -Duse_system_re2=1                                    \
           -Duse_system_snappy=1                                 \
           -Duse_system_speex=1                                  \
@@ -183,6 +110,7 @@
           -Dlinux_use_bundled_gold=0                            \
           -Dlinux_use_gold_flags=0                              \
           -Dlogging_like_official_build=1                       \
+          -Ddisable_fatal_linker_warnings=1                     \
           -Ddisable_nacl=1" &&
 
 # A little jiggle for adboe/flash


### PR DESCRIPTION
- Use bundled version of protobuf or syncing will cause chromium to seg fault
- Added Lunar Linux API keys for the various Google API's chromium can utilize
- Removed unnecessary third part packages cleanup in PRE_BUILD
- Compile and install chromedriver