### PR TITLE
go-bootstrap: a bootstrap go compiler module.

### DIFF
--- a/compilers/go-bootstrap/BUILD
+++ b/compilers/go-bootstrap/BUILD
@@ -1,0 +1,43 @@
+export GOROOT=$SOURCE_DIRECTORY
+export GOBIN=$GOROOT/bin
+export GOROOT_FINAL=/usr/lib/go
+export GOPATH=$BUILD_DIRECTORY
+export GOOS=linux
+
+cd src &&
+bash make.bash &&
+
+case "$(arch)" in
+  x86_64)
+    export GOARCH=amd64
+    ;;
+  i686)
+    export GOARCH=386
+    ;;
+esac &&
+bash make.bash --no-clean &&
+
+$GOROOT/bin/go get -d golang.org/x/tools/cmd/godoc &&
+$GOROOT/bin/go build -o $SOURCE_DIRECTORY/godoc golang.org/x/tools/cmd/godoc &&
+for i in vet cover; do
+  $GOROOT/bin/go get -d golang.org/x/tools/cmd/${i} &&
+  $GOROOT/bin/go build -o $GOROOT/pkg/tool/${GOOS}_${GOARCH}/${i} golang.org/x/tools/cmd/${i}
+done &&
+
+prepare_install &&
+
+cd $SOURCE_DIRECTORY &&
+mkdir -p /usr/lib/go &&
+
+cp -a bin/* /usr/bin/    &&
+cp -a src   /usr/lib/go/ &&
+cp -a lib   /usr/lib/go/ &&
+cp -a pkg   /usr/lib/go/ &&
+cp -a include /usr/lib/go/ &&
+
+ln -sf /usr/bin /usr/lib/go/bin &&
+
+install -Dm0644 src/Make.* /usr/lib/go/src/
+
+# Remove object files from target src dir
+#find /usr/lib/go/src/ -type f -name '*.[ao]' -delete

--- a/compilers/go-bootstrap/CONFLICTS
+++ b/compilers/go-bootstrap/CONFLICTS
@@ -1,0 +1,1 @@
+conflicts go

--- a/compilers/go-bootstrap/DEPENDS
+++ b/compilers/go-bootstrap/DEPENDS
@@ -1,0 +1,6 @@
+depends perl
+depends gawk
+depends inetutils
+depends git
+
+

--- a/compilers/go-bootstrap/DETAILS
+++ b/compilers/go-bootstrap/DETAILS
@@ -1,0 +1,15 @@
+          MODULE=go-bootstrap
+         VERSION=1.4.2
+          SOURCE=go${VERSION}.src.tar.gz
+SOURCE_DIRECTORY=$BUILD_DIRECTORY/go
+      SOURCE_URL=http://storage.googleapis.com/golang
+      SOURCE_VFY=sha256:299a6fd8f8adfdce15bc06bde926e7b252ae8e24dd5b16b7d8791ed79e7b5e9b
+        WEB_SITE=http://golang.org/
+         ENTERED=20140606
+         UPDATED=20150224
+           SHORT="A bootstrap Go compiler and tools"
+
+cat <<EOF
+Compiler and tools for the Go programming language from Google.
+EOF
+

--- a/compilers/go-bootstrap/POST_INSTALL
+++ b/compilers/go-bootstrap/POST_INSTALL
@@ -1,0 +1,1 @@
+rm -fR /usr/src/src


### PR DESCRIPTION
It is used only no previous go compiler is installed on the system. After the install of go module it is removed form the system.
 