### PR TITLE
cronie.service: Fixed systemd unit file.

### DIFF
--- a/utils/cronie/systemd.d/cronie.service
+++ b/utils/cronie/systemd.d/cronie.service
@@ -3,7 +3,7 @@ Description=Periodic Command Scheduler
 After=syslog.target
 
 [Service]
-ExecStart=/usr/bin/crond -n
+ExecStart=/usr/sbin/crond -n
 ExecReload=/usr/bin/kill -HUP $MAINPID
 KillMode=process
 Restart=always


### PR DESCRIPTION
Seems the latest release of cronie moves crond into /usr/sbin, which is
to be fair where it should have been all along anyway.