### PR TITLE
i3: add missing dependency

### DIFF
--- a/x11-wm/i3/DEPENDS
+++ b/x11-wm/i3/DEPENDS
@@ -1,6 +1,7 @@
 depends xcb-util-keysyms
 depends xcb-util-cursor
 depends xcb-util-wm
+depends libxkbcommon
 depends libev
 depends yajl
 depends pango


### PR DESCRIPTION
Without libxkbcommon, i3 will fail to compile.