### PR TITLE
jsoncpp: Bump to 0.10.2. SWitching to $MIRROR_URL since their github …

### DIFF
--- a/libs/jsoncpp/BUILD
+++ b/libs/jsoncpp/BUILD
@@ -1,13 +1,5 @@
-(
 
-  GCC_VER=`lvu installed gcc`   &&
-  scons platform=linux-gcc      &&
+  OPTS+=" -DJSONCPP_WITH_CMAKE_PACKAGE=1 -DJSONCPP_WITH_POST_BUILD_UNITTEST=0" &&
 
-  prepare_install               &&
-  mkdir -p /usr/include/$MODULE &&
-  cp include/json/* /usr/include/$MODULE/ &&
-  cp -r libs/linux-gcc-$GCC_VER/*linux-gcc-$GCC_VER* /usr/lib/ &&
-  ln -sf /usr/lib/libjson_linux-gcc-$GCC_VER\_libmt.so /usr/lib/libjsoncpp.so.0 &&
-  ln -sf /usr/lib/libjson_linux-gcc-$GCC_VER\_libmt.so /usr/lib/libjsoncpp.so
-
-) > $C_FIFO 2>&1
+# Per README.md, scons building is depreciated.
+  default_cmake_build

--- a/libs/jsoncpp/DEPENDS
+++ b/libs/jsoncpp/DEPENDS
@@ -1,2 +1,2 @@
 depends Python
-depends scons
+depends cmake

--- a/libs/jsoncpp/DETAILS
+++ b/libs/jsoncpp/DETAILS
@@ -1,11 +1,11 @@
           MODULE=jsoncpp
-         VERSION=src-0.6.0-rc2
+         VERSION=0.10.2
           SOURCE=$MODULE-$VERSION.tar.gz
-      SOURCE_URL=$SFORGE_URL/$MODULE/$MODULE/0.6.0-rc2/
-      SOURCE_VFY=sha1:a14eb501c44e610b8aaa2962bd1cc1775ed4fde2
+      SOURCE_URL=$MIRROR_URL
+      SOURCE_VFY=sha256:37bb72615018522bb78a5eb425b36dfc79e049c1d5471b724f7ccadeac0ed479
         WEB_SITE=https://github.com/open-source-parsers/jsoncpp
          ENTERED=20140727
-         UPDATED=20140727
+         UPDATED=20150509
            SHORT="manipulate JSON values"
 
 cat << EOF


### PR DESCRIPTION
…releases

omit the module name and you end up with something like 0.10.2.tar.gz (wth is that).

Per their README.md, scons/sconstruct is depreciated and they now use cmake, making
BUILD reflect.