### PR TITLE
mutt-devel: bump to 1.5.24.

### DIFF
--- a/mail/mutt-devel/BUILD
+++ b/mail/mutt-devel/BUILD
@@ -1,6 +1,4 @@
 (
-   patch_it $SOURCE_CACHE/$SOURCE2 1  &&
-
    aclocal &&
    libtoolize -f &&
    AT_M4DIR="m4" autoreconf -i &&

--- a/mail/mutt-devel/DETAILS
+++ b/mail/mutt-devel/DETAILS
@@ -1,13 +1,11 @@
           MODULE=mutt-devel
-         VERSION=1.5.23
+         VERSION=1.5.24
           SOURCE=mutt-$VERSION.tar.gz
-         SOURCE2=patch-$VERSION.sidebar.20140412.txt
 SOURCE_DIRECTORY=$BUILD_DIRECTORY/mutt-$VERSION
-   SOURCE_URL[0]=ftp://ftp.mutt.org/mutt/devel
+   SOURCE_URL[0]=ftp://ftp.mutt.org/pub/mutt/
    SOURCE_URL[1]=$SFORGE_URL/mutt
      SOURCE2_URL=$PATCH_URL
-      SOURCE_VFY=sha1:8ac821d8b1e25504a31bf5fda9c08d93a4acc862
-     SOURCE2_VFY=sha1:8b86f148d8e1a0b37b0b77268349f4c94e797561
+      SOURCE_VFY=sha256:a292ca765ed7b19db4ac495938a3ef808a16193b7d623d65562bb8feb2b42200
         WEB_SITE=http://www.mutt.org
          ENTERED=20010922
          UPDATED=20140412


### PR DESCRIPTION
This came out August 31.

The last "stable" release of mutt came out in June 2007.  I wonder what
it'll take to get them to admit that it's not so much "stable" as
"fossilized".

I took out the sidebar patch because I've never used whatever
functionality it provides.  Anyone who actually does use that is welcome
to reimplement it.