### PR TITLE
zfs: version bumped to 0.7.6

### DIFF
--- a/filesys/zfs-utils/DETAILS
+++ b/filesys/zfs-utils/DETAILS
@@ -1,17 +1,17 @@
           MODULE=zfs-utils
-         VERSION=0.7.5
+         VERSION=0.7.6
           SOURCE=zfs-$VERSION.tar.gz
          SOURCE2=zfs-dracut-0.7.1.patch
 SOURCE_DIRECTORY=$BUILD_DIRECTORY/zfs-$VERSION
       SOURCE_URL=http://github.com/zfsonlinux/zfs/releases/download/zfs-$VERSION/
      SOURCE2_URL=$PATCH_URL
-      SOURCE_VFY=sha256:1b826407418423379ff898c0e6ee0ada59c70754e6085a7663028330d0d8a44a
+      SOURCE_VFY=sha256:1687f4041a990e35caccc4751aa736e8e55123b81d5f5a35b11916d9e580c23d
      SOURCE2_VFY=sha256:f42a0377734789747350e10720aa606e974e393b96cf8c2d773ef8d459457581
       MAINTAINER=ratler@lunar-linux.org
         WEB_SITE=http://zfsonlinux.org/
          LICENSE=cddl
          ENTERED=20130212
-         UPDATED=20171219
+         UPDATED=20180207
            SHORT="The ZFS file system utilities"
 
 cat << EOF

--- a/filesys/zfs/DETAILS
+++ b/filesys/zfs/DETAILS
@@ -1,13 +1,13 @@
           MODULE=zfs
-         VERSION=0.7.5
+         VERSION=0.7.6
           SOURCE=$MODULE-$VERSION.tar.gz
       SOURCE_URL=http://github.com/zfsonlinux/zfs/releases/download/zfs-$VERSION/
-      SOURCE_VFY=sha256:1b826407418423379ff898c0e6ee0ada59c70754e6085a7663028330d0d8a44a
+      SOURCE_VFY=sha256:1687f4041a990e35caccc4751aa736e8e55123b81d5f5a35b11916d9e580c23d
         WEB_SITE=http://zfsonlinux.org/
       MAINTAINER=ratler@lunar-linux.org
          LICENSE=cddl
          ENTERED=20130212
-         UPDATED=20171219
+         UPDATED=20180106
            SHORT="The ZFS file system"
 
 cat << EOF

--- a/kernel/spl/DETAILS
+++ b/kernel/spl/DETAILS
@@ -1,12 +1,12 @@
           MODULE=spl
-         VERSION=0.7.5
+         VERSION=0.7.6
           SOURCE=$MODULE-$VERSION.tar.gz
       SOURCE_URL=http://github.com/zfsonlinux/zfs/releases/download/zfs-$VERSION/
-      SOURCE_VFY=sha256:c4845d9a6123397c53ee003ed1712f2996a50ac2a9a30d1490280771484d08a6
+      SOURCE_VFY=sha256:648148762969d1ee94290c494c4f022aeacabe0e84cddf65906af608be666f95
         WEB_SITE=http://zfsonlinux.org/
       MAINTAINER=ratler@lunar-linux.org
          ENTERED=20150628
-         UPDATED=20171219
+         UPDATED=20180206
            SHORT="Solaris Porting Layer kernel modules and utils"
 KEEP_SOURCE=on
 


### PR DESCRIPTION
It compiles now with Linux kernel version 4.15.x.