### PR TITLE
clamav: Version bumped to 0.99.2.

### DIFF
--- a/security/clamav/DETAILS
+++ b/security/clamav/DETAILS
@@ -1,11 +1,11 @@
           MODULE=clamav
-         VERSION=0.99.1
+         VERSION=0.99.2
           SOURCE=$MODULE-$VERSION.tar.gz
-      SOURCE_URL=$SFORGE_URL/$MODULE
-      SOURCE_VFY=sha256:e144689122d3f91293808c82cbb06b7d3ac9eca7ae29564c5d148ffe7b25d58a
+      SOURCE_URL=http://www.clamav.net/downloads/production/
+      SOURCE_VFY=sha256:167bd6a13e05ece326b968fdb539b05c2ffcfef6018a274a10aeda85c2c0027a
         WEB_SITE=http://www.clamav.net
          ENTERED=20030314
-         UPDATED=20151304
+         UPDATED=20160920
            SHORT="GPL anti-virus toolkit"
 
 cat << EOF


### PR DESCRIPTION
Also, this changes the URL as they seem to have left Sourceforge behind.