### PR TITLE
firefox-bin: use http rather than ftp

### DIFF
--- a/web/firefox-bin/DETAILS
+++ b/web/firefox-bin/DETAILS
@@ -1,7 +1,7 @@
           MODULE=firefox-bin
          VERSION=39.0.3
           SOURCE=firefox-$VERSION.tar.bz2
-   SOURCE_URL[0]=ftp://ftp.mozilla.org/pub/firefox/releases/$VERSION/linux-i686/en-US
+   SOURCE_URL[0]=http://ftp.mozilla.org/pub/firefox/releases/$VERSION/linux-i686/en-US
    SOURCE_URL[1]=ftp://mozilla.isc.org/pub/mozilla.org/firefox/releases/$VERSION/linux-i686/en-US
    SOURCE_URL[2]=ftp://ftp.uni-erlangen.de/pub/mozilla.org/firefox/releases/$VERSION/linux-i686/en-US
       SOURCE_VFY=sha256:58077f0da5339f3d90a2c74f69b875270d936fa8a12d8f98684fe0c856279e92

--- a/web/firefox-bin/DETAILS.x86_64
+++ b/web/firefox-bin/DETAILS.x86_64
@@ -1,7 +1,7 @@
           MODULE=firefox-bin
          VERSION=39.0.3
           SOURCE=firefox-$VERSION.tar.bz2
-   SOURCE_URL[0]=ftp://ftp.mozilla.org/pub/firefox/releases/$VERSION/linux-x86_64/en-US
+   SOURCE_URL[0]=http://ftp.mozilla.org/pub/firefox/releases/$VERSION/linux-x86_64/en-US
    SOURCE_URL[1]=ftp://mozilla.isc.org/pub/mozilla.org/firefox/releases/$VERSION/linux-x86_64/en-US
    SOURCE_URL[2]=ftp://ftp.uni-erlangen.de/pub/mozilla.org/firefox/releases/$VERSION/linux-x86_64/en-US
       SOURCE_VFY=sha256:4c5a6911130d4920703e9101ebaebb21fc77841e0470af0d24c9f48ee60e24df


### PR DESCRIPTION
ftp is slow and sometimes hangs for a long time even 100%