### PR TITLE
ImageMagick: Version bump to 7.0.1-2.

### DIFF
--- a/graphics/ImageMagick/DETAILS
+++ b/graphics/ImageMagick/DETAILS
@@ -3,17 +3,17 @@
 # should version bump to x.y.(z-1)-(highest). That version is always
 # kept on the ftp.imagemagick.org site and should be considered STABLE!!!
           MODULE=ImageMagick
-         VERSION=6.9.3-9
+         VERSION=7.0.1-2
           SOURCE=$MODULE-$VERSION.tar.xz
    SOURCE_URL[0]=$MIRROR_URL
    SOURCE_URL[1]=http://mirrors-usa.go-parts.com/mirrors/ImageMagick
    SOURCE_URL[2]=http://mirror.checkdomain.de/imagemagick
    SOURCE_URL[3]=ftp://ftp.nluug.nl/pub/ImageMagick
    SOURCE_URL[4]=ftp://gd.tuwien.ac.at/pub/graphics/ImageMagick
-      SOURCE_VFY=sha256:cec69db7d14cb1ab2d173381e5676219c678ca27b7af8878c6ffec18ec932960
+      SOURCE_VFY=sha256:be374b507200aa3dab698ed8c550cf418aa1481d3187ad406c6a400c67922b75
         WEB_SITE=http://www.imagemagick.org
          ENTERED=20010922
-         UPDATED=20160501
+         UPDATED=20160509
            SHORT="Automated and interactive manipulation of images"
 
 cat << EOF


### PR DESCRIPTION
This fixes some really nasty security issues, if you have anyone
in the habit of running ImageMagick from, say, PHP scripts.