### PR TITLE
VirtualBox: remove chmod on kernel device from startup script

### DIFF
--- a/virtual/VirtualBox/VirtualBox
+++ b/virtual/VirtualBox/VirtualBox
@@ -95,9 +95,6 @@ if [ "$SHUTDOWN" = "true" ]; then
   exit 0
 fi
 
-chgrp vboxusers /dev/vboxdrv
-chmod g+rwx /dev/vboxdrv
-
 APP=`which $0`
 APP=${APP##/*/}
 case "$APP" in


### PR DESCRIPTION
This script is supposed to be used by regular users.
They are usually not privileged to run these commands.

Also if the admin failed to setup the right permissions for these devices,
this is surely not the place to fix this.