### PR TITLE
gdk-pixbuf: Fix up some dependencies.

### DIFF
--- a/graphics/gdk-pixbuf/DEPENDS
+++ b/graphics/gdk-pixbuf/DEPENDS
@@ -1,9 +1,6 @@
 depends glib-2
-
-optional_depends tiff \
-                 "--with-libtiff"    \
-                 "--without-libtiff" \
-                 "for TIFF image loader"
+depends shared-mime-info
+depends tiff
 
 optional_depends %JPEG \
                  "--with-libjpeg"    \


### PR DESCRIPTION
Now it depends on shared-mime-info.  And because apparently the
gdk-pixbuf developers haven't been testing how well their package honors
the configuration flags you request, tiff is now a hard dependency
rather than an optional one.