### PR TITLE
libostree: New module, for managing binary deployment and upgrades.

### DIFF
--- a/libs/libostree/DEPENDS
+++ b/libs/libostree/DEPENDS
@@ -1,0 +1,1 @@
+depends gpgme

--- a/libs/libostree/DEPENDS
+++ b/libs/libostree/DEPENDS
@@ -1,1 +1,2 @@
 depends gpgme
+depende fuse

--- a/libs/libostree/DEPENDS
+++ b/libs/libostree/DEPENDS
@@ -1,2 +1,2 @@
 depends gpgme
-depende fuse
+depends fuse

--- a/libs/libostree/DETAILS
+++ b/libs/libostree/DETAILS
@@ -1,0 +1,16 @@
+          MODULE=libostree
+         VERSION=2017.12
+          SOURCE=${MODULE}-$VERSION.tar.xz
+      SOURCE_URL=https://github.com/ostreedev/ostree/releases/download/v$VERSION/
+      SOURCE_VFY=sha256:fc409f04c9fd440b83b4fa324f3b912cbf61145389378d44254b8b191c9fef08
+        WEB_SITE=http://www.github.com/ostreedev/ostree/
+         ENTERED=20171025
+         UPDATED=20171025
+           SHORT="Operating system and container binary deployment and upgrades"
+
+cat << EOF
+libostree is both a shared library and suite of command line tools
+that combines a "git-like" model for committing and downloading
+bootable filesystem trees, along with a layer for deploying them
+and managing the bootloader configuration.
+EOF


### PR DESCRIPTION
In library form, rather than as an OS management tool, it's also used by
things like "flatpak".