### PR TITLE
libcgroup: bump to 0.41. Adding a BUILD with OPTS --enable-opaque-hie…

### DIFF
--- a/libs/libcgroup/BUILD
+++ b/libs/libcgroup/BUILD
@@ -1,0 +1,8 @@
+
+OPTS+=" --enable-opaque-hierarchy=name=systemd" &&
+
+default_build &&
+
+install -D -m0644 samples/cgconfig.conf /etc/cgconfig.conf.samples &&
+install -D -m0644 samples/cgrules.conf /etc/cgrules.conf.samples &&
+install -D -m0644 samples/cgsnapshot_blacklist.conf /etc/cgsnapshot_blacklist.conf.samples

--- a/libs/libcgroup/DETAILS
+++ b/libs/libcgroup/DETAILS
@@ -1,11 +1,11 @@
           MODULE=libcgroup
-         VERSION=0.37.1
+         VERSION=0.41
           SOURCE=$MODULE-$VERSION.tar.bz2
       SOURCE_URL=$SFORGE_URL/libcg
-      SOURCE_VFY=sha1:e5b617d3e68d193268aae9bab2d2fe4e888cad00
+      SOURCE_VFY=sha256:e4e38bdc7ef70645ce33740ddcca051248d56b53283c0dc6d404e17706f6fb51
         WEB_SITE=http://libcg.sourceforge.net
          ENTERED=20101006
-         UPDATED=20110406
+         UPDATED=20160531
            SHORT="A library that abstracts the control group file system in Linux"
 
 cat << EOF

--- a/python/rdflib/DEPENDS
+++ b/python/rdflib/DEPENDS
@@ -1,1 +1,6 @@
 depends Python
+depends setuptools
+depends six
+depends nose
+depends BeautifulSoup
+depends isolate


### PR DESCRIPTION
…rarchy=name=systemd

so it will play nicely with systemd. Installing a few conf files as samples.