### PR TITLE
whois: Version bump to 5.3.0.

### DIFF
--- a/net/whois/DETAILS
+++ b/net/whois/DETAILS
@@ -1,11 +1,11 @@
           MODULE=whois
-         VERSION=5.2.20
+         VERSION=5.3.0
           SOURCE=${MODULE}_$VERSION.tar.xz
       SOURCE_URL=http://ftp.debian.org/debian/pool/main/w/whois/
-      SOURCE_VFY=sha256:6848ab671750ab3782fe4ab2a47910fe4e25aa93894e4d0f3f67b5fcee06c009
+      SOURCE_VFY=sha256:4d789c403bfb5833c8ae168a5f31be70e34b045bd5d95a54c82a27b0ff135723
         WEB_SITE=http://www.linux.it/~md/software
          ENTERED=20011228
-         UPDATED=20180117
+         UPDATED=20180130
            SHORT="Find information online about IP addresses or domains"
 
 cat << EOF


### PR DESCRIPTION
The previous version, 5.2.20, seems to have been completely bogus.