### PR TITLE
Sphinx: Changed the url to be https.

### DIFF
--- a/python/Sphinx/DETAILS
+++ b/python/Sphinx/DETAILS
@@ -1,7 +1,7 @@
           MODULE=Sphinx
          VERSION=1.4.4
           SOURCE=$MODULE-$VERSION.tar.gz
-      SOURCE_URL=http://files.pythonhosted.org/packages/source/S/Sphinx/
+      SOURCE_URL=https://files.pythonhosted.org/packages/source/S/Sphinx/
       SOURCE_VFY=sha256:3effd6373734bd59f7457fed2f0bd4ba7ec3c70b4598d7c2e5193a42209dbfa0
         WEB_SITE=http://pypi.python.org/pypi/Sphinx/
          ENTERED=20100824


### PR DESCRIPTION
Odds are this will need to be done for all of the other python modules
too.