### PR TITLE
rustc: The compiler for the Rust programming language

### DIFF
--- a/compilers/rustc/DETAILS
+++ b/compilers/rustc/DETAILS
@@ -1,0 +1,26 @@
+            MODULE=rustc
+           VERSION=1.2.0
+            SOURCE=$MODULE-$VERSION-src.tar.gz
+        SOURCE_URL=http://static.rust-lang.org/dist/
+        SOURCE_VFY=sha256:ea6eb983daf2a073df57186a58f0d4ce0e85c711bec13c627a8c85d51b6a6d78
+          WEB_SITE=http://www.rust-lang.org/
+           ENTERED=20150916
+           UPDATED=20150916
+             SHORT="Rust language compiler"
+             BUILD=${BUILD/pc/unknown}
+
+cat << EOF
+Rust is a systems programming language that runs blazingly fast, prevents
+nearly all segfaults, and guarantees thread safety. 
+
+Featuring:
+* zero-cost abstractions
+* move semantics
+* guaranteed memory safety
+* threads without data races
+* trait-based generics
+* pattern matching
+* type inference
+* minimal runtime
+* efficient C bindings
+EOF


### PR DESCRIPTION
I guess there isn't much software in the wild (yet?) written in Rust,
hence the lack of a module for it.