### PR TITLE
firefox: add missing dependency

### DIFF
--- a/web/firefox/DEPENDS
+++ b/web/firefox/DEPENDS
@@ -6,6 +6,7 @@ depends curl
 depends alsa-lib
 depends libvpx
 depends freetype2
+depends gst-plugins-base
 
 optional_depends libpng "--enable-system-libpng" "--disable-system-libpng" "Build with system libpng"
 optional_depends cairo  "--enable-system-cairo"  "--disable-system-cairo"  "Build with system cairo ${PROBLEM_COLOR}(unstable)"


### PR DESCRIPTION
Firefox 39.0.3 needs gst-plugins-base as backend.