### PR TITLE
Beep patches

### DIFF
--- a/audio/beep/patch.d/CVE-2018-0492.patch
+++ b/audio/beep/patch.d/CVE-2018-0492.patch
@@ -1,0 +1,106 @@
+diff --git a/beep.c b/beep.c
+index 7da2e70..4323d31 100644
+--- a/beep.c
++++ b/beep.c
+@@ -109,6 +109,7 @@ void do_beep(int freq) {
+      /* BEEP_TYPE_EVDEV */
+      struct input_event e;
+ 
++     memset(&e, 0, sizeof(e));
+      e.type = EV_SND;
+      e.code = SND_TONE;
+      e.value = freq;
+@@ -124,10 +125,6 @@ void do_beep(int freq) {
+ /* If we get interrupted, it would be nice to not leave the speaker beeping in
+    perpetuity. */
+ void handle_signal(int signum) {
+-
+-  if(console_device)
+-    free(console_device);
+-
+   switch(signum) {
+   case SIGINT:
+   case SIGTERM:
+@@ -257,7 +254,7 @@ void parse_command_line(int argc, char **argv, beep_parms_t *result) {
+       result->verbose = 1;
+       break;
+     case 'e' : /* also --device */
+-      console_device = strdup(optarg);
++      console_device = optarg;
+       break;
+     case 'h' : /* notice that this is also --help */
+     default :
+@@ -276,26 +273,6 @@ void play_beep(beep_parms_t parms) {
+ 	"%d delay after) @ %.2f Hz\n",
+ 	parms.reps, parms.length, parms.delay, parms.end_delay, parms.freq);
+ 
+-  /* try to snag the console */
+-  if(console_device)
+-    console_fd = open(console_device, O_WRONLY);
+-  else
+-    if((console_fd = open("/dev/tty0", O_WRONLY)) == -1)
+-      console_fd = open("/dev/vc/0", O_WRONLY);
+-
+-  if(console_fd == -1) {
+-    fprintf(stderr, "Could not open %s for writing\n",
+-      console_device != NULL ? console_device : "/dev/tty0 or /dev/vc/0");
+-    printf("\a");  /* Output the only beep we can, in an effort to fall back on usefulness */
+-    perror("open");
+-    exit(1);
+-  }
+-
+-  if (ioctl(console_fd, EVIOCGSND(0)) != -1)
+-    console_type = BEEP_TYPE_EVDEV;
+-  else
+-    console_type = BEEP_TYPE_CONSOLE;
+-  
+   /* Beep */
+   for (i = 0; i < parms.reps; i++) {                    /* start beep */
+     do_beep(parms.freq);
+@@ -305,8 +282,6 @@ void play_beep(beep_parms_t parms) {
+     if(parms.end_delay || (i+1 < parms.reps))
+        usleep(1000*parms.delay);                        /* wait...    */
+   }                                                     /* repeat.    */
+-
+-  close(console_fd);
+ }
+ 
+ 
+@@ -328,6 +303,26 @@ int main(int argc, char **argv) {
+   signal(SIGTERM, handle_signal);
+   parse_command_line(argc, argv, parms);
+ 
++  /* try to snag the console */
++  if(console_device)
++    console_fd = open(console_device, O_WRONLY);
++  else
++    if((console_fd = open("/dev/tty0", O_WRONLY)) == -1)
++      console_fd = open("/dev/vc/0", O_WRONLY);
++
++  if(console_fd == -1) {
++    fprintf(stderr, "Could not open %s for writing\n",
++      console_device != NULL ? console_device : "/dev/tty0 or /dev/vc/0");
++    printf("\a");  /* Output the only beep we can, in an effort to fall back on usefulness */
++    perror("open");
++    exit(1);
++  }
++
++  if (ioctl(console_fd, EVIOCGSND(0)) != -1)
++    console_type = BEEP_TYPE_EVDEV;
++  else
++    console_type = BEEP_TYPE_CONSOLE;
++
+   /* this outermost while loop handles the possibility that -n/--new has been
+      used, i.e. that we have multiple beeps specified. Each iteration will
+      play, then free() one parms instance. */
+@@ -365,8 +360,8 @@ int main(int argc, char **argv) {
+     parms = next;
+   }
+ 
+-  if(console_device)
+-    free(console_device);
++  close(console_fd);
++  console_fd = -1;
+ 
+   return EXIT_SUCCESS;
+ }

--- a/audio/beep/patch.d/catch-sig-term.patch
+++ b/audio/beep/patch.d/catch-sig-term.patch
@@ -1,0 +1,23 @@
+Author: Jérôme <jerome@jolimont.fr>
+Description: also catch SIGTERM for stopping the beep
+
+Index: VCS/beep.c
+===================================================================
+--- VCS.orig/beep.c	2012-06-10 10:03:39.000000000 +0200
++++ VCS/beep.c	2012-06-10 10:03:59.000000000 +0200
+@@ -127,6 +127,7 @@
+ 
+   switch(signum) {
+   case SIGINT:
++  case SIGTERM:
+     if(console_fd >= 0) {
+       /* Kill the sound, quit gracefully */
+       do_beep(0);
+@@ -321,6 +322,7 @@
+   parms->next       = NULL;
+ 
+   signal(SIGINT, handle_signal);
++  signal(SIGTERM, handle_signal);
+   parse_command_line(argc, argv, parms);
+ 
+   /* this outermost while loop handles the possibility that -n/--new has been


### PR DESCRIPTION
Here are a couple of patches from the guys at Debien:

1) catch-sig-term.patch: If someone bangs on ^C halfway through a beep, make the PC speaker shut up, and

2) CVS-2018-0492.patch: The beep command had a security problem!  Imagine that being how your system got rooted.  How embarrassing would that be?