### PR TITLE
Intel microcode: Updated to 20180108.

### DIFF
--- a/utils/microcode/DETAILS
+++ b/utils/microcode/DETAILS
@@ -1,11 +1,11 @@
           MODULE=microcode
-         VERSION=20160714
+         VERSION=20180108
           SOURCE=$MODULE-$VERSION.tgz
-      SOURCE_URL=https://downloadmirror.intel.com/26156/eng
-      SOURCE_VFY=sha256:f3a9c6fc93275bf1febc26f7c397ac93ed5f109e47fb52932f6dbd5cfdbc840e
+      SOURCE_URL=https://downloadmirror.intel.com/27431/eng/
+      SOURCE_VFY=sha256:063f1aa3a546cb49323a5e0b516894e4b040007107b8c8ff017aca8a86204130
         WEB_SITE=http://downloadcenter.intel.com
          ENTERED=20070916
-         UPDATED=20161030
+         UPDATED=20181010
            SHORT="Intel microcode - data files"
 
 cat << EOF


### PR DESCRIPTION
Does anyone know where the "microcode_ctl" command comes from?