### PR TITLE
qemu: Another patch, to fix compiling with gcc 7.x.

### DIFF
--- a/virtual/qemu/DETAILS
+++ b/virtual/qemu/DETAILS
@@ -2,10 +2,13 @@
          VERSION=2.11.0
           SOURCE=$MODULE-$VERSION.tar.bz2
          SOURCE2=$MODULE-memfd.patch
+         SOURCE3=$MODULE-cpp.patch
       SOURCE_URL=http://wiki.qemu.org/download
      SOURCE2_URL=$PATCH_URL
+     SOURCE3_URL=$PATCH_URL
       SOURCE_VFY=sha256:c4f034c7665a84a1c3be72c8da37f3c31ec063475699df062ab646d8b2e17fcb
      SOURCE2_VFY=sha256:5c336076322627f63a8e153254856e381f18c32681c9cbff9e33d99ee84be7a5
+     SOURCE3_VFY=sha256:024bc81085f8e264f2c77ae5972cb8e3cab107182a5914601795a2ea38448b1c
         WEB_SITE=http://wiki.qemu.org/Index.html
          ENTERED=20040318
          UPDATED=20171214

--- a/virtual/qemu/PRE_BUILD
+++ b/virtual/qemu/PRE_BUILD
@@ -3,4 +3,7 @@ default_pre_build &&
 sedit 's/vte-2\.90/vte-2.91/g' configure &&
 
 # fix for compiling with glibc 2.27 
-patch_it $SOURCE2 1
+patch_it $SOURCE2 1 &&
+
+# fix for compiling with gcc 7.x
+patch_it $SOURCE3 1


### PR DESCRIPTION
In newer gcc's (starting at 7.2?), cpp exits with fatal status if you
give it the (meaningless) "-c" flag (I'm assuming that's the flag you
normally give to the compiler to tell it not to link after compiling).