### PR TITLE
fcgi: Changed to a working mirror.

### DIFF
--- a/web/fcgi/DETAILS
+++ b/web/fcgi/DETAILS
@@ -1,7 +1,7 @@
            MODULE=fcgi
           VERSION=2.4.0
            SOURCE=$MODULE-$VERSION.tar.gz
-       SOURCE_URL=http://www.fastcgi.com/dist/
+       SOURCE_URL=http://pkgs.fedoraproject.org/repo/pkgs/fcgi/$MODULE-$VERSION.tar.gz/d15060a813b91383a9f3c66faf84867e/
        SOURCE_VFY=sha1:2329404159e8b8315e524b9eaf1de763202c6e6a
          WEB_SITE=http://fastcgi.com
           ENTERED=20060513


### PR DESCRIPTION
It's an ancient module and the company that published it went out of
business years ago.