### PR TITLE
go-bootstrap, go: refactoring

### DIFF
--- a/compilers/go-bootstrap/BUILD
+++ b/compilers/go-bootstrap/BUILD
@@ -1,0 +1,43 @@
+export GOROOT=$SOURCE_DIRECTORY
+export GOBIN=$GOROOT/bin
+export GOROOT_FINAL=/usr/lib/go
+export GOPATH=$BUILD_DIRECTORY
+export GOOS=linux
+
+cd src &&
+bash make.bash &&
+
+case "$(arch)" in
+  x86_64)
+    export GOARCH=amd64
+    ;;
+  i686)
+    export GOARCH=386
+    ;;
+esac &&
+bash make.bash --no-clean &&
+
+$GOROOT/bin/go get -d golang.org/x/tools/cmd/godoc &&
+$GOROOT/bin/go build -o $SOURCE_DIRECTORY/godoc golang.org/x/tools/cmd/godoc &&
+for i in vet cover; do
+  $GOROOT/bin/go get -d golang.org/x/tools/cmd/${i} &&
+  $GOROOT/bin/go build -o $GOROOT/pkg/tool/${GOOS}_${GOARCH}/${i} golang.org/x/tools/cmd/${i}
+done &&
+
+prepare_install &&
+
+cd $SOURCE_DIRECTORY &&
+mkdir -p /usr/lib/go &&
+
+cp -a bin/* /usr/bin/    &&
+cp -a src   /usr/lib/go/ &&
+cp -a lib   /usr/lib/go/ &&
+cp -a pkg   /usr/lib/go/ &&
+cp -a include /usr/lib/go/ &&
+
+ln -sf /usr/bin /usr/lib/go/bin &&
+
+install -Dm0644 src/Make.* /usr/lib/go/src/
+
+# Remove object files from target src dir
+#find /usr/lib/go/src/ -type f -name '*.[ao]' -delete

--- a/compilers/go-bootstrap/BUILD
+++ b/compilers/go-bootstrap/BUILD
@@ -1,43 +1,16 @@
 export GOROOT=$SOURCE_DIRECTORY
 export GOBIN=$GOROOT/bin
-export GOROOT_FINAL=/usr/lib/go
+export GOROOT_FINAL=/usr/lib/go1.4
 export GOPATH=$BUILD_DIRECTORY
 export GOOS=linux
 
 cd src &&
 bash make.bash &&
 
-case "$(arch)" in
-  x86_64)
-    export GOARCH=amd64
-    ;;
-  i686)
-    export GOARCH=386
-    ;;
-esac &&
-bash make.bash --no-clean &&
-
-$GOROOT/bin/go get -d golang.org/x/tools/cmd/godoc &&
-$GOROOT/bin/go build -o $SOURCE_DIRECTORY/godoc golang.org/x/tools/cmd/godoc &&
-for i in vet cover; do
-  $GOROOT/bin/go get -d golang.org/x/tools/cmd/${i} &&
-  $GOROOT/bin/go build -o $GOROOT/pkg/tool/${GOOS}_${GOARCH}/${i} golang.org/x/tools/cmd/${i}
-done &&
-
 prepare_install &&
 
 cd $SOURCE_DIRECTORY &&
-mkdir -p /usr/lib/go &&
-
-cp -a bin/* /usr/bin/    &&
-cp -a src   /usr/lib/go/ &&
-cp -a lib   /usr/lib/go/ &&
-cp -a pkg   /usr/lib/go/ &&
-cp -a include /usr/lib/go/ &&
-
-ln -sf /usr/bin /usr/lib/go/bin &&
-
-install -Dm0644 src/Make.* /usr/lib/go/src/
-
-# Remove object files from target src dir
-#find /usr/lib/go/src/ -type f -name '*.[ao]' -delete
+mkdir -p /usr/lib/go1.4/bin &&
+cp -a bin/* /usr/lib/go1.4/bin/ &&
+cp -a {src,lib,pkg} /usr/lib/go1.4/ &&
+chmod -R +x /usr/lib/go1.4/pkg/tool

--- a/compilers/go-bootstrap/CONFLICTS
+++ b/compilers/go-bootstrap/CONFLICTS
@@ -1,0 +1,1 @@
+conflicts go

--- a/compilers/go-bootstrap/CONFLICTS
+++ b/compilers/go-bootstrap/CONFLICTS
@@ -1,1 +1,0 @@
-conflicts go

--- a/compilers/go-bootstrap/DEPENDS
+++ b/compilers/go-bootstrap/DEPENDS
@@ -1,6 +1,3 @@
 depends perl
 depends gawk
 depends inetutils
-depends git
-
-

--- a/compilers/go-bootstrap/DEPENDS
+++ b/compilers/go-bootstrap/DEPENDS
@@ -1,0 +1,6 @@
+depends perl
+depends gawk
+depends inetutils
+depends git
+
+

--- a/compilers/go-bootstrap/DETAILS
+++ b/compilers/go-bootstrap/DETAILS
@@ -1,15 +1,17 @@
           MODULE=go-bootstrap
-         VERSION=1.4.2
+         VERSION=1.4.3
           SOURCE=go${VERSION}.src.tar.gz
+         SOURCE2=go-1.4.3-support_new_relocation.patch
 SOURCE_DIRECTORY=$BUILD_DIRECTORY/go
       SOURCE_URL=http://storage.googleapis.com/golang
-      SOURCE_VFY=sha256:299a6fd8f8adfdce15bc06bde926e7b252ae8e24dd5b16b7d8791ed79e7b5e9b
+     SOURCE2_URL=$PATCH_URL
+      SOURCE_VFY=sha256:9947fc705b0b841b5938c48b22dc33e9647ec0752bae66e50278df4f23f64959
+     SOURCE2_VFU=sha256:3bd901d920e53fed95b495a6daf012854826855993187a6d07970a7ef108ef28
         WEB_SITE=http://golang.org/
          ENTERED=20140606
-         UPDATED=20150224
+         UPDATED=20160220
            SHORT="A bootstrap Go compiler and tools"
 
 cat <<EOF
 Compiler and tools for the Go programming language from Google.
 EOF
-

--- a/compilers/go-bootstrap/DETAILS
+++ b/compilers/go-bootstrap/DETAILS
@@ -1,0 +1,15 @@
+          MODULE=go-bootstrap
+         VERSION=1.4.2
+          SOURCE=go${VERSION}.src.tar.gz
+SOURCE_DIRECTORY=$BUILD_DIRECTORY/go
+      SOURCE_URL=http://storage.googleapis.com/golang
+      SOURCE_VFY=sha256:299a6fd8f8adfdce15bc06bde926e7b252ae8e24dd5b16b7d8791ed79e7b5e9b
+        WEB_SITE=http://golang.org/
+         ENTERED=20140606
+         UPDATED=20150224
+           SHORT="A bootstrap Go compiler and tools"
+
+cat <<EOF
+Compiler and tools for the Go programming language from Google.
+EOF
+

--- a/compilers/go-bootstrap/POST_INSTALL
+++ b/compilers/go-bootstrap/POST_INSTALL
@@ -1,1 +1,2 @@
-rm -fR /usr/src/src
+# Fix timestamps to avoid go tools to rebuild its files
+find /usr/lib/go1.4 -type f -exec touch -r /usr/lib/go1.4/pkg/*/runtime.a {} \;

--- a/compilers/go-bootstrap/POST_INSTALL
+++ b/compilers/go-bootstrap/POST_INSTALL
@@ -1,0 +1,1 @@
+rm -fR /usr/src/src

--- a/compilers/go-bootstrap/PRE_BUILD
+++ b/compilers/go-bootstrap/PRE_BUILD
@@ -1,0 +1,4 @@
+default_pre_build &&
+
+# Relocation patch to build using binutils >= 2.26
+patch_it $SOURCE2 1

--- a/compilers/go/BUILD
+++ b/compilers/go/BUILD
@@ -2,7 +2,7 @@ export GOROOT=$SOURCE_DIRECTORY
 export GOBIN=$GOROOT/bin
 export GOROOT_FINAL=/usr/lib/go
 export GOPATH=$BUILD_DIRECTORY
-export GOROOT_BOOTSTRAP=/usr/lib/go
+export GOROOT_BOOTSTRAP=/usr/lib/go1.4
 export GOOS=linux
 
 case "$(arch)" in
@@ -11,52 +11,44 @@ case "$(arch)" in
 esac &&
 
 cd src &&
-bash make.bash --no-clean &&
+bash make.bash &&
 
-#cd $SOURCE_DIRECTORY &&
-
-$GOROOT/bin/go get -d golang.org/x/tools/cmd/godoc &&
-$GOROOT/bin/go build -o $SOURCE_DIRECTORY/godoc golang.org/x/tools/cmd/godoc &&
-for i in vet cover; do
-  $GOROOT/bin/go get -d golang.org/x/tools/cmd/${i} &&
-  $GOROOT/bin/go build -o $GOROOT/pkg/tool/${GOOS}_${GOARCH}/${i} golang.org/x/tools/cmd/${i}
+for i in godex godoc goimports gomvpkg gorename gotype; do
+  $GOROOT/bin/go get -d golang.org/x/tools/cmd/$i &&
+  $GOROOT/bin/go build -v -x -o $GOPATH/bin/$i golang.org/x/tools/cmd/$i
 done &&
 
-if module_installed go-bootstrap; then
-  # remove the bootstrap go compiler
-  lrm go-bootstrap
+for i in benchcmp bundle callgraph digraph eg fiximports html2article oracle present ssadump stress stringer; do
+  $GOROOT/bin/go get -d golang.org/x/tools/cmd/$i
+  $GOROOT/bin/go build -v -x -o $GOPATH/pkg/tool/${GOOS}_${GOARCH}/$i golang.org/x/tools/cmd/$i
+done &&
+
+if [[ "$RUN_TESTS" =~ [yY] ]]; then
+  echo "Testing go..." &&
+    for i in godoc goimports gomvpkg gorename gotype \
+             benchcmp bundle callgraph digraph eg fiximports html2article oracle present ssadump stress stringer; do
+      $GOROOT/bin/go test -v -x golang.org/x/tools/cmd/$i
+    done &&
+    bash run.bash --no-rebuild
 fi &&
 
 prepare_install  &&
 
 cd $SOURCE_DIRECTORY &&
-install -Dm0755 godoc /usr/bin/godoc &&
-mkdir -p /usr/{share/go,lib/go/src,lib/go/site/src} &&
+mkdir -p /usr/{share/go,lib/go/pkg,lib/go/src,lib/go/site/src} &&
 cp -r doc misc /usr/share/go/ &&
 ln -sf /usr/share/go/doc /usr/lib/go/doc &&
 cp -a bin /usr/ &&
-cp -a pkg /usr/lib/go/ &&
+cp -a pkg/{include,linux_${GOARCH},tool} /usr/lib/go/pkg/ &&
+if [ -d "pkg/linux_${GOARCH}_race" ]; then
+  cp -a pkg/linux_${GOARCH}_race /usr/lib/go/pkg/
+fi &&
 cp -a $GOROOT/src /usr/lib/go/ &&
 cp -a $GOROOT/lib /usr/lib/go/ &&
-
-install -Dm0644 src/Make.* /usr/lib/go/src/ &&
-
 ln -sf /usr/bin /usr/lib/go/bin &&
 
-# Remove object files from target src dir
-find /usr/lib/go/src/ -type f -name '*.[ao]' -delete &&
-
-# Remove all executable source files
-find /usr/lib/go/src -type f -executable -delete &&
-
-# For gox
-install -Dm755 src/make.bash /usr/lib/go/src/make.bash &&
-install -Dm755 src/run.bash  /usr/lib/go/src/run.bash  &&
-ln -sf /usr/share/go/misc /usr/lib/go/misc &&
-
-# For godoc
 install -Dm644 favicon.ico /usr/lib/go/favicon.ico &&
-rm -f /usr/share/go/doc/articles/wiki/get.bin &&
 install -Dm644 VERSION /usr/lib/go/VERSION &&
 
-find /usr/lib/go/pkg -type f -exec touch '{}' +
+# Cleanup
+rm -f /usr/lib/go/src/*.bat

--- a/compilers/go/BUILD
+++ b/compilers/go/BUILD
@@ -27,9 +27,9 @@ if [[ "$RUN_TESTS" =~ [yY] ]]; then
   echo "Testing go..." &&
     for i in godoc goimports gomvpkg gorename gotype \
              benchcmp bundle callgraph digraph eg fiximports html2article oracle present ssadump stress stringer; do
-      $GOROOT/bin/go test -v -x golang.org/x/tools/cmd/$i
+      PATH="${GOBIN}:${PATH}" $GOROOT/bin/go test -v -x golang.org/x/tools/cmd/$i
     done &&
-    bash run.bash --no-rebuild
+    PATH="${GOBIN}:${PATH}" ./run.bash --no-rebuild
 fi &&
 
 prepare_install  &&

--- a/compilers/go/BUILD
+++ b/compilers/go/BUILD
@@ -2,29 +2,19 @@ export GOROOT=$SOURCE_DIRECTORY
 export GOBIN=$GOROOT/bin
 export GOROOT_FINAL=/usr/lib/go
 export GOPATH=$BUILD_DIRECTORY
-export GO386=387
+export GOROOT_BOOTSTRAP=/usr/lib/go
 export GOOS=linux
 
-cd src &&
-bash make.bash &&
-
-# Cross compilation support if needed have to be activated from here
-#for i in amd64 386; do
-#  export GOARCH=$i
-#  bash make.bash --no-clean
-#done &&
-
 case "$(arch)" in
-  x86_64)
-    export GOARCH=amd64
-    ;;
-  i686)
-    export GOARCH=386
-    ;;
+  x86_64) export GOARCH=amd64 ;;
+  i686)   export GOARCH=386 ;;
 esac &&
+
+cd src &&
 bash make.bash --no-clean &&
 
-cd $SOURCE_DIRECTORY &&
+#cd $SOURCE_DIRECTORY &&
+
 $GOROOT/bin/go get -d golang.org/x/tools/cmd/godoc &&
 $GOROOT/bin/go build -o $SOURCE_DIRECTORY/godoc golang.org/x/tools/cmd/godoc &&
 for i in vet cover; do
@@ -32,34 +22,41 @@ for i in vet cover; do
   $GOROOT/bin/go build -o $GOROOT/pkg/tool/${GOOS}_${GOARCH}/${i} golang.org/x/tools/cmd/${i}
 done &&
 
-# Clean up before install
-#find $SOURCE_DIRECTORY/ -type f -name '*.[ao]' -delete &&
-#find $SOURCE_DIRECTORY/ -type f -executable -delete &&
+if module_installed go-bootstrap; then
+  # remove the bootstrap go compiler
+  lrm go-bootstrap
+fi &&
 
-prepare_install &&
+prepare_install  &&
 
 cd $SOURCE_DIRECTORY &&
 install -Dm0755 godoc /usr/bin/godoc &&
 mkdir -p /usr/{share/go,lib/go/src,lib/go/site/src} &&
 cp -r doc misc /usr/share/go/ &&
-cp -a bin/* /usr/bin/  &&
+ln -sf /usr/share/go/doc /usr/lib/go/doc &&
+cp -a bin /usr/ &&
 cp -a pkg /usr/lib/go/ &&
-cp -a src /usr/lib/go/ &&
-cp -a src/cmd /usr/lib/go/src/ &&
-cp -a src/lib9 /usr/lib/go/src/ &&
-cp -a lib /usr/lib/go/ &&
-cp -a include /usr/lib/go/ &&
+cp -a $GOROOT/src /usr/lib/go/ &&
+cp -a $GOROOT/lib /usr/lib/go/ &&
+
 install -Dm0644 src/Make.* /usr/lib/go/src/ &&
+
 ln -sf /usr/bin /usr/lib/go/bin &&
 
-# Headers for C modules
-install -Dm644 src/runtime/runtime.h "/usr/lib/go/src/runtime/runtime.h" &&
-install -Dm644 src/runtime/cgocall.h "/usr/lib/go/src/runtime/cgocall.h" &&
+# Remove object files from target src dir
+find /usr/lib/go/src/ -type f -name '*.[ao]' -delete &&
+
+# Remove all executable source files
+find /usr/lib/go/src -type f -executable -delete &&
 
 # For gox
-install -Dm755 src/make.bash "/usr/lib/go/src/make.bash" &&
-install -Dm755 src/run.bash "/usr/lib/go/src/run.bash" &&
-cp -r misc/ "/usr/lib/go/" &&
+install -Dm755 src/make.bash /usr/lib/go/src/make.bash &&
+install -Dm755 src/run.bash  /usr/lib/go/src/run.bash  &&
+ln -sf /usr/share/go/misc /usr/lib/go/misc &&
 
 # For godoc
-install -Dm644 favicon.ico "/usr/lib/go/favicon.ico"
+install -Dm644 favicon.ico /usr/lib/go/favicon.ico &&
+rm -f /usr/share/go/doc/articles/wiki/get.bin &&
+install -Dm644 VERSION /usr/lib/go/VERSION &&
+
+find /usr/lib/go/pkg -type f -exec touch '{}' +

--- a/compilers/go/CONFIGURE
+++ b/compilers/go/CONFIGURE
@@ -1,0 +1,1 @@
+mquery RUN_TESTS "Run tests for the go compiler and tools to make sure everything is ok before installing?" y

--- a/compilers/go/DEPENDS
+++ b/compilers/go/DEPENDS
@@ -1,3 +1,7 @@
+depends inetutils
+depends git
+depends go-bootstrap
+
 optional_depends mercurial  "" "" "for mercurial repositories support"
 optional_depends subversion "" "" "for subversion repositories support"
 optional_depends bzr        "" "" "for bzr repositories support"

--- a/compilers/go/DEPENDS
+++ b/compilers/go/DEPENDS
@@ -1,10 +1,3 @@
-depends perl
-depends gawk
-depends inetutils
-
-optional_depends git        "" "" "for git repositories support"
 optional_depends mercurial  "" "" "for mercurial repositories support"
 optional_depends subversion "" "" "for subversion repositories support"
 optional_depends bzr        "" "" "for bzr repositories support"
-
-

--- a/compilers/go/DETAILS
+++ b/compilers/go/DETAILS
@@ -1,15 +1,14 @@
           MODULE=go
-         VERSION=1.4.2
+         VERSION=1.6
           SOURCE=${MODULE}${VERSION}.src.tar.gz
-      SOURCE_URL=https://storage.googleapis.com/golang
-      SOURCE_VFY=sha256:299a6fd8f8adfdce15bc06bde926e7b252ae8e24dd5b16b7d8791ed79e7b5e9b
 SOURCE_DIRECTORY=$BUILD_DIRECTORY/$MODULE
+      SOURCE_URL=http://storage.googleapis.com/golang
+      SOURCE_VFY=sha256:a96cce8ce43a9bf9b2a4c7d470bc7ee0cb00410da815980681c8353218dcf146
         WEB_SITE=http://golang.org/
          ENTERED=20140606
-         UPDATED=20150224
+         UPDATED=20160218
            SHORT="Compiler and tools for the Go programming language from Google"
 
 cat <<EOF
 Compiler and tools for the Go programming language from Google.
 EOF
-

--- a/compilers/go/POST_INSTALL
+++ b/compilers/go/POST_INSTALL
@@ -1,1 +1,3 @@
 rm -fR /usr/src/src
+# Fix timestamps in order to stop go from rebuilding lots of packages
+find /usr/lib/go -type f -exec touch -r /usr/lib/go/pkg/*/runtime.a {} \;

--- a/compilers/go/PRE_BUILD
+++ b/compilers/go/PRE_BUILD
@@ -1,7 +1,4 @@
-# if go is already installed we'll use it for the bootstrap
-if ! ( ( module_installed go ) || (module_installed go-bootstrap) ); then
-  # install a minimal go compiler for the bootstrap
-  lin go-bootstrap
-fi &&
+default_pre_build &&
 
-default_pre_build
+# Fix path for test suite
+sedit "s;/bin/hostname;/usr&;g" src/os/os_test.go

--- a/compilers/go/PRE_BUILD
+++ b/compilers/go/PRE_BUILD
@@ -1,0 +1,7 @@
+# if go is already installed we'll use it for the bootstrap
+if ! ( ( module_installed go ) || (module_installed go-bootstrap) ); then
+  # install a minimal go compiler for the bootstrap
+  lin go-bootstrap
+fi &&
+
+default_pre_build

--- a/compilers/go/profile.d/go.rc
+++ b/compilers/go/profile.d/go.rc
@@ -1,0 +1,1 @@
+export GOROOT="/usr/lib/go"


### PR DESCRIPTION
I backported a patch from go1.5 (written in go) to go1.4 (C) that fixes the symbol relocation issues. The patch is part of go-bootstrap. Enjoy!

This closes #540 and closes #567.