### PR TITLE
ufraw: depends lcms2 rather than lcms

### DIFF
--- a/graphics/ufraw/DEPENDS
+++ b/graphics/ufraw/DEPENDS
@@ -1,4 +1,4 @@
-depends lcms
+depends lcms2
 
 optional_depends "gtkimageview" "--with-gtk"  "--without-gtk"  "for a GTK GUI"
 optional_depends "gimp"         "--with-gimp" "--without-gimp" "for UFRaw to create a Gimp plug-in"


### PR DESCRIPTION
./configure tries to find lcms2, not lcms version 1 :>