### PR TITLE
libmng: bump to 2.0.2 along with a few changes to the BUILD. The second ...

### DIFF
--- a/graphics/libmng/BUILD
+++ b/graphics/libmng/BUILD
@@ -1,13 +1,8 @@
-(
 
-  cp unmaintained/autogen.sh . &&
-  chmod 755 autogen.sh &&
+  sedit "207i #include <jpeglib.h>" libmng_types.h &&
 
-# autogen tanks with our version of automake.
-  sed -i '/^AM_C_PROTOTYPES$/d' makefiles/configure.in &&
-
-  ./autogen.sh  &&
+  if in_depends $MODULE jpeg ; then
+    sedit "202,206d" libmng_types.h
+  fi &&
 
   default_build
-
-) > $C_FIFO 2>&1

--- a/graphics/libmng/BUILD
+++ b/graphics/libmng/BUILD
@@ -1,5 +1,7 @@
 
+  if in_depends $MODULE %JPEG ; then
   sedit "207i #include <jpeglib.h>" libmng_types.h &&
+  fi &&
 
   if in_depends $MODULE jpeg ; then
     sedit "202,206d" libmng_types.h

--- a/graphics/libmng/BUILD
+++ b/graphics/libmng/BUILD
@@ -1,6 +1,6 @@
 
   if in_depends $MODULE %JPEG ; then
-  sedit "207i #include <jpeglib.h>" libmng_types.h &&
+  sedit "207i #include <jpeglib.h>" libmng_types.h
   fi &&
 
   if in_depends $MODULE jpeg ; then

--- a/graphics/libmng/DEPENDS
+++ b/graphics/libmng/DEPENDS
@@ -1,3 +1,3 @@
-optional_depends zlib  "--with-zlib" "--without-zlib" "for compression support"
-optional_depends lcms  "--with-lcms" "--without-lcms" "for color management support"
-optional_depends %JPEG "--with-jpeg" "--without-jpeg" "for jpeg graphics support"
+optional_depends zlib  "--with-zlib"  "--without-zlib"  "for compression support"
+optional_depends lcms2 "--with-lcms2" "--without-lcms2" "for color management support"
+optional_depends %JPEG "--with-jpeg"  "--without-jpeg"  "for jpeg graphics support"

--- a/graphics/libmng/DEPENDS
+++ b/graphics/libmng/DEPENDS
@@ -1,3 +1,3 @@
-optional_depends zlib  "--with-zlib"  "--without-zlib"  "for compression support"
-optional_depends lcms2 "--with-lcms2" "--without-lcms2" "for color management support"
-optional_depends %JPEG "--with-jpeg"  "--without-jpeg"  "for jpeg graphics support"
+optional_depends zlib  "--with-zlib"  "--without-zlib"  "for compression support" y
+optional_depends lcms2 "--with-lcms2" "--without-lcms2" "for color management support" y
+optional_depends %JPEG "--with-jpeg"  "--without-jpeg"  "for jpeg graphics support" y

--- a/graphics/libmng/DETAILS
+++ b/graphics/libmng/DETAILS
@@ -1,11 +1,11 @@
           MODULE=libmng
-         VERSION=1.0.10
-          SOURCE=$MODULE-$VERSION.tar.gz
+         VERSION=2.0.2
+          SOURCE=$MODULE-$VERSION.tar.xz
       SOURCE_URL=$SFORGE_URL/$MODULE/
-      SOURCE_VFY=sha1:78ad516a1de79d00de720bf2a7c9afea2c896b09
+      SOURCE_VFY=sha1:7dd35369ff5916e1823cbacef984ab1b87714b69
         WEB_SITE=http://www.libmng.com/
          ENTERED=20010922
-         UPDATED=20070714
+         UPDATED=20150211
            SHORT="A library that supports the MNG graphics format"
 
 cat << EOF


### PR DESCRIPTION
...sedit is

to account for a make failure if jpeg is installed. I use libjpeg-turbo so that
part is not tested. The sedits are taken from;

http://sources.gentoo.org/cgi-bin/viewvc.cgi/gentoo-x86/media-libs/libmng/files/