### PR TITLE
nettle:Update Download URL

### DIFF
--- a/crypto/nettle/DETAILS
+++ b/crypto/nettle/DETAILS
@@ -1,12 +1,12 @@
           MODULE=nettle
          VERSION=3.4
           SOURCE=$MODULE-$VERSION.tar.gz
-   SOURCE_URL[1]=http://www.lysator.liu.se/~nisse/archive
-   SOURCE_URL[2]=ftp://ftp.lysator.liu.se/pub/security/lsh
+   SOURCE_URL[0]=https://ftp.gnu.org/gnu/nettle/
+   SOURCE_URL[1]=https://www.lysator.liu.se/~nisse/archive
       SOURCE_VFY=sha256:ae7a42df026550b85daca8389b6a60ba6313b0567f374392e54918588a411e94
-        WEB_SITE=http://www.lysator.liu.se/~nisse/nettle
+        WEB_SITE=https://www.lysator.liu.se/~nisse/nettle
          ENTERED=20110404
-         UPDATED=20171120
+         UPDATED=20171202
            SHORT="A low-level cryptographic library"
 
 cat << EOF


### PR DESCRIPTION
The original link is invalid and cannot be installed normally after downloading,deletes an invalid link.