### PR TITLE
openttd: version bumped to 1.6.1

### DIFF
--- a/games/openttd/DETAILS
+++ b/games/openttd/DETAILS
@@ -1,5 +1,5 @@
           MODULE=openttd
-         VERSION=1.6.0
+         VERSION=1.6.1
         VERSION2=0.5.2
         VERSION3=0.2.3
         VERSION4=0.3.1
@@ -11,13 +11,13 @@
      SOURCE2_URL=http://binaries.openttd.org/extra/opengfx/$VERSION2
      SOURCE3_URL=http://binaries.openttd.org/extra/opensfx/$VERSION3
      SOURCE4_URL=http://binaries.openttd.org/extra/openmsx/$VERSION4
-      SOURCE_VFY=sha1:5c7dde84208781d477938afd4c93e09b339f32cc
+      SOURCE_VFY=sha1:79b5c5b26a7e6890f33ce213a706a5efddfdb0c4
      SOURCE2_VFY=sha1:1c25d2d4d906924725146e214910f14036820eb2
      SOURCE3_VFY=sha1:368480f627b0563af80ca724695875a4aa898db3
      SOURCE4_VFY=sha1:e9c4203923bb9c974ac67886bd00b7090658b961
         WEB_SITE=http://www.openttd.org/
          ENTERED=20060322
-         UPDATED=20160523
+         UPDATED=20161022
            SHORT="A clone of the Microprose game Transport Tycoon Deluxe"
          GARBAGE=off
 


### PR DESCRIPTION
changelog @ https://git.openttd.org/?p=tags/1.6.1.git;a=blob_plain;f=changelog.txt;hb=refs/heads/master