### PR TITLE
go: version bumped to 1.6.

### DIFF
--- a/compilers/go/BUILD
+++ b/compilers/go/BUILD
@@ -2,29 +2,19 @@ export GOROOT=$SOURCE_DIRECTORY
 export GOBIN=$GOROOT/bin
 export GOROOT_FINAL=/usr/lib/go
 export GOPATH=$BUILD_DIRECTORY
-export GO386=387
+export GOROOT_BOOTSTRAP=/usr/lib/go
 export GOOS=linux
 
-cd src &&
-bash make.bash &&
-
-# Cross compilation support if needed have to be activated from here
-#for i in amd64 386; do
-#  export GOARCH=$i
-#  bash make.bash --no-clean
-#done &&
-
 case "$(arch)" in
-  x86_64)
-    export GOARCH=amd64
-    ;;
-  i686)
-    export GOARCH=386
-    ;;
+  x86_64) export GOARCH=amd64 ;;
+  i686)   export GOARCH=386 ;;
 esac &&
+
+cd src &&
 bash make.bash --no-clean &&
 
-cd $SOURCE_DIRECTORY &&
+#cd $SOURCE_DIRECTORY &&
+
 $GOROOT/bin/go get -d golang.org/x/tools/cmd/godoc &&
 $GOROOT/bin/go build -o $SOURCE_DIRECTORY/godoc golang.org/x/tools/cmd/godoc &&
 for i in vet cover; do
@@ -32,34 +22,41 @@ for i in vet cover; do
   $GOROOT/bin/go build -o $GOROOT/pkg/tool/${GOOS}_${GOARCH}/${i} golang.org/x/tools/cmd/${i}
 done &&
 
-# Clean up before install
-#find $SOURCE_DIRECTORY/ -type f -name '*.[ao]' -delete &&
-#find $SOURCE_DIRECTORY/ -type f -executable -delete &&
+if module_installed go-bootstrap; then
+  # remove the bootstrap go compiler
+  lrm go-bootstrap
+fi &&
 
-prepare_install &&
+prepare_install  &&
 
 cd $SOURCE_DIRECTORY &&
 install -Dm0755 godoc /usr/bin/godoc &&
 mkdir -p /usr/{share/go,lib/go/src,lib/go/site/src} &&
 cp -r doc misc /usr/share/go/ &&
-cp -a bin/* /usr/bin/  &&
+ln -sf /usr/share/go/doc /usr/lib/go/doc &&
+cp -a bin /usr/ &&
 cp -a pkg /usr/lib/go/ &&
-cp -a src /usr/lib/go/ &&
-cp -a src/cmd /usr/lib/go/src/ &&
-cp -a src/lib9 /usr/lib/go/src/ &&
-cp -a lib /usr/lib/go/ &&
-cp -a include /usr/lib/go/ &&
+cp -a $GOROOT/src /usr/lib/go/ &&
+cp -a $GOROOT/lib /usr/lib/go/ &&
+
 install -Dm0644 src/Make.* /usr/lib/go/src/ &&
+
 ln -sf /usr/bin /usr/lib/go/bin &&
 
-# Headers for C modules
-install -Dm644 src/runtime/runtime.h "/usr/lib/go/src/runtime/runtime.h" &&
-install -Dm644 src/runtime/cgocall.h "/usr/lib/go/src/runtime/cgocall.h" &&
+# Remove object files from target src dir
+find /usr/lib/go/src/ -type f -name '*.[ao]' -delete &&
+
+# Remove all executable source files
+find /usr/lib/go/src -type f -executable -delete &&
 
 # For gox
-install -Dm755 src/make.bash "/usr/lib/go/src/make.bash" &&
-install -Dm755 src/run.bash "/usr/lib/go/src/run.bash" &&
-cp -r misc/ "/usr/lib/go/" &&
+install -Dm755 src/make.bash /usr/lib/go/src/make.bash &&
+install -Dm755 src/run.bash  /usr/lib/go/src/run.bash  &&
+ln -sf /usr/share/go/misc /usr/lib/go/misc &&
 
 # For godoc
-install -Dm644 favicon.ico "/usr/lib/go/favicon.ico"
+install -Dm644 favicon.ico /usr/lib/go/favicon.ico &&
+rm -f /usr/share/go/doc/articles/wiki/get.bin &&
+install -Dm644 VERSION /usr/lib/go/VERSION &&
+
+find /usr/lib/go/pkg -type f -exec touch '{}' +

--- a/compilers/go/DEPENDS
+++ b/compilers/go/DEPENDS
@@ -1,10 +1,3 @@
-depends perl
-depends gawk
-depends inetutils
-
-optional_depends git        "" "" "for git repositories support"
 optional_depends mercurial  "" "" "for mercurial repositories support"
 optional_depends subversion "" "" "for subversion repositories support"
 optional_depends bzr        "" "" "for bzr repositories support"
-
-

--- a/compilers/go/DETAILS
+++ b/compilers/go/DETAILS
@@ -1,15 +1,14 @@
           MODULE=go
-         VERSION=1.4.2
+         VERSION=1.6
           SOURCE=${MODULE}${VERSION}.src.tar.gz
-      SOURCE_URL=https://storage.googleapis.com/golang
-      SOURCE_VFY=sha256:299a6fd8f8adfdce15bc06bde926e7b252ae8e24dd5b16b7d8791ed79e7b5e9b
 SOURCE_DIRECTORY=$BUILD_DIRECTORY/$MODULE
+      SOURCE_URL=http://storage.googleapis.com/golang
+      SOURCE_VFY=sha256:a96cce8ce43a9bf9b2a4c7d470bc7ee0cb00410da815980681c8353218dcf146
         WEB_SITE=http://golang.org/
          ENTERED=20140606
-         UPDATED=20150224
+         UPDATED=20160218
            SHORT="Compiler and tools for the Go programming language from Google"
 
 cat <<EOF
 Compiler and tools for the Go programming language from Google.
 EOF
-

--- a/compilers/go/PRE_BUILD
+++ b/compilers/go/PRE_BUILD
@@ -1,0 +1,7 @@
+# if go is already installed we'll use it for the bootstrap
+if ! ( ( module_installed go ) || (module_installed go-bootstrap) ); then
+  # install a minimal go compiler for the bootstrap
+  lin go-bootstrap
+fi &&
+
+default_pre_build

--- a/compilers/go/profile.d/go.rc
+++ b/compilers/go/profile.d/go.rc
@@ -1,0 +1,1 @@
+export GOROOT="/usr/lib/go"


### PR DESCRIPTION
It needs a running go compiler in the system (if not found it installs go-bootstrap, compile, and after that uninstall go-bootstrap).