### PR TITLE
MPlayer: add missing dependency

### DIFF
--- a/video/MPlayer/DEPENDS
+++ b/video/MPlayer/DEPENDS
@@ -1,6 +1,7 @@
 # Using minimal --enables, because MPlayer's build system is FLAKY.
 depends freetype2
 depends yasm
+depends fribidi
 
 optional_depends MPlayer-essentials \
                  "" \


### PR DESCRIPTION
I created a module "smplayer"( a qt front-end gui for MPlayer). When I tried to play mp3, it said MPlayer didn't have FriBiDi compiled with it.  But according to the followings in source codes directory:

lee@lunar /tmp/mplayer/MPlayer-1.1.1 $ ./configure --help | grep bidi
  --enable-fribidi       enable the FriBiDi libs [autodetect]
 
This should be auto detected while smplayer said no. So I decided to add fribidi to MPlayer's DEPENDS.
