### PR TITLE
smartmontools: Adding a sha256sum.

### DIFF
--- a/utils/smartmontools/DETAILS
+++ b/utils/smartmontools/DETAILS
@@ -2,7 +2,7 @@
          VERSION=6.6
           SOURCE=$MODULE-$VERSION.tar.gz
       SOURCE_URL=$SFORGE_URL/$MODULE
-      SOURCE_VFY=sha256:
+      SOURCE_VFY=sha256:51f43d0fb064fccaf823bbe68cf0d317d0895ff895aa353b3339a3b316a53054
         WEB_SITE=http://smartmontools.sourceforge.net
          ENTERED=20040330
          UPDATED=20171108


### PR DESCRIPTION
How is not having a sha256 sum even allowed?