### PR TITLE
ImageMagick: The issue of hdri and rmagick (not in moonbase) is resol…

### DIFF
--- a/graphics/ImageMagick/BUILD
+++ b/graphics/ImageMagick/BUILD
@@ -1,13 +1,21 @@
 OPTS+=" --enable-shared --disable-static --disable-docs" &&
 
 # see CONFIGURE
-OPTS+=" --disable-hdri" &&
+#OPTS+=" --disable-hdri" &&
 
 # They say to run this if you got dirty.
 # autoreconf &&
-
+# This stage will default to a quantum depth of 16
 default_config &&
 
 make &&
+prepare_install &&
+make install-strip &&
+
+# Now we do it again to get a quantum depth of 32
+OPTS+=" --with-quantum-depth=32" &&
+default_config &&
+make &&
+
 prepare_install &&
 make install-strip

--- a/graphics/ImageMagick/CONFIGURE
+++ b/graphics/ImageMagick/CONFIGURE
@@ -1,4 +1,0 @@
-# currently broken
-mquery ENABLE_HDRI "Enable High Dynamic Range Images (breaks rmagick, but otherwise harmless)" n "--enable-hdri" "--disable-hdri"
-
-mquery ENABLE_32BIT_QUANTUM_DEPTH "Use 32bit per pixel instead of default 16bit" n "--with-quantum-depth=32" "--with-quantum-depth=16"


### PR DESCRIPTION
…ved with their PR

https://github.com/rmagick-temp/rmagick/pull/90. Not that it matters to us since as I
mentioned that module is not in moonbase.

Modified the build to create both quantum depths (16,32). The base pc files such wand.pc
and those without the depth identifer defaults to 32. However there are additional pc files
for both, such as;

/usr/lib/pkgconfig/ImageMagick-6.Q16.pc
/usr/lib/pkgconfig/ImageMagick++-6.Q16.pc
/usr/lib/pkgconfig/ImageMagick-6.Q32.pc
/usr/lib/pkgconfig/ImageMagick++-6.Q32.pc
/usr/lib/pkgconfig/ImageMagick.pc
/usr/lib/pkgconfig/ImageMagick++.pc
/usr/lib/pkgconfig/Magick++-6.Q16.pc
/usr/lib/pkgconfig/Magick++-6.Q32.pc
/usr/lib/pkgconfig/MagickCore-6.Q16.pc
/usr/lib/pkgconfig/MagickCore-6.Q32.pc
/usr/lib/pkgconfig/MagickCore.pc
/usr/lib/pkgconfig/Magick++.pc
/usr/lib/pkgconfig/MagickWand-6.Q16.pc
/usr/lib/pkgconfig/MagickWand-6.Q32.pc
/usr/lib/pkgconfig/MagickWand.pc
/usr/lib/pkgconfig/Wand-6.Q16.pc
/usr/lib/pkgconfig/Wand-6.Q32.pc
/usr/lib/pkgconfig/Wand.pc

And of course there are the respecitve libs for each;

/usr/lib/ImageMagick-6.9.9
/usr/lib/ImageMagick-6.9.9/config-Q16
/usr/lib/ImageMagick-6.9.9/config-Q16/configure.xml
/usr/lib/ImageMagick-6.9.9/config-Q32
/usr/lib/ImageMagick-6.9.9/config-Q32/configure.xml
/usr/lib/libMagick++-6.Q16.so
/usr/lib/libMagick++-6.Q16.so.8
/usr/lib/libMagick++-6.Q16.so.8.0.0
/usr/lib/libMagick++-6.Q32.so
/usr/lib/libMagick++-6.Q32.so.8
/usr/lib/libMagick++-6.Q32.so.8.0.0
/usr/lib/libMagickCore-6.Q16.so
/usr/lib/libMagickCore-6.Q16.so.5
/usr/lib/libMagickCore-6.Q16.so.5.0.0
/usr/lib/libMagickCore-6.Q32.so
/usr/lib/libMagickCore-6.Q32.so.5
/usr/lib/libMagickCore-6.Q32.so.5.0.0
/usr/lib/libMagickWand-6.Q16.so
/usr/lib/libMagickWand-6.Q16.so.5
/usr/lib/libMagickWand-6.Q16.so.5.0.0
/usr/lib/libMagickWand-6.Q32.so
/usr/lib/libMagickWand-6.Q32.so.5
/usr/lib/libMagickWand-6.Q32.so.5.0.0

If it is preferred Wand.pc and the like to default to 16 then just do 32bit quantum
first. As is Wand.pc looks like this (snip):

prefix=/usr
exec_prefix=${prefix}
libdir=${exec_prefix}/lib
includedir=${prefix}/include/ImageMagick-6
includearchdir=/usr/include/ImageMagick-6
libname=MagickWand-6.Q32

Prior to this proposed change if a user decided to switch to another quantum depth at least
a lunar fix to account for the library name changes.