### PR TITLE
Update DETAILS.x86_64

### DIFF
--- a/web/firefox-bin/DETAILS.x86_64
+++ b/web/firefox-bin/DETAILS.x86_64
@@ -1,11 +1,11 @@
           MODULE=firefox-bin
          VERSION=59.0.2
           SOURCE=firefox-$VERSION.tar.bz2
-      SOURCE_URL=http://download-installer.cdn.mozilla.net/pub/firefox/releases/$VERSION/linux-i686/en-US
-      SOURCE_VFY=sha256:23b078678b72a3009fed819d9f1510b677285995f62decbb9ec13b3ce28a9b24
+      SOURCE_URL=http://download-installer.cdn.mozilla.net/pub/firefox/releases/$VERSION/linux-x86_64/en-US
+      SOURCE_VFY=sha256:be1699906ab25786d68f04a26e31ee6bd0c0cf141d89be7f48fdde3e3496cddb
         WEB_SITE=http://www.mozilla.org/projects/firefox
          ENTERED=20091207
-         UPDATED=20180326
+         UPDATED=20180402
          ARCHIVE=off
            SHORT="A speedy, full-featured web browser"
 


### PR DESCRIPTION
firefox-bin: Fix download link for x86_64 architectures