### PR TITLE
Allow for the XMLRPC feature in rtorrent

### DIFF
--- a/distributed/rtorrent/BUILD
+++ b/distributed/rtorrent/BUILD
@@ -3,6 +3,8 @@
 
   ./autogen.sh &&
 
+  autoreconf -fi &&
+
   default_build &&
 
   gather_docs TODO doc/rtorrent.rc

--- a/distributed/rtorrent/DEPENDS
+++ b/distributed/rtorrent/DEPENDS
@@ -1,7 +1,6 @@
 depends  libtorrent
 depends  ncurses
 depends  curl
-depends  cppunit
 optional_depends xmlrpc-c \
                  "--with-xmlrpc-c" "" \
 		 "for XMLRPC interface"

--- a/distributed/rtorrent/DEPENDS
+++ b/distributed/rtorrent/DEPENDS
@@ -1,3 +1,7 @@
 depends  libtorrent
 depends  ncurses
 depends  curl
+depends  cppunit
+optional_depends xmlrpc-c \
+                 "--with-xmlrpc-c" "" \
+		 "for XMLRPC interface"

--- a/distributed/rtorrent/DETAILS
+++ b/distributed/rtorrent/DETAILS
@@ -5,7 +5,7 @@
       SOURCE_VFY=sha256:109021ffdb9c71e920bccdd7023d2671a9f760689a782be689c0641cf0492839
         WEB_SITE=http://rakshasa.github.io/rtorrent/
          ENTERED=20060704
-         UPDATED=20141026
+         UPDATED=20160516
            SHORT="A BitTorrent client using libtorrent"
 
 cat << EOF

--- a/libs/libtorrent/DEPENDS
+++ b/libs/libtorrent/DEPENDS
@@ -1,5 +1,6 @@
 depends  pkgconfig
 depends  libsigc++2
+depends  cppunit
 
 optional_depends  "openssl"  ""  "--disable-openssl"  \
                   "to use OpenSSL's SHA1 implementation"

--- a/libs/xmlrpc-c/BUILD
+++ b/libs/xmlrpc-c/BUILD
@@ -1,0 +1,7 @@
+(
+
+  OPTS+=" --disable-docs"
+
+  default_build
+
+)

--- a/libs/xmlrpc-c/BUILD
+++ b/libs/xmlrpc-c/BUILD
@@ -2,6 +2,8 @@
 
   OPTS+=" --disable-docs"
 
+  aclocal &&
+
   default_build
 
 )

--- a/libs/xmlrpc-c/DEPENDS
+++ b/libs/xmlrpc-c/DEPENDS
@@ -1,0 +1,1 @@
+depends  curl

--- a/libs/xmlrpc-c/DETAILS
+++ b/libs/xmlrpc-c/DETAILS
@@ -1,0 +1,17 @@
+          MODULE=xmlrpc-c
+         VERSION=1.39.07
+          SOURCE=$MODULE-$VERSION.tgz
+      SOURCE_URL=$SFORGE_URL/$MODULE/
+      SOURCE_VFY=sha1:3c7b7b9426ce643532d5c7096a45996738c6c576
+        WEB_SITE=http://xmlrpc-c.sourceforge.net/
+         ENTERED=20160515
+         UPDATED=20160515
+           SHORT="This library provides a modular implementation of XML-RPC for C and C++."
+
+cat << EOF
+XML-RPC is a quick-and-easy way to make procedure calls over the Internet. 
+It converts the procedure call into an XML document, sends it to a remote
+server using HTTP, and gets back the response as XML.
+
+This library provides a modular implementation of XML-RPC for C and C++.
+EOF


### PR DESCRIPTION
Adds the xmlrpc-c module and updates rtorrent module to use it if configured at install time.