### PR TITLE
ImageMagick: version bumped to 6.9.6-8

### DIFF
--- a/graphics/ImageMagick/DETAILS
+++ b/graphics/ImageMagick/DETAILS
@@ -3,17 +3,17 @@
 # should version bump to x.y.(z-1)-(highest). That version is always
 # kept on the ftp.imagemagick.org site and should be considered STABLE!!!
           MODULE=ImageMagick
-         VERSION=6.9.6-6
+         VERSION=6.9.6-8
           SOURCE=$MODULE-$VERSION.tar.xz
    SOURCE_URL[0]=$MIRROR_URL
    SOURCE_URL[1]=http://mirrors-usa.go-parts.com/mirrors/ImageMagick
    SOURCE_URL[2]=http://mirror.checkdomain.de/imagemagick
    SOURCE_URL[3]=ftp://ftp.nluug.nl/pub/ImageMagick
    SOURCE_URL[4]=ftp://gd.tuwien.ac.at/pub/graphics/ImageMagic
-      SOURCE_VFY=sha256:9cd1fe001d3ecb68b7d053ede40950d411956d47afc5267acc3ca57a77070d0a
+      SOURCE_VFY=sha256:39bb2b18183454bd5e0ec6b975e648d08064e44f3ac1b945c9005706e9af3f5d
         WEB_SITE=http://www.imagemagick.org
          ENTERED=20010922
-         UPDATED=20161128
+         UPDATED=20161216
            SHORT="Automated and interactive manipulation of images"
 
 cat << EOF


### PR DESCRIPTION
the archive was not on the mirror sites... I just took the next version