### PR TITLE
keychain: Version bump to 2.8.2

### DIFF
--- a/security/keychain/DETAILS
+++ b/security/keychain/DETAILS
@@ -1,11 +1,11 @@
           MODULE=keychain
-         VERSION=2.8.1
+         VERSION=2.8.2
           SOURCE=$MODULE-$VERSION.tar.bz2
       SOURCE_URL=http://www.funtoo.org/distfiles/keychain/
-      SOURCE_VFY=sha256:1568c0946db3638fe081d5a7ba3df022b533dbeb8aa67cd07dc8276e87598809
+      SOURCE_VFY=sha256:74895832297616a1a951e81a56603f2fc6e5449576411f8b122a5cc933ae3301
         WEB_SITE=http://www.funtoo.org/Keychain
          ENTERED=20151109
-         UPDATED=21051109
+         UPDATED=20160206
            SHORT="Lets you reuse ssh/gpg agents and manage keys"
 
 cat << 'EOF'


### PR DESCRIPTION
Supports new ssh features, fixes bugs, according to the changelog.