### PR TITLE
New module: icu-le-hb 1.0.3

### DIFF
--- a/i18n/icu-le-hb/BUILD
+++ b/i18n/icu-le-hb/BUILD
@@ -1,0 +1,5 @@
+./autogen.sh
+
+OPTS+=" --disable-static" &&
+
+default_build

--- a/i18n/icu-le-hb/DEPENDS
+++ b/i18n/icu-le-hb/DEPENDS
@@ -1,0 +1,2 @@
+depends harfbuzz
+depends icu4c

--- a/i18n/icu-le-hb/DETAILS
+++ b/i18n/icu-le-hb/DETAILS
@@ -1,0 +1,16 @@
+          MODULE=icu-le-hb
+         VERSION=1.0.3
+          SOURCE=$VERSION.tar.gz
+      SOURCE_URL=https://github.com/behdad/icu-le-hb/archive
+      SOURCE_VFY=sha256:1c759ec8ab979bcd2fdf13bf398aa255fa6b8dc002e4232f8187b4b288f91907
+        WEB_SITE=https://github.com/behdad/icu-le-hb
+         ENTERED=20161223
+         UPDATED=20161223
+           SHORT="A library implementing the ICU Layout Engine (icu-le) API"
+
+cat << EOF
+icu-le-hb is a library implementing the ICU Layout Engine (icu-le) API
+using external HarfBuzz library for implementation.  This is useful as a
+compatibility layer to make applications using ICU Layout Engine to use
+HarfBuzz without porting them to use the HarfBuzz API.
+EOF

--- a/i18n/icu4c/DEPENDS
+++ b/i18n/icu4c/DEPENDS
@@ -1,1 +1,2 @@
 depends pkgconfig
+optional_depends icu-le-hb "" "" "Allows ICU layout engine support using harfbuzz"


### PR DESCRIPTION
This module is the new support for the ICU layout engine using harfbuzz. Once installed, layoutex/libiculx.so (removed in icu4c-58) will be enabled/included when building icu4c