### PR TITLE
llvm: version bumped to 3.6.0.

### DIFF
--- a/compilers/llvm/DETAILS
+++ b/compilers/llvm/DETAILS
@@ -1,5 +1,5 @@
           MODULE=llvm
-         VERSION=3.5.1
+         VERSION=3.6.0
           SOURCE=$MODULE-$VERSION.src.tar.xz
          SOURCE2=cfe-$VERSION.src.tar.xz
          SOURCE3=clang-tools-extra-$VERSION.src.tar.xz
@@ -7,12 +7,12 @@ SOURCE_DIRECTORY=${BUILD_DIRECTORY}/$MODULE-${VERSION}.src
       SOURCE_URL=http://llvm.org/releases/$VERSION/
      SOURCE2_URL=$SOURCE_URL
      SOURCE3_URL=$SOURCE_URL
-      SOURCE_VFY=sha256:bf3275d2d7890015c8d8f5e6f4f882f8cf3bf51967297ebe74111d6d8b53be15
-     SOURCE2_VFY=sha256:6773f3f9cf815631cc7e779ec134ddd228dc8e9a250e1ea3a910610c59eb8f5c
-     SOURCE3_VFY=sha256:e8d011250389cfc36eb51557ca25ae66ab08173e8d53536a0747356105d72906
+      SOURCE_VFY=sha256:b39a69e501b49e8f73ff75c9ad72313681ee58d6f430bfad4d81846fe92eb9ce
+     SOURCE2_VFY=sha256:be0e69378119fe26f0f2f74cffe82b7c26da840c9733fe522ed3c1b66b11082d
+     SOURCE3_VFY=sha256:3aa949ba82913490a75697287d9ee8598c619fae0aa6bb8fddf0095ff51bc812
         WEB_SITE=http://www.llvm.org
          ENTERED=20090128
-         UPDATED=20150114
+         UPDATED=20150309
            SHORT="Low Level Virtual Machine"
 
 cat << EOF


### PR DESCRIPTION
It's needed for the new mesa-lib version (10.5.4) when it will be committed in the moonbase.
It breaks the existing mesa-lib.