### PR TITLE
alsa-plugins: add missing dependency

### DIFF
--- a/audio/alsa-plugins/DEPENDS
+++ b/audio/alsa-plugins/DEPENDS
@@ -1,4 +1,5 @@
 depends alsa-lib
+depends speex
 
 optional_depends pulseaudio "--enable-pulseaudio" "--disable-pulseaudio" "for PulseAudio support"
 optional_depends jack       "--enable-jack"       "--disable-jack"       "for low latency audio support"


### PR DESCRIPTION
lastest alsa-plugins is trying to find speex rate plugin and speex preprocess plugins. In this case, speex is needed.