### PR TITLE
virtuoso: bump to 7.2.4.2. If you say yes to perl and run into this;

### DIFF
--- a/graphics/ImageMagick/BUILD
+++ b/graphics/ImageMagick/BUILD
@@ -1,4 +1,4 @@
-OPTS+=" --enable-shared --disable-static" &&
+OPTS+=" --enable-shared --disable-static --disable-docs" &&
 
 # see CONFIGURE
 OPTS+=" --disable-hdri" &&

--- a/sql/virtuoso/DEPENDS
+++ b/sql/virtuoso/DEPENDS
@@ -1,6 +1,7 @@
 depends systemd
 depends unixODBC
 depends net-tools
+depends libiodbc
 
 optional_depends perl        "--enable-perl"           "--disable-perl"        "for perl hosting support" y
 optional_depends readline    "--with-readline"         " --without-readline"   "for readline support" y

--- a/sql/virtuoso/DEPENDS
+++ b/sql/virtuoso/DEPENDS
@@ -1,21 +1,19 @@
+depends systemd
 depends unixODBC
 depends net-tools
 
-#Leaving perl commented out. Make failes if this is enabled.
-#optional_depends perl        "--enable-perl"        "--disable-perl"        "for perl hosting support"
-
-optional_depends readline    "--with-readline"         " --without-readline"   "for readline support"
-optional_depends libedit     "--with-editline"         "--with-editline=no"    "for editline support"
-optional_depends Python      "--enable-python"         "--disable-python"      "for python hosting support"
-optional_depends ruby        "--enable-ruby"           "--disable-ruby"        "for ruby hosting support"
-optional_depends ImageMagick "--enable-imagemagick"    "--disable-imagemagick" "for ImageMagick plugin"
-optional_depends %PHP        "--enable-php5"           "--disable-php5 "       "for PHP extension support"
-optional_depends openldap    "--enable-openldap"       "--disable-openldap"    "for openldap support"
-optional_depends %OSSL       "--enable-openssl"        "--disable-openssl"     "for openssl support"
-optional_depends heimdal     "--enable-krb"            "--disable-krb"         "for Kerberos extension support"
-optional_depends libwbxml    "--enable-wbxml2"         "--disable-wbxml2"      "for Wireless Binary XML support"
-optional_depends zlib        "--without-internal-zlib" "--with-internal-zlib"  "use internal or external zlib - Default external"
-optional_depends systemd     ""                        ""                      "use systemd init style sysem"
+optional_depends perl        "--enable-perl"           "--disable-perl"        "for perl hosting support" y
+optional_depends readline    "--with-readline"         " --without-readline"   "for readline support" y
+optional_depends libedit     "--with-editline"         "--with-editline=no"    "for editline support" y
+optional_depends Python      "--enable-python"         "--disable-python"      "for python hosting support" y
+optional_depends ruby        "--enable-ruby"           "--disable-ruby"        "for ruby hosting support" y
+optional_depends ImageMagick "--enable-imagemagick"    "--disable-imagemagick" "for ImageMagick plugin" y
+optional_depends %PHP        "--enable-php5"           "--disable-php5 "       "for PHP extension support" n
+optional_depends openldap    "--enable-openldap"       "--disable-openldap"    "for openldap support" n
+optional_depends %OSSL       "--enable-openssl"        "--disable-openssl"     "for openssl support" y
+optional_depends heimdal     "--enable-krb"            "--disable-krb"         "for Kerberos extension support" n
+optional_depends libwbxml    "--enable-wbxml2"         "--disable-wbxml2"      "for Wireless Binary XML support" n
+optional_depends zlib        "--without-internal-zlib" "--with-internal-zlib"  "use internal or external zlib - Default external" y
 
 # broken due to missing *internal* libgc include
 #optional_depends mono        "--enable-mono"           "--disable-mono"        "for mono extension support"

--- a/sql/virtuoso/DEPENDS
+++ b/sql/virtuoso/DEPENDS
@@ -1,20 +1,20 @@
+depends zlib
+depends readline
 depends systemd
 depends unixODBC
 depends net-tools
 depends libiodbc
 
 optional_depends perl        "--enable-perl"           "--disable-perl"        "for perl hosting support" y
-optional_depends readline    "--with-readline"         " --without-readline"   "for readline support" y
 optional_depends libedit     "--with-editline"         "--with-editline=no"    "for editline support" y
 optional_depends Python      "--enable-python"         "--disable-python"      "for python hosting support" y
 optional_depends ruby        "--enable-ruby"           "--disable-ruby"        "for ruby hosting support" y
-optional_depends ImageMagick "--enable-imagemagick"    "--disable-imagemagick" "for ImageMagick plugin" y
+optional_depends ImageMagick "--enable-imagemagick"    "--disable-imagemagick" "for ImageMagick plugin" n
 optional_depends %PHP        "--enable-php5"           "--disable-php5 "       "for PHP extension support" n
 optional_depends openldap    "--enable-openldap"       "--disable-openldap"    "for openldap support" n
 optional_depends %OSSL       "--enable-openssl"        "--disable-openssl"     "for openssl support" y
 optional_depends heimdal     "--enable-krb"            "--disable-krb"         "for Kerberos extension support" n
 optional_depends libwbxml    "--enable-wbxml2"         "--disable-wbxml2"      "for Wireless Binary XML support" n
-optional_depends zlib        "--without-internal-zlib" "--with-internal-zlib"  "use internal or external zlib - Default external" y
 
 # broken due to missing *internal* libgc include
 #optional_depends mono        "--enable-mono"           "--disable-mono"        "for mono extension support"

--- a/sql/virtuoso/DETAILS
+++ b/sql/virtuoso/DETAILS
@@ -1,13 +1,13 @@
           MODULE=virtuoso
             TYPE=opensource
-         VERSION=7.2.1
+         VERSION=7.2.4.2
           SOURCE=$MODULE-$TYPE-$VERSION.tar.gz
 SOURCE_DIRECTORY=$BUILD_DIRECTORY/$MODULE-$TYPE-$VERSION
       SOURCE_URL=$SFORGE_URL/virtuoso/virtuoso/${VERSION%_*}
-      SOURCE_VFY=sha256:8e680173f975266046cdc33b0949c6c3320b82630288aed778524657a32ee094
+      SOURCE_VFY=sha256:028075d3cf1970dbb9b79f660c833771de8be5be7403b9001d6907f64255b889
         WEB_SITE=http://virtuoso.openlinksw.com/dataspace/dav/wiki/Main
          ENTERED=20100116
-         UPDATED=20150709
+         UPDATED=20171224
            SHORT="high-performance object-relational SQL database"
 
 cat << EOF

--- a/sql/virtuoso/PRE_BUILD
+++ b/sql/virtuoso/PRE_BUILD
@@ -1,8 +1,6 @@
  default_pre_build &&
 
- sedit "s:AM_CONFIG_HEADER:AC_CONFIG_HEADER:" configure.in &&
- mv configure.in configure.ac &&
- autoreconf -i &&
+ autoreconf -fi &&
 
  sedit "s:\(test \"\${with_editline+set\}\" = set\):\1 -a \"\${with_editline}\" != no": configure &&
 


### PR DESCRIPTION
/usr/lib/perl5/5.26.1/x86_64-linux-thread-multi/CORE/perl.h:738:13: fatal error: xlocale.h: No such file or directory

That means you went for the glibc-2.26 bump. This is the second module I ran into (well perl) that uses xlocale.h in past
versions of glibc. Well the glibc folks dropped that header and now you only have locale.h. Why, dunno but the short of it,
relin perl and you should be good to go.

Oh and I fiddled with a few other depends, best guess.