### PR TITLE
cairo: Break the dependency loop.

### DIFF
--- a/graphics/cairo/DEPENDS
+++ b/graphics/cairo/DEPENDS
@@ -2,7 +2,6 @@ depends glib-2
 depends pixman
 depends libpng
 depends poppler
-depends librsvg
 
 optional_depends libXext \
                  "--enable-xlib --enable-xcb --enable-xlib-xcb --enable-tee" \


### PR DESCRIPTION
When you install librsvg (which is a stricly optional dependency; cairo
builds A-OK without it)), it gives you the option to rebuild cairo with
SVG support anyway.  So let's get rid of it here and lose the circular
dependency.