### PR TITLE
cdrtools: version bumped to 3.02a01

### DIFF
--- a/cd/cdrtools/DEPENDS
+++ b/cd/cdrtools/DEPENDS
@@ -2,3 +2,4 @@ depends acl
 depends libcap
 
 optional_depends dirsplit "" "" "for cdrkit compatibility and optimal file layout on discs"
+optional_depends pulseaudio "" "" "to enable pulseaudio output for cdda2wav -echo"

--- a/cd/cdrtools/DETAILS
+++ b/cd/cdrtools/DETAILS
@@ -1,11 +1,11 @@
           MODULE=cdrtools
-         VERSION=3.01
-          SOURCE=$MODULE-${VERSION}.tar.bz2
+         VERSION=3.02
+          SOURCE=$MODULE-${VERSION}a01.tar.bz2
       SOURCE_URL=$SFORGE_URL/$MODULE/
-      SOURCE_VFY=sha256:ed282eb6276c4154ce6a0b5dee0bdb81940d0cbbfc7d03f769c4735ef5f5860f
+      SOURCE_VFY=sha256:7f3cccabe108e26cae62976bd4b0ee0f50c5f715f016eb535f749b275b66ce63
         WEB_SITE=http://cdrtools.sourceforge.net/private/cdrecord.html
          ENTERED=20010922
-         UPDATED=20150830
+         UPDATED=20151111
            SHORT="Creates home-burned CDs/DVDs/BDs with a CD-R/CD-RW/DVD/Blu-ray recorder"
 PSAFE=no
 


### PR DESCRIPTION
I've added an optional_depends on pulseaudio for the "-echo" feature of cdda2wav which is able to use pulseaudio since 3.02a01.
Thanks