### PR TITLE
ebtables: new module (actually very old module)

### DIFF
--- a/net/ebtables/BUILD
+++ b/net/ebtables/BUILD
@@ -1,0 +1,4 @@
+sedit 's/-Werror//' Makefile &&
+make &&
+prepare_install &&
+make install MANDIR=/usr/man BINDIR=/usr/bin

--- a/net/ebtables/DETAILS
+++ b/net/ebtables/DETAILS
@@ -1,0 +1,18 @@
+          MODULE=ebtables
+         VERSION=v2.0.10-4
+          SOURCE=$MODULE-$VERSION.tar.gz
+      SOURCE_URL=ftp://ftp.netfilter.org/pub/$MODULE/
+      SOURCE_VFY=sha256:dc6f7b484f207dc712bfca81645f45120cb6aee3380e77a1771e9c34a9a4455d
+        WEB_SITE=http://www.ex-parrot.com/~pdw/iftop/
+         ENTERED=20160130
+         UPDATED=20160130
+           SHORT="filtering tool for a bridging firewall"
+
+cat << EOF
+The ebtables program is a filtering tool for a Linux-based bridging
+firewall. It enables transparent filtering of network traffic passing
+through a Linux bridge. The filtering possibilities are limited to link
+layer filtering and some basic filtering on higher network layers.
+Advanced logging, MAC DNAT/SNAT and brouter facilities are also
+included.
+EOF


### PR DESCRIPTION
Apparently the latest version of libvirt needs this.  It's a tool
to build firewall rules at the Ethernet bridging level rather than
at the IP level.