### PR TITLE
bitlbee: Version bump to 3.4.1

### DIFF
--- a/chat/bitlbee/DETAILS
+++ b/chat/bitlbee/DETAILS
@@ -1,8 +1,8 @@
           MODULE=bitlbee
-         VERSION=3.4
+         VERSION=3.4.1
           SOURCE=$MODULE-$VERSION.tar.gz
       SOURCE_URL=http://get.bitlbee.org/src/
-      SOURCE_VFY=sha256:cebad646bbfd17c80923743244039fd970e3ca27e8c1b7cf872622e773239d5e
+      SOURCE_VFY=sha256:500a0b19943040d67458eb3beb0a63d004abb2aa54a777addeb2a895d4f5c0e1
         WEB_SITE=http://www.bitlbee.org/
          ENTERED=20100917
          UPDATED=20150506


### PR DESCRIPTION
MSN messenger support has been reinstated, for both of the people who
still use that.