### PR TITLE
Fixed the URL for bitcoin-core.

### DIFF
--- a/crypto/bitcoin/DETAILS
+++ b/crypto/bitcoin/DETAILS
@@ -1,8 +1,8 @@
           MODULE=bitcoin
          VERSION=0.15.1
           SOURCE=$MODULE-$VERSION.tar.gz
- SOURCE_URL_FULL=http://github.com/bitcoin/bitcoin/archive/v$VERSION.tar.gz
-      SOURCE_VFY=sha256:e429d4f257f2b5b6d0caaf36ed1a5f5203e5918c57837efac00b0c322a1fef79
+ SOURCE_URL_FULL=https://bitcoin.org/bin/$MODULE-core-$VERSION/$SOURCE
+      SOURCE_VFY=sha256:34de2dbe058c1f8b6464494468ebe2ff0422614203d292da1c6458d6f87342b4
         WEB_SITE=http://bitcoin.org
          ENTERED=20120820
          UPDATED=20171112


### PR DESCRIPTION
As it says on their github page:

> Preferably use the above download link, not the below links to
> download the source tarball, as the release tarballs are generated
> deterministically and GitHub's are not.