### PR TITLE
httpd: version bump to 2.2.29

### DIFF
--- a/web/httpd/DETAILS
+++ b/web/httpd/DETAILS
@@ -1,11 +1,11 @@
           MODULE=httpd
-         VERSION=2.4.12
+         VERSION=2.2.29
           SOURCE=$MODULE-$VERSION.tar.bz2
       SOURCE_URL=http://www.apache.org/dist/$MODULE
-      SOURCE_VFY=sha256:ad6d39edfe4621d8cc9a2791f6f8d6876943a9da41ac8533d77407a2e630eae4
+      SOURCE_VFY=sha256:574b4f994b99178dfd5160bcb14025402e2ce381be9889b83e4be0ffbf5839a4
         WEB_SITE=http://www.apache.org
          ENTERED=20020710
-         UPDATED=20150131
+         UPDATED=20150205
            SHORT="A popular HTTP server"
 
 cat << EOF


### PR DESCRIPTION
Note that this rolls back the previous untested version bump from 2.2.27 to 2.4.12.

Please stop bumping the version of httpd from 2.2 to 2.4.  2.2 and 2.4 have incompatible configurations and a bump like that will break everyone's web servers.  Quit doing that.  Make an httpd24 module if you are really intent on using httpd 2.4, or stop bumping the versions of modules you clearly don't use just because a new version has been released.