### PR TITLE
serd: Adding to moonbase. Part of a dependency chain required for a t…

### DIFF
--- a/libs/serd/BUILD
+++ b/libs/serd/BUILD
@@ -1,0 +1,10 @@
+sed -i "/ldconfig/d" wscript &&
+
+python ./waf configure --prefix=/usr \
+                        --mandir=/usr/share/man
+
+python ./waf build &&
+
+prepare_install &&
+
+python ./waf install

--- a/libs/serd/DEPENDS
+++ b/libs/serd/DEPENDS
@@ -1,0 +1,1 @@
+depends Python

--- a/libs/serd/DETAILS
+++ b/libs/serd/DETAILS
@@ -1,0 +1,17 @@
+          MODULE=serd
+         VERSION=0.28.0
+          SOURCE=$MODULE-$VERSION.tar.bz2
+      SOURCE_URL=http://download.drobilla.net/
+      SOURCE_VFY=sha256:1df21a8874d256a9f3d51a18b8c6e2539e8092b62cc2674b110307e93f898aec
+        WEB_SITE=http://drobilla.net/software/serd
+         ENTERED=20180113
+         UPDATED=20180113
+           SHORT="library RDF synatx for reading Turtle Trig NTriples and NQuads"
+
+cat << EOF
+Serd is a lightweight C library for RDF syntax which supports reading and writing Turtle, TRiG, NTriples, and NQuads.
+
+Serd is not intended to be a swiss-army knife of RDF syntax, but rather is suited to resource limited or performance
+critical applications (e.g. converting many gigabytes of NTriples to Turtle), or situations where a simple reader/writer
+with minimal dependencies is ideal (e.g. in LV2 implementations or embedded applications).
+EOF


### PR DESCRIPTION
…raverso bump which now requires

lilv.