### PR TITLE
cairo: Added poppler (PDF) dependency required by libreoffice-bin

### DIFF
--- a/graphics/cairo/DEPENDS
+++ b/graphics/cairo/DEPENDS
@@ -1,7 +1,10 @@
 depends glib-2
 depends pixman
 depends libpng
-depends poppler
+
+optional_depends poppler "--enable-pdf=yes" \
+                 "--enable-pdf=no" \
+                 "for PDF support" y
 
 optional_depends librsvg \
                  "--enable-svg" \

--- a/graphics/cairo/DEPENDS
+++ b/graphics/cairo/DEPENDS
@@ -1,6 +1,7 @@
 depends glib-2
 depends pixman
 depends libpng
+depends poppler
 
 optional_depends librsvg \
                  "--enable-svg" \


### PR DESCRIPTION
then the PDF support will be included in cairo as reclaimed by libreoffice-bin compile error on /usr/include/cairo-pdf.h