### PR TITLE
pulseaudio: optional udev defaults to n

### DIFF
--- a/audio/pulseaudio/DEPENDS
+++ b/audio/pulseaudio/DEPENDS
@@ -3,6 +3,8 @@ depends libsndfile
 depends libatomic_ops
 depends gdbm
 depends speexdsp
+depends json-c
+depends sbc
 
 optional_depends fftw3         "--with-fftw"         "--without-fftw"       "for FFTW-using modules (equalizer) support"
 optional_depends alsa-lib      "--enable-alsa"       "--disable-alsa"       "for ALSA support"
@@ -12,12 +14,12 @@ optional_depends libasyncns    "--enable-asyncns"    "--disable-asyncns"    "for
 optional_depends libcap        "--with-caps"         "--without-caps"       "for POSIX 1003.1e support"
 optional_depends avahi         "--enable-avahi"      "--disable-avahi"      "for ZeroConf support"
 optional_depends dbus          "--enable-dbus"       "--disable-dbus"       "optional D-Bus support"
-optional_depends %UDEV         "--enable-udev"       "--disable-udev"       "optional UDEV support"
+optional_depends %UDEV         "--enable-udev"       "--disable-udev"       "optional UDEV support" n
 optional_depends lirc          "--enable-lirc"       "--disable-lirc"       "optional LIRC support"
 optional_depends GConf         "--enable-gconf"      "--disable-gconf"      "optional GConf support"
 optional_depends gtk+-3        "--enable-gtk3"       "--disable-gtk3"       "optional Gtk+ 3 support"
-optional_depends libsamplerate "--enable-samplerate" "--disable-samplerate" "optional libsamplerate support, ${PROBLEM_COLOR} this is deprecated by Pulseaudio${DEFAULT_COLOR}" n
-optional_depends openssl       "--enable-openssl"    "--disable-openssl"    "for OpenSSL support"
+optional_depends libsamplerate "--enable-samplerate" "--disable-samplerate" "optional libsamplerate support, ${PROBLEM_COLOR} this is depreciated by Pulseaudio${DEFAULT_COLOR}" n
+optional_depends %OSSL         "--enable-openssl"    "--disable-openssl"    "for OpenSSL support"
 optional_depends orc           "--enable-orc"        "--disable-orc"        "for orc support"
 optional_depends esound        "--enable-esound"     "--disable-esound"     "for esound support"
 
@@ -33,7 +35,3 @@ optional_depends webrtc-audio-processing \
 
 # We take care of which bluez to enable in the BUILD
 optional_depends %BLUEZ "" "" "optional BlueZ support"
-
-if ( in_depends $MODULE bluez-5 ) || ( in_depends $MODULE bluez ); then
-  depends sbc
-fi


### PR DESCRIPTION
I want to see if a pulseaudio's configure doesn't fail with this
(later comment edits: catched while doing an update after rtlaneroad's first commit on i3status PR) ... we talked on IRC about it and to let florin have a thought on that
it was closed because I saw "pending" on his PR and thus wanted to let rtlanceroad have another i3status build, but I saw jenkins can trigger more than one at once :P