### PR TITLE
cups-filters: let's renderer choose default ghosrscript

### DIFF
--- a/printer/cups-filters/BUILD
+++ b/printer/cups-filters/BUILD
@@ -6,7 +6,6 @@ fi &&
 
 OPTS+=" --disable-static \
         --sysconfdir=/etc \
-        --with-pdftops=pdftops \
         --sbindir=/usr/bin \
         --localstatedir=/var \
         --with-browseremoteprotocols=DNSSD,CUPS \


### PR DESCRIPTION
My full build log is here: http://paste.pound-python.org/show/W2yx7R0um2f5XgydTTTN/

Main error message:

filter/pdftops.c: In function 'main':
filter/pdftops.c:265:25: error: 'CUPS_PDFTOPS_RENDERER' undeclared (first use in this function)
   renderer_t    renderer = CUPS_PDFTOPS_RENDERER; /* Renderer: gs or pdftops or acroread or pdftocairo or hybri
                         ^
filter/pdftops.c:265:25: note: each undeclared identifier is reported only once for each function it appears in
Makefile:3128: recipe for target 'pdftops-pdftops.o' failed
make[1]: *** [pdftops-pdftops.o] Error 1
make[1]: Leaving directory '/usr/src/cups-filters-1.5.0'
Makefile:1765: recipe for target 'all' failed
make: *** [all] Error 2
Creating /var/log/lunar/compile/cups-filters-1.5.0.xz 

It doesn't build with OPTS+=" --with-pdftops=pdftops" . if I drop this line, it builds fine.

You are welcome to give a better solution.

cc @Florin65 (since you bumped it)
