### PR TITLE
mariadb: Got this error compiling;

### DIFF
--- a/sql/mariadb/BUILD
+++ b/sql/mariadb/BUILD
@@ -20,12 +20,12 @@ OPTS+=" -DSYSCONFDIR=/etc/mysql \
         -DENABLED_LOCAL_INFILE=ON \
         -DDEFAULT_CHARSET=utf8 \
         -DDEFAULT_COLLATION=utf8_general_ci \
-        -DCMAKE_EXE_LINKER_FLAGS='-ljemalloc' \
+        -DCMAKE_EXE_LINKER_FLAGS='-L/usr/lib/libjemalloc.so' \
         -DWITH_ZLIB=system \
         -DWITH_READLINE=ON \
         -DWITH_EXTRA_CHARSETS=complex \
         -DWITH_LIBWRAP=OFF \
-        -DWITH_JEMALLOC=ON \
+        -DWITH_JEMALLOC=system \
         -DWITH_PCRE=system \
         -DWITH_INNOBASE_STORAGE_ENGINE=1 \
         -DWITH_MYISAMMRG_STORAGE_ENGINE=1 \

--- a/sql/mariadb/DETAILS
+++ b/sql/mariadb/DETAILS
@@ -7,8 +7,7 @@
          ENTERED=20130921
          UPDATED=20160521
            SHORT="Fast SQL database server, drop-in replacement for MySQL"
-           PSAFE=no
-
+PSAFE=no
 cat << EOF
 MariaDB is a drop-in replacement for MySQL.
 MariaDB strives to be the logical choice for database professionals


### PR DESCRIPTION
[ 11%] Built target comp_err
Scanning dependencies of target GenError
[ 11%] Generating ../include/mysqld_error.h.tmp
/bin/sh: line 1: 20672 Segmentation fault      (core dumped) ./comp_err --charset=/usr/src/mariadb-10.1.14/sql/share/charsets --out-dir=/usr/src/mariadb-10.1.14/mariadb-oosb/sql/share/ --header_file=/usr/src/mariadb-10.1.14/mariadb-oosb/include/mysqld_error.h.tmp --name_file=/usr/src/mariadb-10.1.14/mariadb-oosb/include/mysqld_ername.h.tmp --state_file=/usr/src/mariadb-10.1.14/mariadb-oosb/include/sql_state.h.tmp --in_file=/usr/src/mariadb-10.1.14/sql/share/errmsg-utf8.txt
make[2]: *** [extra/CMakeFiles/GenError.dir/build.make:62: include/mysqld_error.h.tmp] Error 139
make[1]: *** [CMakeFiles/Makefile2:9445: extra/CMakeFiles/GenError.dir/all] Error 2
make: *** [Makefile:161: all] Error 2

Turns out the recent jemalloc bump was the culprit. Got the same error on mariadb-10.1.13. Downgrading jemalloc
and all was fine. Adjusting the BUILD to link directly to jemalloc library which clears up the the compile error
and changing this to; -DWITH_JEMALLOC=system

On a side note, from the jemalloc.cmake they (mariadb) it no longer bundles jemalloc.