### PR TITLE
alsa-utils: add missing dependency

### DIFF
--- a/audio/alsa-utils/DEPENDS
+++ b/audio/alsa-utils/DEPENDS
@@ -1,4 +1,5 @@
 depends alsa-lib
 depends ncurses
+depends fftw3
 
 optional_depends xmlto "" "--disable-xmlto" "generate the man pages with xmlto"


### PR DESCRIPTION
fftw3 is needed to build latest alsa-utils.