### PR TITLE
lirc: add optional Python-3 dep

### DIFF
--- a/utils/lirc/DEPENDS
+++ b/utils/lirc/DEPENDS
@@ -1,4 +1,4 @@
 optional_depends alsa-lib "" "" "for ALSA audio support"
 optional_depends libX11   "" "" "for X11 support"
 optional_depends man      "" "" "for html documentation"
-
+optional_depends Python-3 "" "" "for Python 3 support"


### PR DESCRIPTION
The main webpage lists python3 as  Mandatory dependencies , but I think lunar doesn't treat it as mandatory. 