### PR TITLE
frescobaldi: moved from -kde

### DIFF
--- a/doc-tools/frescobaldi/BUILD
+++ b/doc-tools/frescobaldi/BUILD
@@ -1,0 +1,4 @@
+  source /etc/profile.d/qt4.rc &&
+
+  prepare_install &&
+  python setup.py install --prefix=/usr

--- a/doc-tools/frescobaldi/DEPENDS
+++ b/doc-tools/frescobaldi/DEPENDS
@@ -1,0 +1,8 @@
+depends Python
+depends qt4
+depends PyQt
+depends python-poppler-qt4
+
+depends tango-icon-theme
+
+depends lilypond

--- a/doc-tools/frescobaldi/DETAILS
+++ b/doc-tools/frescobaldi/DETAILS
@@ -1,0 +1,14 @@
+          MODULE=frescobaldi
+         VERSION=2.18.2
+          SOURCE=$MODULE-$VERSION.tar.gz
+      SOURCE_URL=https://github.com/wbsoft/frescobaldi/releases/download/v${VERSION}
+      SOURCE_VFY=sha256:e54a674bc4f8fad368969822829d913dc4c6de0ae2ca4e762e1f0a25b03ddafa
+        WEB_SITE=http://www.frescobaldi.org/
+         ENTERED=20090307
+         UPDATED=20160114
+           SHORT="LilyPond sheet music editor"
+
+cat << EOF
+Frescobaldi is a LilyPond sheet music editor.
+It aims to be powerful, yet lightweight and easy to use.
+EOF

--- a/doc-tools/frescobaldi/PRE_BUILD
+++ b/doc-tools/frescobaldi/PRE_BUILD
@@ -1,0 +1,4 @@
+default_pre_build &&
+
+# this is provided by the tango-icon-theme module
+rm -r frescobaldi_app/icons/Tango


### PR DESCRIPTION
This module does not depend on kde anymore
and got completely rewritten since it did.

blocked until the module is actually removed from -kde.