### PR TITLE
httpd: Version bump to 2.2.34.

### DIFF
--- a/web/httpd/DETAILS
+++ b/web/httpd/DETAILS
@@ -1,29 +1,20 @@
 # This module provides the 2.2 maintenance series of httpd
 # For the 2.4 series please consider httpd2.4
           MODULE=httpd
-         VERSION=2.2.32
+         VERSION=2.2.34
           SOURCE=$MODULE-$VERSION.tar.bz2
-         SOURCE2=CVE-2017-3167.patch
-         SOURCE3=CVE-2017-3169.patch
-         SOURCE4=CVE-2017-7668.patch
-         SOURCE5=CVE-2017-7679.patch
       SOURCE_URL=http://www.apache.org/dist/$MODULE
-     SOURCE2_URL=http://www.apache.org/dist/httpd/patches/apply_to_2.2.32/
-     SOURCE3_URL=http://www.apache.org/dist/httpd/patches/apply_to_2.2.32/
-     SOURCE4_URL=http://www.apache.org/dist/httpd/patches/apply_to_2.2.32/
-     SOURCE5_URL=http://www.apache.org/dist/httpd/patches/apply_to_2.2.32/
-      SOURCE_VFY=sha256:527bc9d8092d784daf08910dd6c9d2681d6a2325055b2cc69806a0a7df7ed650
-     SOURCE2_VFY=sha256:6dcd786a9eec242747c24c5cbc45bc58b95c4878621c82838b0f3c9546cf3a40
-     SOURCE3_VFY=sha256:e0c6a2a866c41bcee4315e611a5c30f55bff5a33767c781dd18604c478c4a693
-     SOURCE4_VFY=sha256:3728447dd18cd807808d7e635efbdcbad9fa60ac237dbab458134b17fd6b8198
-     SOURCE5_VFY=sha256:44436809a6b0481618c6f2d947206001a5e7717ae88f8b2d2bd6337ddb0827c3
+      SOURCE_VFY=sha256:e53183d5dfac5740d768b4c9bea193b1099f4b06b57e5f28d7caaf9ea7498160
         WEB_SITE=http://www.apache.org
          ENTERED=20020710
-         UPDATED=20170625
+         UPDATED=20171219
            SHORT="A popular HTTP server"
 
 cat << EOF
 Apache is the world's most popular HTTP server, being quite possibly
 the best around in terms of functionality, efficiency, security and
 speed. This is Apache's v2 of the http server.
+
+Please note: 2.2.34 will be the LAST release of http 2.2!  In future,
+consider migrating to the httpd2.4 package.
 EOF

--- a/web/httpd/PRE_BUILD
+++ b/web/httpd/PRE_BUILD
@@ -1,7 +1,0 @@
-default_pre_build &&
-
-# Various CVE fixes
-patch_it $SOURCE2 0
-patch_it $SOURCE3 0
-patch_it $SOURCE4 0
-patch_it $SOURCE5 0


### PR DESCRIPTION
Note that with this release, httpd 2.2 is now at its end-of-life, so if
you haven't done so already, you should migrate to httpd 2.4.