### PR TITLE
firefox: add missing depends

### DIFF
--- a/web/firefox/DEPENDS
+++ b/web/firefox/DEPENDS
@@ -6,6 +6,7 @@ depends curl
 depends alsa-lib
 depends libvpx
 depends freetype2
+depends GConf
 
 optional_depends libpng "--enable-system-libpng" "--disable-system-libpng" "Build with system libpng"
 optional_depends cairo  "--enable-system-cairo"  "--disable-system-cairo"  "Build with system cairo ${PROBLEM_COLOR}(unstable)"


### PR DESCRIPTION
The configure error message:

configure:19613: checking for gconf-2.0 >= 1.2.1 gobject-2.0
configure: error: * * * Could not find gconf-2.0
*** Fix above errors and then restart with\
               "/usr/bin/make -f client.mk build"
/usr/src/firefox-43.0.1/client.mk:359: recipe for target 'configure' failed
make[2]: *** [configure] Error 1
make[2]: Leaving directory '/usr/src/firefox-43.0.1'
/usr/src/firefox-43.0.1/client.mk:373: recipe for target '/usr/src/firefox-43.0.1/build-mozilla/Makefile' failed
make[1]: *** [/usr/src/firefox-43.0.1/build-mozilla/Makefile] Error 2
make[1]: Leaving directory '/usr/src/firefox-43.0.1'
client.mk:171: recipe for target 'build' failed
make: *** [build] Error 2
Creating /var/log/lunar/compile/firefox-43.0.1.xz