### PR TITLE
Samba fix startup

### DIFF
--- a/net/samba/CONFIGURE
+++ b/net/samba/CONFIGURE
@@ -1,2 +1,2 @@
 mquery AUTO_MOUNT "Configure samba with automount?" y "--with-automount" "--without-automount"
-mquery ENABLE_DDNS "for DNS update support?" y "--with-dnsupdate" "--without-dnsupdate"
+mquery ENABLE_DDNS "Enable DNS update support?" y "--with-dnsupdate" "--without-dnsupdate"

--- a/net/samba/systemd.d/nmbd.service
+++ b/net/samba/systemd.d/nmbd.service
@@ -5,7 +5,7 @@ After=network.target
 [Service]
 Type=forking
 PIDFile=/var/run/nmbd.pid
-ExecStart=/usr/bin/nmbd -D
+ExecStart=/usr/sbin/nmbd -D
 ExecReload=/bin/kill -HUP $MAINPID
 
 [Install]

--- a/net/samba/systemd.d/samba.service
+++ b/net/samba/systemd.d/samba.service
@@ -7,7 +7,7 @@ Type=forking
 PIDFile=/var/run/samba.pid
 LimitNOFILE=16384
 EnvironmentFile=-/etc/config.d/samba
-ExecStart=/usr/bin/samba $SAMBAOPTIONS
+ExecStart=/usr/sbin/samba $SAMBAOPTIONS
 ExecReload=/usr/bin/kill -HUP $MAINPID
 
 [Install]

--- a/net/samba/systemd.d/smbd.service
+++ b/net/samba/systemd.d/smbd.service
@@ -5,7 +5,7 @@ After=network.target nmbd.service winbindd.service
 [Service]
 Type=forking
 PIDFile=/var/run/smbd.pid
-ExecStart=/usr/bin/smbd -D
+ExecStart=/usr/sbin/smbd -D
 ExecReload=/bin/kill -HUP $MAINPID
 
 [Install]

--- a/net/samba/systemd.d/winbindd.service
+++ b/net/samba/systemd.d/winbindd.service
@@ -5,7 +5,7 @@ After=network.target nmbd.service
 [Service]
 Type=forking
 PIDFile=/var/run/winbindd.pid
-ExecStart=/usr/bin/winbindd -D
+ExecStart=/usr/sbin/winbindd -D
 ExecReload=/bin/kill -HUP $MAINPID
 
 [Install]


### PR DESCRIPTION
Samba has moved its daemons into /usr/sbin, which is correct!  But our systemd units still have it in /usr/bin which means that it fails now.