### PR TITLE
gforth: version bump to 0.7.3.

### DIFF
--- a/compilers/gforth/DETAILS
+++ b/compilers/gforth/DETAILS
@@ -1,11 +1,11 @@
           MODULE=gforth
-         VERSION=0.7.0
+         VERSION=0.7.3
           SOURCE=${MODULE}-${VERSION}.tar.gz
       SOURCE_URL=${GNU_URL}/${MODULE}/
-      SOURCE_VFY=sha1:5bb357268cba683f2a8c63d2a4bcab8f41cb0086
+      SOURCE_VFY=sha256:2f62f2233bf022c23d01c920b1556aa13eab168e3236b13352ac5e9f18542bb0
         WEB_SITE=http://www.gnu.org/software/gforth/
          ENTERED=20081019
-         UPDATED=20081110
+         UPDATED=20150901
            SHORT="A Forth compiler/interpreter"
 
 PSAFE=no


### PR DESCRIPTION
Module untouched since 2008, I bet everyone else forgot that this even existed!