### PR TITLE
rsyslog: adding a mkdir to BUILD so its service file stops barking ab…

### DIFF
--- a/utils/rsyslog/BUILD
+++ b/utils/rsyslog/BUILD
@@ -12,6 +12,10 @@ OPTS+=" --exec-prefix=/usr  \
 
 default_build &&
 
+# The rsyslog.conf defaults to /var/spool/rsyslog, so lets mk it else
+#it's service file barks about its WorkDirectory missing
+mkdir -p /var/spool/rsyslog &&
+
 if [ ! -f /etc/rsyslog.conf ]; then
   install -m 644 $SCRIPT_DIRECTORY/rsyslog.conf /etc/rsyslog.conf
 fi &&

--- a/utils/rsyslog/DETAILS
+++ b/utils/rsyslog/DETAILS
@@ -6,10 +6,10 @@
         WEB_SITE=http://www.rsyslog.com/
       MAINTAINER=ratler@lunar-linux.org
          ENTERED=20080731
-         UPDATED=20171206
+         UPDATED=20171214
            SHORT="An enhanced multi-threaded syslogd"
 
-cat <<EOF
+cat << EOF
 Rsyslog is an enhanced multi-threaded syslogd with a focus on security
 and reliability. Among others, it offers support for on-demand disk
 buffering, reliable syslog over TCP, SSL, TLS and RELP, writing


### PR DESCRIPTION
…out /var/spool/rsyslog missing