### PR TITLE
Tons of modules: Change dependency on "Python" to "Python-2"

### DIFF
--- a/archive/rdiff-backup/BUILD
+++ b/archive/rdiff-backup/BUILD
@@ -1,6 +1,6 @@
 (
-   python setup.py build &&
+   python2 setup.py build &&
    prepare_install &&
-   python setup.py install
+   python2 setup.py install
         
 ) > $C_FIFO 2>&1

--- a/archive/rdiff-backup/DEPENDS
+++ b/archive/rdiff-backup/DEPENDS
@@ -1,2 +1,2 @@
-depends Python-2
+depends python2
 depends librsync

--- a/archive/rdiff-backup/DEPENDS
+++ b/archive/rdiff-backup/DEPENDS
@@ -1,2 +1,2 @@
-depends Python
+depends Python-2
 depends librsync

--- a/archive/zziplib/DEPENDS
+++ b/archive/zziplib/DEPENDS
@@ -1,6 +1,6 @@
 depends zlib
 depends xmlto
-depends Python
+depends Python-2
 
 optional_depends SDL \
                  "--enable-sdl"  \

--- a/archive/zziplib/DEPENDS
+++ b/archive/zziplib/DEPENDS
@@ -1,6 +1,6 @@
 depends zlib
 depends xmlto
-depends Python-2
+depends python2
 
 optional_depends SDL \
                  "--enable-sdl"  \

--- a/audio/alsa-lib/DEPENDS
+++ b/audio/alsa-lib/DEPENDS
@@ -1,3 +1,3 @@
 depends %PKGCONF
 
-optional_depends Python "" "--disable-python" "to build Python related components (like smixer plugin)"
+optional_depends Python-2 "" "--disable-python" "to build Python 2 related components (like smixer plugin)"

--- a/audio/alsa-lib/DEPENDS
+++ b/audio/alsa-lib/DEPENDS
@@ -1,3 +1,3 @@
 depends %PKGCONF
 
-optional_depends Python-2 "" "--disable-python" "to build Python 2 related components (like smixer plugin)"
+optional_depends python2 "" "--disable-python" "to build Python 2 related components (like smixer plugin)"

--- a/audio/jack/BUILD
+++ b/audio/jack/BUILD
@@ -1,11 +1,11 @@
-python waf configure --prefix=/usr \
+python2 waf configure --prefix=/usr \
                      --alsa &&
 
-python waf build &&
+python2 waf build &&
 
 prepare_install &&
 
-python waf install &&
+python2 waf install &&
 
 # configure realtime access/scheduling
 install -Dm644 $SCRIPT_DIRECTORY/99-audio.conf /etc/security/limits.d/99-audio.conf &&

--- a/audio/libmusicbrainz/DEPENDS
+++ b/audio/libmusicbrainz/DEPENDS
@@ -3,4 +3,4 @@ depends expat
 depends libdiscid
 depends neon
 
-optional_depends Python-2 "" "" "to build the Python 2 bindings"
+optional_depends python2 "" "" "to build the Python 2 bindings"

--- a/audio/libmusicbrainz/DEPENDS
+++ b/audio/libmusicbrainz/DEPENDS
@@ -3,4 +3,4 @@ depends expat
 depends libdiscid
 depends neon
 
-optional_depends Python "" "" "to build the Python bindings"
+optional_depends Python-2 "" "" "to build the Python 2 bindings"

--- a/audio/libmusicbrainz2/BUILD
+++ b/audio/libmusicbrainz2/BUILD
@@ -1,7 +1,7 @@
 default_build &&
 
-if in_depends $MODULE Python ; then
+if in_depends $MODULE Python-2 ; then
   cd python &&
-  python setup.py build &&
-  python setup.py install
+  python2 setup.py build &&
+  python2 setup.py install
 fi

--- a/audio/libmusicbrainz2/DEPENDS
+++ b/audio/libmusicbrainz2/DEPENDS
@@ -2,4 +2,4 @@ depends expat
 depends libdiscid
 depends neon
 
-optional_depends Python "" "" "to build the Python bindings"
+optional_depends Python-2 "" "" "to build the Python 2 bindings"

--- a/audio/libmusicbrainz2/DEPENDS
+++ b/audio/libmusicbrainz2/DEPENDS
@@ -2,4 +2,4 @@ depends expat
 depends libdiscid
 depends neon
 
-optional_depends Python-2 "" "" "to build the Python 2 bindings"
+optional_depends python2 "" "" "to build the Python 2 bindings"

--- a/audio/libmusicbrainz3/DEPENDS
+++ b/audio/libmusicbrainz3/DEPENDS
@@ -3,4 +3,4 @@ depends expat
 depends libdiscid
 depends neon
 
-optional_depends Python-2 "" "" "to build the Python 2 bindings"
+optional_depends python2 "" "" "to build the Python 2 bindings"

--- a/audio/libmusicbrainz3/DEPENDS
+++ b/audio/libmusicbrainz3/DEPENDS
@@ -3,4 +3,4 @@ depends expat
 depends libdiscid
 depends neon
 
-optional_depends Python "" "" "to build the Python bindings"
+optional_depends Python-2 "" "" "to build the Python 2 bindings"

--- a/audio/lv2/DEPENDS
+++ b/audio/lv2/DEPENDS
@@ -1,3 +1,3 @@
 depends libsndfile
 # For the waf build system
-depends Python
+depends Python-2

--- a/audio/lv2/DEPENDS
+++ b/audio/lv2/DEPENDS
@@ -1,3 +1,3 @@
 depends libsndfile
 # For the waf build system
-depends Python-2
+depends python2

--- a/audio/slv2/DEPENDS
+++ b/audio/slv2/DEPENDS
@@ -2,6 +2,6 @@ depends lv2
 depends redland
 
 # For the waf build system
-depends Python
+depends Python-2
 
 optional_depends jack "" "--no-jack" "to build jack clients"

--- a/audio/slv2/DEPENDS
+++ b/audio/slv2/DEPENDS
@@ -2,6 +2,6 @@ depends lv2
 depends redland
 
 # For the waf build system
-depends Python-2
+depends python2
 
 optional_depends jack "" "--no-jack" "to build jack clients"

--- a/bluetooth/gammu/BUILD
+++ b/bluetooth/gammu/BUILD
@@ -1,5 +1,5 @@
-if in_depends $MODULE Python; then
-  VER=`lvu version Python | cut -c 1-3` &&
+if in_depends $MODULE Python-2; then
+  VER=`lvu version Python-2 | cut -c 1-3` &&
   OPTS="-DBUILD_PYTHON=/usr/bin/python$VER"
 else
   OPTS="-DWITH_PYTHON=OFF"

--- a/bluetooth/gammu/DEPENDS
+++ b/bluetooth/gammu/DEPENDS
@@ -5,7 +5,7 @@ depends libdbi
 depends curl
 depends cmake
 
-optional_depends Python-2   "" "" "for Python 2 support"
+optional_depends python2   "" "" "for Python 2 support"
 optional_depends %MYSQL     "" "" "for mysql database support"
 optional_depends postgresql "" "" "for database support"
 optional_depends doxygen    "" "" "for documentation install"

--- a/bluetooth/gammu/DEPENDS
+++ b/bluetooth/gammu/DEPENDS
@@ -5,7 +5,7 @@ depends libdbi
 depends curl
 depends cmake
 
-optional_depends Python     "" "" "for Python support"
+optional_depends Python-2   "" "" "for Python 2 support"
 optional_depends %MYSQL     "" "" "for mysql database support"
 optional_depends postgresql "" "" "for database support"
 optional_depends doxygen    "" "" "for documentation install"

--- a/chat/weechat/DEPENDS
+++ b/chat/weechat/DEPENDS
@@ -5,7 +5,7 @@ depends curl
 depends %PKGCONF
 
 optional_depends perl   "-DENABLE_PERL=ON"   "-DENABLE_PERL=OFF"   "to compile the perl plugin"
-optional_depends Python "-DENABLE_PYTHON=ON" "-DENABLE_PYTHON=OFF" "to compile the Python plugin"
+optional_depends Python-2 "-DENABLE_PYTHON=ON" "-DENABLE_PYTHON=OFF" "to compile the Python 2 plugin"
 optional_depends lua    "-DENABLE_LUA=ON"    "-DENABLE_LUA=OFF"    "to compile the lua plugin"
 optional_depends ruby   "-DENABLE_RUBY=ON"   "-DENABLE_RUBY=OFF"   "to compile the ruby plugin"
 optional_depends tcl    "-DENABLE_TCL=ON"    "-DENABLE_TCL=OFF"    "to compile the tcl plugin"

--- a/chat/weechat/DEPENDS
+++ b/chat/weechat/DEPENDS
@@ -5,7 +5,7 @@ depends curl
 depends %PKGCONF
 
 optional_depends perl   "-DENABLE_PERL=ON"   "-DENABLE_PERL=OFF"   "to compile the perl plugin"
-optional_depends Python-2 "-DENABLE_PYTHON=ON" "-DENABLE_PYTHON=OFF" "to compile the Python 2 plugin"
+optional_depends python2 "-DENABLE_PYTHON=ON" "-DENABLE_PYTHON=OFF" "to compile the Python 2 plugin"
 optional_depends lua    "-DENABLE_LUA=ON"    "-DENABLE_LUA=OFF"    "to compile the lua plugin"
 optional_depends ruby   "-DENABLE_RUBY=ON"   "-DENABLE_RUBY=OFF"   "to compile the ruby plugin"
 optional_depends tcl    "-DENABLE_TCL=ON"    "-DENABLE_TCL=OFF"    "to compile the tcl plugin"

--- a/chat/xchat/DEPENDS
+++ b/chat/xchat/DEPENDS
@@ -3,8 +3,8 @@ depends  gtk+-2
 optional_depends "%OSSL"    "--enable-openssl"  "--disable-openssl" \
                  "enable support for openSSL"
 
-optional_depends "Python"   "--enable-python"   "--disable-python"  \
-                 "enable support for python plugins"
+optional_depends "Python-2" "--enable-python"   "--disable-python"  \
+                 "enable support for python 2 plugins"
 
 optional_depends "perl"     "--enable-perl"     "--disable-perl"    \
                  "enable support for perl plugins"

--- a/chat/xchat/DEPENDS
+++ b/chat/xchat/DEPENDS
@@ -3,7 +3,7 @@ depends  gtk+-2
 optional_depends "%OSSL"    "--enable-openssl"  "--disable-openssl" \
                  "enable support for openSSL"
 
-optional_depends "Python-2" "--enable-python"   "--disable-python"  \
+optional_depends "python2" "--enable-python"   "--disable-python"  \
                  "enable support for python 2 plugins"
 
 optional_depends "perl"     "--enable-perl"     "--disable-perl"    \

--- a/compilers/Cython/BUILD
+++ b/compilers/Cython/BUILD
@@ -3,6 +3,6 @@ prepare_install &&
 python3 setup.py install --root=/
 
 if module_installed setuptools; then
-  python setup.py build &&
-  python setup.py install --root=/
+  python2 setup.py build &&
+  python2 setup.py install --root=/
 fi

--- a/compilers/clingo/DEPENDS
+++ b/compilers/clingo/DEPENDS
@@ -2,5 +2,5 @@ depends scons
 depends re2c
 depends bison
 
-optional_depends Python-2 "-DCLINGO_REQUIRE_PYTHON=ON" "-DCLINGO_BUILD_WITH_PYTHON=OFF" "build python 2 scripting extension"
+optional_depends python2 "-DCLINGO_REQUIRE_PYTHON=ON" "-DCLINGO_BUILD_WITH_PYTHON=OFF" "build python 2 scripting extension"
 optional_depends lua    "-DCLINGO_REQUIRE_LUA=ON" "-DCLINGO_REQUIRE_LUA=OFF" "build lua scripting extension"

--- a/compilers/clingo/DEPENDS
+++ b/compilers/clingo/DEPENDS
@@ -2,5 +2,5 @@ depends scons
 depends re2c
 depends bison
 
-optional_depends Python "-DCLINGO_REQUIRE_PYTHON=ON" "-DCLINGO_BUILD_WITH_PYTHON=OFF" "build python scripting extension"
+optional_depends Python-2 "-DCLINGO_REQUIRE_PYTHON=ON" "-DCLINGO_BUILD_WITH_PYTHON=OFF" "build python 2 scripting extension"
 optional_depends lua    "-DCLINGO_REQUIRE_LUA=ON" "-DCLINGO_REQUIRE_LUA=OFF" "build lua scripting extension"

--- a/compilers/gringo/DEPENDS
+++ b/compilers/gringo/DEPENDS
@@ -2,5 +2,5 @@ depends scons
 depends re2c
 depends bison
 
-optional_depends Python "WITH_PYTHON=python2.7 CPPPATH=/usr/include/python2.7" " " "build python scripting extension"
+optional_depends Python-2 "WITH_PYTHON=python2.7 CPPPATH=/usr/include/python2.7" " " "build python 2 scripting extension"
 optional_depends lua    "WITH_LUA=lua" " " "build lua scripting extension"

--- a/compilers/gringo/DEPENDS
+++ b/compilers/gringo/DEPENDS
@@ -2,5 +2,5 @@ depends scons
 depends re2c
 depends bison
 
-optional_depends Python-2 "WITH_PYTHON=python2.7 CPPPATH=/usr/include/python2.7" " " "build python 2 scripting extension"
+optional_depends python2 "WITH_PYTHON=python2.7 CPPPATH=/usr/include/python2.7" " " "build python 2 scripting extension"
 optional_depends lua    "WITH_LUA=lua" " " "build lua scripting extension"

--- a/compilers/rustc/DEPENDS
+++ b/compilers/rustc/DEPENDS
@@ -1,5 +1,5 @@
 depends perl
-depends Python
+depends Python-2
 depends curl
 depends libffi
 depends jemalloc

--- a/compilers/rustc/DEPENDS
+++ b/compilers/rustc/DEPENDS
@@ -1,5 +1,5 @@
 depends perl
-depends Python-2
+depends python2
 depends curl
 depends libffi
 depends jemalloc

--- a/crater/lv2core/DEPENDS
+++ b/crater/lv2core/DEPENDS
@@ -1,2 +1,2 @@
 # For the waf build system
-depends Python-2
+depends python2

--- a/crater/lv2core/DEPENDS
+++ b/crater/lv2core/DEPENDS
@@ -1,2 +1,2 @@
 # For the waf build system
-depends Python
+depends Python-2

--- a/crypto/Botan/BUILD
+++ b/crypto/Botan/BUILD
@@ -7,6 +7,6 @@ OPTS+="  --prefix=/usr  \
          --with-sqlite3 \
          --with-zlib"  &&
 
-CXXFLAGS="$CXXFLAGS -O3" ./configure.py $OPTS &&
+python2 configure.py $OPTS &&
 
 default_make

--- a/crypto/beecrypt/DEPENDS
+++ b/crypto/beecrypt/DEPENDS
@@ -1,3 +1,3 @@
-optional_depends Python    "--with-python" "--without-python" "for Python support"
+optional_depends Python-2    "--with-python" "--without-python" "for Python 2 support"
 optional_depends %JAVA_SDK "--with-java"   "--without-java"   "for java support"
 optional_depends icu4c     ""              ""                 "for unicode support"

--- a/crypto/beecrypt/DEPENDS
+++ b/crypto/beecrypt/DEPENDS
@@ -1,3 +1,3 @@
-optional_depends Python-2    "--with-python" "--without-python" "for Python 2 support"
+optional_depends python2    "--with-python" "--without-python" "for Python 2 support"
 optional_depends %JAVA_SDK "--with-java"   "--without-java"   "for java support"
 optional_depends icu4c     ""              ""                 "for unicode support"

--- a/devel/bzr/BUILD
+++ b/devel/bzr/BUILD
@@ -1,6 +1,6 @@
 prepare_install &&
 
-python setup.py install &&
+python2 setup.py install &&
 
 install -dm 755 /usr/share/bash-completion/completions &&
 install -m 644 contrib/bash/bzr /usr/share/bash-completion/completions/

--- a/devel/bzr/DEPENDS
+++ b/devel/bzr/DEPENDS
@@ -1,3 +1,3 @@
-depends Python-2
+depends python2
 
 optional_depends paramiko "" "" "For sftp support"

--- a/devel/bzr/DEPENDS
+++ b/devel/bzr/DEPENDS
@@ -1,3 +1,3 @@
-depends Python
+depends Python-2
 
 optional_depends paramiko "" "" "For sftp support"

--- a/devel/cdiff/BUILD
+++ b/devel/cdiff/BUILD
@@ -1,5 +1,5 @@
-python setup.py build &&
+python2 setup.py build &&
 
 prepare_install &&
 
-python setup.py install --optimize=1
+python2 setup.py install --optimize=1

--- a/devel/cdiff/DEPENDS
+++ b/devel/cdiff/DEPENDS
@@ -1,1 +1,1 @@
-depends Python
+depends Python-2

--- a/devel/cdiff/DEPENDS
+++ b/devel/cdiff/DEPENDS
@@ -1,1 +1,1 @@
-depends Python-2
+depends python2

--- a/devel/gdb/DEPENDS
+++ b/devel/gdb/DEPENDS
@@ -3,7 +3,7 @@ depends readline
 depends zlib
 depends texinfo
 
-optional_depends Python "" "" "for Python related components"
+optional_depends Python-2 "" "" "for Python 2 related components"
 
 # guile breaks the build
 #optional_depends guile \

--- a/devel/gdb/DEPENDS
+++ b/devel/gdb/DEPENDS
@@ -3,7 +3,7 @@ depends readline
 depends zlib
 depends texinfo
 
-optional_depends Python-2 "" "" "for Python 2 related components"
+optional_depends python2 "" "" "for Python 2 related components"
 
 # guile breaks the build
 #optional_depends guile \

--- a/devel/gdbus-codegen/DEPENDS
+++ b/devel/gdbus-codegen/DEPENDS
@@ -1,2 +1,2 @@
 depends glib-2
-depends Python-2
+depends python2

--- a/devel/gdbus-codegen/DEPENDS
+++ b/devel/gdbus-codegen/DEPENDS
@@ -1,2 +1,2 @@
 depends glib-2
-depends Python
+depends Python-2

--- a/devel/git/DEPENDS
+++ b/devel/git/DEPENDS
@@ -1,4 +1,4 @@
-depends Python-2
+depends python2
 depends %OSSL
 depends rsync
 depends zlib

--- a/devel/git/DEPENDS
+++ b/devel/git/DEPENDS
@@ -1,4 +1,4 @@
-depends Python
+depends Python-2
 depends %OSSL
 depends rsync
 depends zlib

--- a/devel/gobject-introspection/DEPENDS
+++ b/devel/gobject-introspection/DEPENDS
@@ -5,4 +5,4 @@ depends glib-2
 # will fail without cairo support
 optional_depends cairo   "" "" "for cairo graphics support${PROBLEM_COLOR} While this defaults to yes, you should say no on a clean install, else you will have troubles${DEFAULT_COLOR}" y
 
-optional_depends Python  ""  ""  "for Python support"
+optional_depends Python-2  ""  ""  "for Python support"

--- a/devel/gobject-introspection/DEPENDS
+++ b/devel/gobject-introspection/DEPENDS
@@ -5,4 +5,4 @@ depends glib-2
 # will fail without cairo support
 optional_depends cairo   "" "" "for cairo graphics support${PROBLEM_COLOR} While this defaults to yes, you should say no on a clean install, else you will have troubles${DEFAULT_COLOR}" y
 
-optional_depends Python-2  ""  ""  "for Python support"
+optional_depends python2  ""  ""  "for Python support"

--- a/devel/libftdi/DEPENDS
+++ b/devel/libftdi/DEPENDS
@@ -2,4 +2,4 @@ depends %PKGCONF
 depends libusb
 depends cmake
 optional_depends boost "-DFTDIPP=ON" "-DFTDIPP=OFF" "Build C++ binding library libftdi1++"
-optional_depends Python "-DPYTHON_BINDINGS=ON" "-DPYTHON_BINDINGS=OFF" "Build Python bindings"
+optional_depends Python-2 "-DPYTHON_BINDINGS=ON" "-DPYTHON_BINDINGS=OFF" "Build Python 2 bindings"

--- a/devel/libftdi/DEPENDS
+++ b/devel/libftdi/DEPENDS
@@ -2,4 +2,4 @@ depends %PKGCONF
 depends libusb
 depends cmake
 optional_depends boost "-DFTDIPP=ON" "-DFTDIPP=OFF" "Build C++ binding library libftdi1++"
-optional_depends Python-2 "-DPYTHON_BINDINGS=ON" "-DPYTHON_BINDINGS=OFF" "Build Python 2 bindings"
+optional_depends python2 "-DPYTHON_BINDINGS=ON" "-DPYTHON_BINDINGS=OFF" "Build Python 2 bindings"

--- a/devel/libftdi1/DEPENDS
+++ b/devel/libftdi1/DEPENDS
@@ -7,7 +7,7 @@ optional_depends boost \
                  "-DFTDIPP=OFF" \
                  "Build C++ binding library libftdi1++"
 
-optional_depends Python-2 \
+optional_depends python2 \
                  "-DPYTHON_BINDINGS=ON" \
                  "-DPYTHON_BINDINGS=OFF" \
                  "Build Python 2 bindings"

--- a/devel/libftdi1/DEPENDS
+++ b/devel/libftdi1/DEPENDS
@@ -7,10 +7,10 @@ optional_depends boost \
                  "-DFTDIPP=OFF" \
                  "Build C++ binding library libftdi1++"
 
-optional_depends Python \
+optional_depends Python-2 \
                  "-DPYTHON_BINDINGS=ON" \
                  "-DPYTHON_BINDINGS=OFF" \
-                 "Build Python bindings"
+                 "Build Python 2 bindings"
 
 optional_depends confuse \
                  "-DFTDI_EEPROM=ON" \

--- a/devel/meld/BUILD
+++ b/devel/meld/BUILD
@@ -1,4 +1,4 @@
-python setup.py build &&
+python2 setup.py build &&
 
 prepare_install &&
 

--- a/devel/mercurial/BUILD
+++ b/devel/mercurial/BUILD
@@ -1,6 +1,6 @@
 prepare_install &&
 
-python setup.py install --force &&
+python2 setup.py install --force &&
 cp -p contrib/hgk /usr/bin &&
 gather_docs CONTRIBUTORS PKG-INFO hgweb*.cgi doc/*.html doc/*.txt &&
 

--- a/devel/mercurial/DEPENDS
+++ b/devel/mercurial/DEPENDS
@@ -1,3 +1,3 @@
-depends Python-2
+depends python2
 
 optional_depends tk "" "" "for a TK front-end hg tool"

--- a/devel/mercurial/DEPENDS
+++ b/devel/mercurial/DEPENDS
@@ -1,3 +1,3 @@
-depends Python
+depends Python-2
 
 optional_depends tk "" "" "for a TK front-end hg tool"

--- a/devel/ninja/BUILD
+++ b/devel/ninja/BUILD
@@ -1,4 +1,4 @@
-python configure.py --bootstrap &&
+python2 configure.py --bootstrap &&
 
 # test it
 ./ninja ninja_test &&

--- a/devel/ninja/DEPENDS
+++ b/devel/ninja/DEPENDS
@@ -1,2 +1,2 @@
-depends Python
+depends Python-2
 depends re2c

--- a/devel/ninja/DEPENDS
+++ b/devel/ninja/DEPENDS
@@ -1,2 +1,2 @@
-depends Python-2
+depends python2
 depends re2c

--- a/devel/psyco/BUILD
+++ b/devel/psyco/BUILD
@@ -1,5 +1,5 @@
 (
-   python setup.py build &&
+   python2 setup.py build &&
    prepare_install &&
-   python setup.py install
+   python2 setup.py install
 ) > $C_FIFO 2>&1

--- a/devel/psyco/DEPENDS
+++ b/devel/psyco/DEPENDS
@@ -1,1 +1,1 @@
-depends Python
+depends Python-2

--- a/devel/psyco/DEPENDS
+++ b/devel/psyco/DEPENDS
@@ -1,1 +1,1 @@
-depends Python-2
+depends python2

--- a/devel/scons/BUILD
+++ b/devel/scons/BUILD
@@ -1,7 +1,7 @@
-python setup.py build &&
+python2 setup.py build &&
 
 prepare_install &&
 
-python setup.py install --root=/ \
+python2 setup.py install --root=/ \
                         --prefix=/usr \
                         --install-data=/usr/share

--- a/devel/scons/DEPENDS
+++ b/devel/scons/DEPENDS
@@ -1,1 +1,1 @@
-depends Python
+depends Python-2

--- a/devel/scons/DEPENDS
+++ b/devel/scons/DEPENDS
@@ -1,1 +1,1 @@
-depends Python-2
+depends python2

--- a/devel/swig/DEPENDS
+++ b/devel/swig/DEPENDS
@@ -2,7 +2,7 @@ depends zlib
 
 optional_depends pcre      "--with-pcre"    "--without-pcre"    "for regular expressions using PCRE"
 optional_depends boost     "--with-boost"   "--without-boost"   "for Boost library support"
-optional_depends Python-2  "--with-python"  "--without-python"  "for Python 2 bindings support"
+optional_depends python2  "--with-python"  "--without-python"  "for Python 2 bindings support"
 optional_depends Python-3  "--with-python3" "--without-python3" "for Python 3 bindings support"
 optional_depends perl      "--with-perl5"   "--without-perl5"   "for perl bindings support"
 optional_depends %JAVA_SDK "--with-java"    "--without-java"    "for java bindings support"

--- a/devel/swig/DEPENDS
+++ b/devel/swig/DEPENDS
@@ -2,7 +2,7 @@ depends zlib
 
 optional_depends pcre      "--with-pcre"    "--without-pcre"    "for regular expressions using PCRE"
 optional_depends boost     "--with-boost"   "--without-boost"   "for Boost library support"
-optional_depends Python    "--with-python"  "--without-python"  "for Python bindings support"
+optional_depends Python-2  "--with-python"  "--without-python"  "for Python 2 bindings support"
 optional_depends Python-3  "--with-python3" "--without-python3" "for Python 3 bindings support"
 optional_depends perl      "--with-perl5"   "--without-perl5"   "for perl bindings support"
 optional_depends %JAVA_SDK "--with-java"    "--without-java"    "for java bindings support"

--- a/devel/talloc/DEPENDS
+++ b/devel/talloc/DEPENDS
@@ -1,3 +1,3 @@
-depends Python
-depends %PKGCONF
+depends Python-2
+depends pkgconfig
 depends docbook-xsl

--- a/devel/talloc/DEPENDS
+++ b/devel/talloc/DEPENDS
@@ -1,3 +1,3 @@
-depends Python-2
+depends python2
 depends pkgconfig
 depends docbook-xsl

--- a/doc-tools/asciidoc/DEPENDS
+++ b/doc-tools/asciidoc/DEPENDS
@@ -1,2 +1,2 @@
-depends Python-2
+depends python2
 

--- a/doc-tools/asciidoc/DEPENDS
+++ b/doc-tools/asciidoc/DEPENDS
@@ -1,2 +1,2 @@
-depends Python
+depends Python-2
 

--- a/doc-tools/dblatex/BUILD
+++ b/doc-tools/dblatex/BUILD
@@ -1,5 +1,5 @@
-python setup.py build &&
+python2 setup.py build &&
 
 prepare_install &&
 
-python setup.py install --root=/
+python2 setup.py install --root=/

--- a/doc-tools/dblatex/DEPENDS
+++ b/doc-tools/dblatex/DEPENDS
@@ -1,4 +1,4 @@
-depends Python
+depends Python-2
 depends libxslt
 depends libxml2
 depends texlive

--- a/doc-tools/dblatex/DEPENDS
+++ b/doc-tools/dblatex/DEPENDS
@@ -1,4 +1,4 @@
-depends Python-2
+depends python2
 depends libxslt
 depends libxml2
 depends texlive

--- a/doc-tools/docutils/BUILD
+++ b/doc-tools/docutils/BUILD
@@ -6,6 +6,6 @@ prepare_install &&
 #python3 setup.py install --root=/
 
 #if in_depends $MODULE Python; then
-  python setup.py build &&
-  python setup.py install --root=/
+  python2 setup.py build &&
+  python2 setup.py install --root=/
 #fi

--- a/doc-tools/docutils/DEPENDS
+++ b/doc-tools/docutils/DEPENDS
@@ -1,3 +1,3 @@
-depends Python-2
+depends python2
 
 #optional_depends Python "" "" "for Python2 support"

--- a/doc-tools/docutils/DEPENDS
+++ b/doc-tools/docutils/DEPENDS
@@ -1,3 +1,3 @@
-depends Python
+depends Python-2
 
 #optional_depends Python "" "" "for Python2 support"

--- a/doc-tools/doxygen/DEPENDS
+++ b/doc-tools/doxygen/DEPENDS
@@ -5,7 +5,7 @@ depends perl
 
 optional_depends ghostscript "" "" "Formulas support"
 optional_depends graphviz    "" ""  "Graphs support"
-optional_depends Python      "" "" "Build the doc files"
+optional_depends Python-2    "" "" "Build the doc files"
 optional_depends texlive     "" "" "LaTeX, Postscript and PDF output"
 optional_depends xapian-core "" "" "Include search/indexing support"
 

--- a/doc-tools/doxygen/DEPENDS
+++ b/doc-tools/doxygen/DEPENDS
@@ -5,7 +5,7 @@ depends perl
 
 optional_depends ghostscript "" "" "Formulas support"
 optional_depends graphviz    "" ""  "Graphs support"
-optional_depends Python-2    "" "" "Build the doc files"
+optional_depends python2    "" "" "Build the doc files"
 optional_depends texlive     "" "" "LaTeX, Postscript and PDF output"
 optional_depends xapian-core "" "" "Include search/indexing support"
 

--- a/doc-tools/epydoc/DEPENDS
+++ b/doc-tools/epydoc/DEPENDS
@@ -1,1 +1,1 @@
-depends "Python-2"
+depends "python2"

--- a/doc-tools/epydoc/DEPENDS
+++ b/doc-tools/epydoc/DEPENDS
@@ -1,1 +1,1 @@
-depends "Python"
+depends "Python-2"

--- a/doc-tools/lilypond/DEPENDS
+++ b/doc-tools/lilypond/DEPENDS
@@ -18,7 +18,7 @@ depends freetype2
 depends ghostscript
 depends guile-1
 depends pango
-depends Python
+depends Python-2
 
 optional_depends texi2html "--enable-documentation" "--disable-documentation" "build documentation"
 optional_depends netpbm "" "" "needed for documentation"

--- a/doc-tools/lilypond/DEPENDS
+++ b/doc-tools/lilypond/DEPENDS
@@ -18,7 +18,7 @@ depends freetype2
 depends ghostscript
 depends guile-1
 depends pango
-depends Python-2
+depends python2
 
 optional_depends texi2html "--enable-documentation" "--disable-documentation" "build documentation"
 optional_depends netpbm "" "" "needed for documentation"

--- a/doc-tools/pdfshuffler/BUILD
+++ b/doc-tools/pdfshuffler/BUILD
@@ -1,5 +1,5 @@
-python setup.py config &&
+python2 setup.py config &&
 
 prepare_install &&
 
-python setup.py install
+python2 setup.py install

--- a/doc-tools/txt2tags/DEPENDS
+++ b/doc-tools/txt2tags/DEPENDS
@@ -1,1 +1,1 @@
-depends Python
+depends Python-2

--- a/doc-tools/txt2tags/DEPENDS
+++ b/doc-tools/txt2tags/DEPENDS
@@ -1,1 +1,1 @@
-depends Python-2
+depends python2

--- a/doc-tools/uTidylib/BUILD
+++ b/doc-tools/uTidylib/BUILD
@@ -1,5 +1,5 @@
 (
-  python setup.py build &&
+  python2 setup.py build &&
   prepare_install &&
-  python setup.py install
+  python2 setup.py install
 ) > $C_FIFO 2>&1

--- a/doc-tools/uTidylib/DEPENDS
+++ b/doc-tools/uTidylib/DEPENDS
@@ -1,3 +1,3 @@
 depends tidy
-depends Python
+depends Python-2
 depends unzip

--- a/doc-tools/uTidylib/DEPENDS
+++ b/doc-tools/uTidylib/DEPENDS
@@ -1,3 +1,3 @@
 depends tidy
-depends Python-2
+depends python2
 depends unzip

--- a/fonts/fontforge/DEPENDS
+++ b/fonts/fontforge/DEPENDS
@@ -1,4 +1,4 @@
-depends Python
+depends Python-2
 depends git
 depends libXi
 depends libxkbui

--- a/fonts/fontforge/DEPENDS
+++ b/fonts/fontforge/DEPENDS
@@ -1,4 +1,4 @@
-depends Python-2
+depends python2
 depends git
 depends libXi
 depends libxkbui

--- a/fonts/fonttools/BUILD
+++ b/fonts/fonttools/BUILD
@@ -1,6 +1,6 @@
 
-  python setup.py build  &&
+  python2 setup.py build  &&
 
   prepare_install  &&
 
-  python setup.py install
+  python2 setup.py install

--- a/fonts/fonttools/DEPENDS
+++ b/fonts/fonttools/DEPENDS
@@ -1,2 +1,2 @@
-depends Python-2
+depends python2
 

--- a/fonts/fonttools/DEPENDS
+++ b/fonts/fonttools/DEPENDS
@@ -1,2 +1,2 @@
-depends Python
+depends Python-2
 

--- a/games/paintown/DEPENDS
+++ b/games/paintown/DEPENDS
@@ -1,4 +1,4 @@
-depends Python-2
+depends python2
 depends scons
 depends freetype2
 depends libpng

--- a/games/paintown/DEPENDS
+++ b/games/paintown/DEPENDS
@@ -1,4 +1,4 @@
-depends Python
+depends Python-2
 depends scons
 depends freetype2
 depends libpng

--- a/games/spring/DEPENDS
+++ b/games/spring/DEPENDS
@@ -14,5 +14,5 @@ depends %GLX
 # to find docbook-xsl, so these will not be generated anyway
 #depends asciidoc
 
-optional_depends Python "" "" "for AI Interfaces and Skirmish AIs"
+optional_depends Python-2 "" "" "for AI Interfaces and Skirmish AIs"
 optional_depends sun-jdk "" "" "for AI Interfaces and Skirmish AIs"

--- a/games/spring/DEPENDS
+++ b/games/spring/DEPENDS
@@ -14,5 +14,5 @@ depends %GLX
 # to find docbook-xsl, so these will not be generated anyway
 #depends asciidoc
 
-optional_depends Python-2 "" "" "for AI Interfaces and Skirmish AIs"
+optional_depends python2 "" "" "for AI Interfaces and Skirmish AIs"
 optional_depends sun-jdk "" "" "for AI Interfaces and Skirmish AIs"

--- a/games/unknown-horizons/BUILD
+++ b/games/unknown-horizons/BUILD
@@ -1,3 +1,3 @@
-python setup.py build &&
+python2 setup.py build &&
 prepare_install &&
-python setup.py install
+python2 setup.py install

--- a/graphics/OpenImageIO-oiio/DEPENDS
+++ b/graphics/OpenImageIO-oiio/DEPENDS
@@ -9,7 +9,7 @@ depends libwebp
 
 optional_depends giflib      "-DUSE_GIF=ON"      "-DUSE_GIF=OFF"      "for gif image support" y
 optional_depends LibRaw      "-DUSE_LIBRAW=ON"   "-DUSE_LIBRAW=OFF"   "for raw image support" 
-optional_depends Python      "-DUSE_PYTHON=ON"   "-DUSE_PYTHON=OFF"   "for Python bindings support" y
+optional_depends Python-2    "-DUSE_PYTHON=ON"   "-DUSE_PYTHON=OFF"   "for Python 2 bindings support" y
 optional_depends opencv-3    "-DUSE_OPENCV=ON"   "-DUSE_OPENCV=OFF"   "for open computer vision support" y
 optional_depends "%OSSL"     "-DUSE_OPENSSL=ON"  "-DUSE_OPENSSL=OFF"  "for ssl support" y
 optional_depends openjpeg    "-DUSE_OPENJPEG=ON" "-DUSE_OPENJPEG=OFF" "for openjpeg graphics support"y

--- a/graphics/OpenImageIO-oiio/DEPENDS
+++ b/graphics/OpenImageIO-oiio/DEPENDS
@@ -9,7 +9,7 @@ depends libwebp
 
 optional_depends giflib      "-DUSE_GIF=ON"      "-DUSE_GIF=OFF"      "for gif image support" y
 optional_depends LibRaw      "-DUSE_LIBRAW=ON"   "-DUSE_LIBRAW=OFF"   "for raw image support" 
-optional_depends Python-2    "-DUSE_PYTHON=ON"   "-DUSE_PYTHON=OFF"   "for Python 2 bindings support" y
+optional_depends python2    "-DUSE_PYTHON=ON"   "-DUSE_PYTHON=OFF"   "for Python 2 bindings support" y
 optional_depends opencv-3    "-DUSE_OPENCV=ON"   "-DUSE_OPENCV=OFF"   "for open computer vision support" y
 optional_depends "%OSSL"     "-DUSE_OPENSSL=ON"  "-DUSE_OPENSSL=OFF"  "for ssl support" y
 optional_depends openjpeg    "-DUSE_OPENJPEG=ON" "-DUSE_OPENJPEG=OFF" "for openjpeg graphics support"y

--- a/graphics/VTK/DEPENDS
+++ b/graphics/VTK/DEPENDS
@@ -1,5 +1,5 @@
 depends zlib
-depends Python-2
+depends python2
 depends boost
 depends libtheora
 depends jsoncpp

--- a/graphics/VTK/DEPENDS
+++ b/graphics/VTK/DEPENDS
@@ -1,5 +1,5 @@
 depends zlib
-depends Python
+depends Python-2
 depends boost
 depends libtheora
 depends jsoncpp

--- a/graphics/graphite/DEPENDS
+++ b/graphics/graphite/DEPENDS
@@ -1,3 +1,3 @@
-depends Python
+depends Python-2
 depends cmake
 depends freetype2

--- a/graphics/graphite/DEPENDS
+++ b/graphics/graphite/DEPENDS
@@ -1,3 +1,3 @@
-depends Python-2
+depends python2
 depends cmake
 depends freetype2

--- a/graphics/graphviz/DEPENDS
+++ b/graphics/graphviz/DEPENDS
@@ -12,7 +12,7 @@ optional_depends urw-fonts "" "" "extra fonts for XOrg X11"
 optional_depends ghostscript "--with-ghostscript" "--without-ghostscript" "for Postscript support"
 optional_depends %JAVA_SDK   "--enable-java"      "--disable-java"        "for java support"
 optional_depends Python-3    "--enable-python"    "--disable-python"      "for Python 3.x support"
-optional_depends Python-2    "--enable-python27"  "--disable-python27"    "for Python 2.x support"
+optional_depends python2    "--enable-python27"  "--disable-python27"    "for Python 2.x support"
 
 optional_depends perl    "--enable-perl" "--disable-perl"  "perl support"
 optional_depends R       "--enable-r"    "--disable-r"     "for R language support"

--- a/graphics/graphviz/DEPENDS
+++ b/graphics/graphviz/DEPENDS
@@ -12,7 +12,7 @@ optional_depends urw-fonts "" "" "extra fonts for XOrg X11"
 optional_depends ghostscript "--with-ghostscript" "--without-ghostscript" "for Postscript support"
 optional_depends %JAVA_SDK   "--enable-java"      "--disable-java"        "for java support"
 optional_depends Python-3    "--enable-python"    "--disable-python"      "for Python 3.x support"
-optional_depends Python      "--enable-python27"  "--disable-python27"    "for Python 2.x support"
+optional_depends Python-2    "--enable-python27"  "--disable-python27"    "for Python 2.x support"
 
 optional_depends perl    "--enable-perl" "--disable-perl"  "perl support"
 optional_depends R       "--enable-r"    "--disable-r"     "for R language support"

--- a/graphics/ptex/DEPENDS
+++ b/graphics/ptex/DEPENDS
@@ -1,2 +1,2 @@
 depends zlib
-depends Python
+depends Python-2

--- a/graphics/ptex/DEPENDS
+++ b/graphics/ptex/DEPENDS
@@ -1,2 +1,2 @@
 depends zlib
-depends Python-2
+depends python2

--- a/libs/PDFlib-Lite/DEPENDS
+++ b/libs/PDFlib-Lite/DEPENDS
@@ -1,6 +1,6 @@
 optional_depends "perl"      ""                                      "--with-perl=no"    "for perl bindings"
-optional_depends "Python"    "--with-pyincl=/usr/include/python2.7/" "--without-python"  "for python bindings"
-optional_depends "%JAVA_SDK" "--with-java=/usr/lib/java/latest"      "--without-java"    "for java bindings" n
+optional_depends "Python-2"    "--with-pyincl=/usr/include/python2.7/" "--without-python"  "for python 2 bindings"
+optional_depends "%JAVA_SDK" "--with-java=/usr/lib/java/latest"      "--without-java"    "for java bindings"
 optional_depends "tcl"       ""                                      "--without-tcl"     "for tcl bindings"
 optional_depends "openssl"   ""                                      "--without-openssl" "for openssl support"
 optional_depends "icu4c"     "--enable-icu"                          "--disable-icu"     "for icu support"

--- a/libs/PDFlib-Lite/DEPENDS
+++ b/libs/PDFlib-Lite/DEPENDS
@@ -1,5 +1,5 @@
 optional_depends "perl"      ""                                      "--with-perl=no"    "for perl bindings"
-optional_depends "Python-2"    "--with-pyincl=/usr/include/python2.7/" "--without-python"  "for python 2 bindings"
+optional_depends "python2"    "--with-pyincl=/usr/include/python2.7/" "--without-python"  "for python 2 bindings"
 optional_depends "%JAVA_SDK" "--with-java=/usr/lib/java/latest"      "--without-java"    "for java bindings"
 optional_depends "tcl"       ""                                      "--without-tcl"     "for tcl bindings"
 optional_depends "openssl"   ""                                      "--without-openssl" "for openssl support"

--- a/libs/assimp/DEPENDS
+++ b/libs/assimp/DEPENDS
@@ -3,4 +3,4 @@ depends boost
 depends devil
 depends cmake
 
-optional_depends Python-2 "" " " "for pyassimp"
+optional_depends python2 "" " " "for pyassimp"

--- a/libs/assimp/DEPENDS
+++ b/libs/assimp/DEPENDS
@@ -2,3 +2,5 @@ depends unzip
 depends boost
 depends devil
 depends cmake
+
+optional_depends Python-2 "" " " "for pyassimp"

--- a/libs/boost/DEPENDS
+++ b/libs/boost/DEPENDS
@@ -4,6 +4,6 @@ depends icu4c
 depends bzip2
 depends zlib
 
-optional_depends Python-2 \
+optional_depends python2 \
                  "" "--without-python" \
                  "to build the Boost Python 2 bindings"

--- a/libs/boost/DEPENDS
+++ b/libs/boost/DEPENDS
@@ -4,6 +4,6 @@ depends icu4c
 depends bzip2
 depends zlib
 
-optional_depends Python \
+optional_depends Python-2 \
                  "" "--without-python" \
-                 "to build the Boost Python bindings"
+                 "to build the Boost Python 2 bindings"

--- a/libs/cmark/DEPENDS
+++ b/libs/cmark/DEPENDS
@@ -1,2 +1,2 @@
-depends Python
+depends Python-2
 depends cmake

--- a/libs/cmark/DEPENDS
+++ b/libs/cmark/DEPENDS
@@ -1,2 +1,2 @@
-depends Python-2
+depends python2
 depends cmake

--- a/libs/flann/DEPENDS
+++ b/libs/flann/DEPENDS
@@ -1,3 +1,3 @@
 depends ImageMagick
 depends cmake
-depends Python
+depends Python-2

--- a/libs/flann/DEPENDS
+++ b/libs/flann/DEPENDS
@@ -1,3 +1,3 @@
 depends ImageMagick
 depends cmake
-depends Python-2
+depends python2

--- a/libs/gdal/DEPENDS
+++ b/libs/gdal/DEPENDS
@@ -1,4 +1,4 @@
-depends Python
+depends Python-2
 
 optional_depends cryptopp "--with-cryptopp" "--without-cryptopp" "for crypto support" n
 optional_depends xz      "--with-liblzma" "--without-liblzma" "for xz support"

--- a/libs/gdal/DEPENDS
+++ b/libs/gdal/DEPENDS
@@ -1,4 +1,4 @@
-depends Python-2
+depends python2
 
 optional_depends cryptopp "--with-cryptopp" "--without-cryptopp" "for crypto support" n
 optional_depends xz      "--with-liblzma" "--without-liblzma" "for xz support"

--- a/libs/gtk-vnc/DEPENDS
+++ b/libs/gtk-vnc/DEPENDS
@@ -1,4 +1,4 @@
-depends Python
+depends Python-2
 depends libgcrypt
 depends gnutls
 depends gtk+-3

--- a/libs/gtk-vnc/DEPENDS
+++ b/libs/gtk-vnc/DEPENDS
@@ -1,4 +1,4 @@
-depends Python-2
+depends python2
 depends libgcrypt
 depends gnutls
 depends gtk+-3

--- a/libs/jsoncpp/DEPENDS
+++ b/libs/jsoncpp/DEPENDS
@@ -1,2 +1,2 @@
-depends Python
+depends Python-2
 depends cmake

--- a/libs/jsoncpp/DEPENDS
+++ b/libs/jsoncpp/DEPENDS
@@ -1,2 +1,2 @@
-depends Python-2
+depends python2
 depends cmake

--- a/libs/lcms/DEPENDS
+++ b/libs/lcms/DEPENDS
@@ -12,7 +12,7 @@ optional_depends "tiff"                 \
                  "--without-tiff"       \
                  "for TIFF support"
 
-optional_depends "Python-2"               \
+optional_depends "python2"               \
                  "--with-python"        \
                  "--without-python"     \
                  "for python 2 extension"

--- a/libs/lcms/DEPENDS
+++ b/libs/lcms/DEPENDS
@@ -12,7 +12,7 @@ optional_depends "tiff"                 \
                  "--without-tiff"       \
                  "for TIFF support"
 
-optional_depends "Python"               \
+optional_depends "Python-2"               \
                  "--with-python"        \
                  "--without-python"     \
-                 "for python extension"
+                 "for python 2 extension"

--- a/libs/lcms2/DEPENDS
+++ b/libs/lcms2/DEPENDS
@@ -1,4 +1,4 @@
-depends Python-2
+depends python2
 
 optional_depends tiff  "--with-tiff" "--without-tiff" "for tiff support"
 optional_depends %JPEG "--with-jpeg" "--without-jpeg" "for jpeg support"

--- a/libs/lcms2/DEPENDS
+++ b/libs/lcms2/DEPENDS
@@ -1,4 +1,4 @@
-depends Python
+depends Python-2
 
 optional_depends tiff  "--with-tiff" "--without-tiff" "for tiff support"
 optional_depends %JPEG "--with-jpeg" "--without-jpeg" "for jpeg support"

--- a/libs/libaccounts-glib/DEPENDS
+++ b/libs/libaccounts-glib/DEPENDS
@@ -1,2 +1,2 @@
-optional_depends "Python"                "--enable-python"        "--disable-python"        "for Python bindings support"
+optional_depends "Python-2"                "--enable-python"        "--disable-python"        "for Python 2 bindings support"
 optional_depends "gobject-introspection" "--enable-introspection" "--disable-introspection" "for introspection support"

--- a/libs/libaccounts-glib/DEPENDS
+++ b/libs/libaccounts-glib/DEPENDS
@@ -1,2 +1,2 @@
-optional_depends "Python-2"                "--enable-python"        "--disable-python"        "for Python 2 bindings support"
+optional_depends "python2"                "--enable-python"        "--disable-python"        "for Python 2 bindings support"
 optional_depends "gobject-introspection" "--enable-introspection" "--disable-introspection" "for introspection support"

--- a/libs/libcap-ng/DEPENDS
+++ b/libs/libcap-ng/DEPENDS
@@ -1,2 +1,2 @@
-optional_depends Python-2 "--with-python"  "--without-python"  "for Python 2.x bindings support"
+optional_depends python2 "--with-python"  "--without-python"  "for Python 2.x bindings support"
 optional_depends Python-3 "--with-python3" "--without-python3" "for Python 3.x bindings support"

--- a/libs/libcap-ng/DEPENDS
+++ b/libs/libcap-ng/DEPENDS
@@ -1,2 +1,2 @@
-optional_depends Python   "--with-python"  "--without-python"  "for Python 2.x bindings support"
+optional_depends Python-2 "--with-python"  "--without-python"  "for Python 2.x bindings support"
 optional_depends Python-3 "--with-python3" "--without-python3" "for Python 3.x bindings support"

--- a/libs/libieee1284/DEPENDS
+++ b/libs/libieee1284/DEPENDS
@@ -1,1 +1,1 @@
-depends Python
+depends Python-2

--- a/libs/libieee1284/DEPENDS
+++ b/libs/libieee1284/DEPENDS
@@ -1,1 +1,1 @@
-depends Python-2
+depends python2

--- a/libs/libiptcdata/DEPENDS
+++ b/libs/libiptcdata/DEPENDS
@@ -1,1 +1,1 @@
-optional_depends Python-2 "--enable-python" "--disable-python" "For python 2 bindings support"
+optional_depends python2 "--enable-python" "--disable-python" "For python 2 bindings support"

--- a/libs/libiptcdata/DEPENDS
+++ b/libs/libiptcdata/DEPENDS
@@ -1,1 +1,1 @@
-optional_depends Python "--enable-python" "--disable-python" "For python bindings support"
+optional_depends Python-2 "--enable-python" "--disable-python" "For python 2 bindings support"

--- a/libs/libproxy/DEPENDS
+++ b/libs/libproxy/DEPENDS
@@ -1,10 +1,10 @@
 depends vala
 depends cmake
 
-optional_depends Python \
+optional_depends Python-2 \
                  "-DWITH_PYTHON=1" \
                  "-DWITH_PYTHON=0" \
-                 "for the Python bindings"
+                 "for the Python 2 bindings"
 
 optional_depends perl \
                  "-DWITH_PERL=1" \

--- a/libs/libproxy/DEPENDS
+++ b/libs/libproxy/DEPENDS
@@ -1,7 +1,7 @@
 depends vala
 depends cmake
 
-optional_depends Python-2 \
+optional_depends python2 \
                  "-DWITH_PYTHON=1" \
                  "-DWITH_PYTHON=0" \
                  "for the Python 2 bindings"

--- a/libs/libpst/DEPENDS
+++ b/libs/libpst/DEPENDS
@@ -1,4 +1,4 @@
 depends libgsf
 
-optional_depends Python-2 "--enable-python"     "--disable-python"       "for python 2 bindings support" n
+optional_depends python2 "--enable-python"     "--disable-python"       "for python 2 bindings support" n
 optional_depends boost  "--with-boost-python" "--without-boost-python" "for boost support" n

--- a/libs/libpst/DEPENDS
+++ b/libs/libpst/DEPENDS
@@ -1,4 +1,4 @@
 depends libgsf
 
-optional_depends Python "--enable-python"     "--disable-python"       "for python bindings support" n
+optional_depends Python-2 "--enable-python"     "--disable-python"       "for python 2 bindings support" n
 optional_depends boost  "--with-boost-python" "--without-boost-python" "for boost support" n

--- a/libs/libxml2/DEPENDS
+++ b/libs/libxml2/DEPENDS
@@ -2,4 +2,4 @@ depends zlib
 
 optional_depends icu4c  "--with-icu" "--without-icu" "for ICU support"
 
-optional_depends Python-2 "" "" "to build Python 2 bindings (required for gnome2)"
+optional_depends python2 "" "" "to build Python 2 bindings (required for gnome2)"

--- a/libs/libxml2/DEPENDS
+++ b/libs/libxml2/DEPENDS
@@ -2,4 +2,4 @@ depends zlib
 
 optional_depends icu4c  "--with-icu" "--without-icu" "for ICU support"
 
-optional_depends Python "" "" "to build Python bindings (required for gnome2)"
+optional_depends Python-2 "" "" "to build Python 2 bindings (required for gnome2)"

--- a/libs/lilv/BUILD
+++ b/libs/lilv/BUILD
@@ -1,13 +1,12 @@
 sed -i "/ldconfig/d" wscript &&
 
-python waf configure --prefix=/usr    \
-                     --no-bash-completion \
+python2 waf configure --prefix=/usr    \
                      --configdir=/etc \
                      --dyn-manifest \
                      --bindings &&
 
-python waf build ${MAKES:+-j${MAKES}} &&
+python2 waf build ${MAKES:+-j${MAKES}} &&
 
 prepare_install &&
 
-python waf install 
+python2 waf install

--- a/libs/ming/DEPENDS
+++ b/libs/ming/DEPENDS
@@ -5,7 +5,7 @@ depends libpng
 depends %PKGCONF
 
 optional_depends freetype2 "--enable-freetype" "--disable-freetype" "for freetype font support"
-optional_depends Python    "--enable-python"   "--disable-python"   "for Python script support"
+optional_depends Python-2  "--enable-python"   "--disable-python"   "for Python 2 script support"
 optional_depends perl      "--enable-perl"     "--disable-perl"     "for perl scripting support"
 optional_depends %PHP      "--enable-php"      "--disable-php"      "for PHP scripting support"
 optional_depends tcl       "--enable-tcl"      "--disable-tcl"      "for tcl scripting support"

--- a/libs/ming/DEPENDS
+++ b/libs/ming/DEPENDS
@@ -5,7 +5,7 @@ depends libpng
 depends %PKGCONF
 
 optional_depends freetype2 "--enable-freetype" "--disable-freetype" "for freetype font support"
-optional_depends Python-2  "--enable-python"   "--disable-python"   "for Python 2 script support"
+optional_depends python2  "--enable-python"   "--disable-python"   "for Python 2 script support"
 optional_depends perl      "--enable-perl"     "--disable-perl"     "for perl scripting support"
 optional_depends %PHP      "--enable-php"      "--disable-php"      "for PHP scripting support"
 optional_depends tcl       "--enable-tcl"      "--disable-tcl"      "for tcl scripting support"

--- a/libs/newt/DEPENDS
+++ b/libs/newt/DEPENDS
@@ -1,5 +1,5 @@
 depends popt
 depends slang
 
-optional_depends Python "--with-python" "--without-python" "for Python support"
+optional_depends Python-2 "--with-python" "--without-python" "for Python 2 support"
 optional_depends tcl    "--with-tcl"    "--without-tcl"    "for tcl support"

--- a/libs/newt/DEPENDS
+++ b/libs/newt/DEPENDS
@@ -1,5 +1,5 @@
 depends popt
 depends slang
 
-optional_depends Python-2 "--with-python" "--without-python" "for Python 2 support"
+optional_depends python2 "--with-python" "--without-python" "for Python 2 support"
 optional_depends tcl    "--with-tcl"    "--without-tcl"    "for tcl support"

--- a/libs/reportlab/BUILD
+++ b/libs/reportlab/BUILD
@@ -1,4 +1,4 @@
 
-  python setup.py build &&
+  python2 setup.py build &&
         prepare_install &&
-  python setup.py install --root=/
+  python2 setup.py install --root=/

--- a/libs/reportlab/DEPENDS
+++ b/libs/reportlab/DEPENDS
@@ -1,4 +1,4 @@
 depends zlib
-depends Python-2
+depends python2
 depends Pillow
 depends pip

--- a/libs/reportlab/DEPENDS
+++ b/libs/reportlab/DEPENDS
@@ -1,4 +1,4 @@
 depends zlib
-depends Python
+depends Python-2
 depends Pillow
 depends pip

--- a/libs/serd/BUILD
+++ b/libs/serd/BUILD
@@ -1,10 +1,10 @@
 sed -i "/ldconfig/d" wscript &&
 
-python ./waf configure --prefix=/usr \
+python2 ./waf configure --prefix=/usr \
                         --mandir=/usr/share/man
 
-python ./waf build &&
+python2 ./waf build &&
 
 prepare_install &&
 
-python ./waf install
+python2 ./waf install

--- a/libs/serd/DEPENDS
+++ b/libs/serd/DEPENDS
@@ -1,1 +1,1 @@
-depends Python
+depends Python-2

--- a/libs/serd/DEPENDS
+++ b/libs/serd/DEPENDS
@@ -1,1 +1,1 @@
-depends Python-2
+depends python2

--- a/libs/sord/BUILD
+++ b/libs/sord/BUILD
@@ -1,8 +1,8 @@
 sed -i "/ldconfig/d" wscript &&
 
-python waf configure --prefix=/usr &&
-python waf build ${MAKES:+-j${MAKES}} &&
+python2 waf configure --prefix=/usr &&
+python2 waf build ${MAKES:+-j${MAKES}} &&
 
 prepare_install &&
 
-python waf install 
+python2 waf install

--- a/libs/sord/DEPENDS
+++ b/libs/sord/DEPENDS
@@ -1,3 +1,3 @@
-depends Python-2
+depends python2
 depends pcre
 depends serd

--- a/libs/sord/DEPENDS
+++ b/libs/sord/DEPENDS
@@ -1,3 +1,3 @@
-depends Python
+depends Python-2
 depends pcre
 depends serd

--- a/libs/sratom/BUILD
+++ b/libs/sratom/BUILD
@@ -1,8 +1,8 @@
 sed -i "/ldconfig/d" wscript &&
 
-python waf configure --prefix=/usr &&
-python waf build ${MAKES:+-j${MAKES}} &&
+python2 waf configure --prefix=/usr &&
+python2 waf build ${MAKES:+-j${MAKES}} &&
 
 prepare_install &&
 
-python waf install 
+python2 waf install

--- a/libs/sratom/DEPENDS
+++ b/libs/sratom/DEPENDS
@@ -1,3 +1,3 @@
-depends Python-2
+depends python2
 depends sord
 depends lv2

--- a/libs/sratom/DEPENDS
+++ b/libs/sratom/DEPENDS
@@ -1,3 +1,3 @@
-depends Python
+depends Python-2
 depends sord
 depends lv2

--- a/libs/zbar/DEPENDS
+++ b/libs/zbar/DEPENDS
@@ -1,5 +1,5 @@
 optional_depends "%JPEG"       "--with-jpeg"        "--without-jpeg"        "support JPEG conversion"
 optional_depends "ImageMagick" "--with-imagemagick" "--without-imagemagick" "support scanning images using ImageMagick"
-optional_depends "Python"      "--with-python"      "--without-python"      "build python bindings"
+optional_depends "Python-2"      "--with-python"      "--without-python"      "build python 2 bindings"
 optional_depends "pygtk"       "--with-gtk"         "--without-gtk"         "build GTK+2 widget"
 optional_depends "qt4"         "--with-qt"          "--without-qt"          "build Qt4 widget (needed by merkaartor)"

--- a/libs/zbar/DEPENDS
+++ b/libs/zbar/DEPENDS
@@ -1,5 +1,5 @@
 optional_depends "%JPEG"       "--with-jpeg"        "--without-jpeg"        "support JPEG conversion"
 optional_depends "ImageMagick" "--with-imagemagick" "--without-imagemagick" "support scanning images using ImageMagick"
-optional_depends "Python-2"      "--with-python"      "--without-python"      "build python 2 bindings"
+optional_depends "python2"      "--with-python"      "--without-python"      "build python 2 bindings"
 optional_depends "pygtk"       "--with-gtk"         "--without-gtk"         "build GTK+2 widget"
 optional_depends "qt4"         "--with-qt"          "--without-qt"          "build Qt4 widget (needed by merkaartor)"

--- a/mail/dovecot/systemd.d/dovecot.service
+++ b/mail/dovecot/systemd.d/dovecot.service
@@ -4,9 +4,8 @@ After=local-fs.target network.target
 
 [Service]
 Type=simple
-ExecStart=/usr/bin/dovecot -F
+ExecStart=/usr/sbin/dovecot -F
 NonBlocking=yes
 
 [Install]
 WantedBy=multi-user.target
-

--- a/mail/fetchmail/DEPENDS
+++ b/mail/fetchmail/DEPENDS
@@ -1,4 +1,4 @@
 depends bison
 
 optional_depends "%OSSL"   "--with-ssl=/usr" "--without-ssl" "for SSL/TLS support"
-optional_depends "Python"  ""                ""              "for fetchmailconf support"
+optional_depends "Python-2"  ""                ""              "for fetchmailconf support"

--- a/mail/fetchmail/DEPENDS
+++ b/mail/fetchmail/DEPENDS
@@ -1,4 +1,4 @@
 depends bison
 
 optional_depends "%OSSL"   "--with-ssl=/usr" "--without-ssl" "for SSL/TLS support"
-optional_depends "Python-2"  ""                ""              "for fetchmailconf support"
+optional_depends "python2"  ""                ""              "for fetchmailconf support"

--- a/mail/mailman/BUILD
+++ b/mail/mailman/BUILD
@@ -10,7 +10,7 @@
               --with-var-prefix=/var/mailman   \
               --with-username=mailman          \
               --with-groupname=mailman         \
-              --with-python=/usr/bin/python    \
+              --with-python=/usr/bin/python2   \
               --with-mail-gid=$MAIL_GID        \
               --with-cgi-gid=$MAILMAN_GID     &&
               

--- a/mail/thunderbird/DEPENDS
+++ b/mail/thunderbird/DEPENDS
@@ -5,7 +5,7 @@ depends unzip
 depends libvpx
 depends libffi
 depends icu4c
-depends Python
+depends Python-2
 depends hicolor-icon-theme
 depends libevent
 depends hunspell

--- a/mail/thunderbird/DEPENDS
+++ b/mail/thunderbird/DEPENDS
@@ -5,7 +5,7 @@ depends unzip
 depends libvpx
 depends libffi
 depends icu4c
-depends Python-2
+depends python2
 depends hicolor-icon-theme
 depends libevent
 depends hunspell

--- a/net/libpgm/DEPENDS
+++ b/net/libpgm/DEPENDS
@@ -1,1 +1,1 @@
-depends Python
+depends Python-2

--- a/net/libpgm/DEPENDS
+++ b/net/libpgm/DEPENDS
@@ -1,1 +1,1 @@
-depends Python-2
+depends python2

--- a/net/netatalk/DEPENDS
+++ b/net/netatalk/DEPENDS
@@ -2,7 +2,7 @@ depends db
 depends libevent
 depends libgcrypt
 depends dbus-glib
-depends Python
+depends Python-2
 
 optional_depends tdb       "--with-tdb"        "--without-tdb"      "For tbd support,${PROBLEM_COLOR}No equals using system tdb${DEFAULT_COLOR}" n
 optional_depends avahi     "--enable-zeroconf" "--disable-zeroconf" "For zeroconf support"

--- a/net/netatalk/DEPENDS
+++ b/net/netatalk/DEPENDS
@@ -2,7 +2,7 @@ depends db
 depends libevent
 depends libgcrypt
 depends dbus-glib
-depends Python-2
+depends python2
 
 optional_depends tdb       "--with-tdb"        "--without-tdb"      "For tbd support,${PROBLEM_COLOR}No equals using system tdb${DEFAULT_COLOR}" n
 optional_depends avahi     "--enable-zeroconf" "--disable-zeroconf" "For zeroconf support"

--- a/net/obexftp/DEPENDS
+++ b/net/obexftp/DEPENDS
@@ -3,6 +3,6 @@ depends swig
 depends openobex
 
 optional_depends perl   "-DENABLE_PERL=1"   "-DENABLE_PERL=0"   "for perl bindings support"
-optional_depends Python-2 "-DENABLE_PYTHON=1" "-DENABLE_PYTHON=0" "for python 2 bindings support"
+optional_depends python2 "-DENABLE_PYTHON=1" "-DENABLE_PYTHON=0" "for python 2 bindings support"
 optional_depends ruby   "-DENABLE_RUBY=1"   "-DENABLE_RUBY=0"   "for ruby bindings support"
 optional_depends tcl    "-DENABLE_TCL=1"    "-DENABLE_TCL=0"    "for tcl support"

--- a/net/obexftp/DEPENDS
+++ b/net/obexftp/DEPENDS
@@ -3,6 +3,6 @@ depends swig
 depends openobex
 
 optional_depends perl   "-DENABLE_PERL=1"   "-DENABLE_PERL=0"   "for perl bindings support"
-optional_depends Python "-DENABLE_PYTHON=1" "-DENABLE_PYTHON=0" "for python bindings support"
+optional_depends Python-2 "-DENABLE_PYTHON=1" "-DENABLE_PYTHON=0" "for python 2 bindings support"
 optional_depends ruby   "-DENABLE_RUBY=1"   "-DENABLE_RUBY=0"   "for ruby bindings support"
 optional_depends tcl    "-DENABLE_TCL=1"    "-DENABLE_TCL=0"    "for tcl support"

--- a/net/openconnect/DEPENDS
+++ b/net/openconnect/DEPENDS
@@ -1,6 +1,6 @@
 depends zlib
 depends libxml2
 depends libproxy
-depends Python
+depends Python-2
 
 optional_depends %OSSL "--with-openssl" "--without-openssl" "for Secure Sockets Layer support"

--- a/net/openconnect/DEPENDS
+++ b/net/openconnect/DEPENDS
@@ -1,6 +1,6 @@
 depends zlib
 depends libxml2
 depends libproxy
-depends Python-2
+depends python2
 
 optional_depends %OSSL "--with-openssl" "--without-openssl" "for Secure Sockets Layer support"

--- a/net/rabbitmq-server/DEPENDS
+++ b/net/rabbitmq-server/DEPENDS
@@ -1,5 +1,5 @@
 depends erlang
-depends Python
+depends Python-2
 depends xmlto
 depends libxslt
 depends logrotate

--- a/net/rabbitmq-server/DEPENDS
+++ b/net/rabbitmq-server/DEPENDS
@@ -1,5 +1,5 @@
 depends erlang
-depends Python-2
+depends python2
 depends xmlto
 depends libxslt
 depends logrotate

--- a/net/samba/DEPENDS
+++ b/net/samba/DEPENDS
@@ -1,4 +1,4 @@
-depends Python
+depends Python-2
 depends ncurses
 depends readline
 depends popt

--- a/net/samba/DEPENDS
+++ b/net/samba/DEPENDS
@@ -1,4 +1,4 @@
-depends Python-2
+depends python2
 depends ncurses
 depends readline
 depends popt

--- a/printer/cups/DEPENDS
+++ b/printer/cups/DEPENDS
@@ -20,7 +20,7 @@ optional_depends libusb    "--enable-libusb"   "--disable-libusb"   "for usb dev
 optional_depends %JAVA_SDK "--with-java"       "--without-java"     "for Java interpreter web interfaces"
 optional_depends perl      "--with-perl"       "--without-perl"     "for Perl interpreter web interfaces"
 optional_depends %PHP      "--with-php"        "--without-php"      "for PHP interpreter web interfaces"
-optional_depends Python    "--with-python"     "--without-python"   "for Python interpreter web interfaces"
+optional_depends Python-2  "--with-python"     "--without-python"   "for Python 2 interpreter web interfaces"
 optional_depends heimdal   "--enable-gssapi"   "--disable-gssapi"   "for Heimdal support"
 optional_depends avahi     "--enable-avahi"    "--disable-avahi"    "for avahi support"
 optional_depends xinetd    "--with-xinetd"     "--without-xinetd"   "for xinetd support"

--- a/printer/cups/DEPENDS
+++ b/printer/cups/DEPENDS
@@ -20,7 +20,7 @@ optional_depends libusb    "--enable-libusb"   "--disable-libusb"   "for usb dev
 optional_depends %JAVA_SDK "--with-java"       "--without-java"     "for Java interpreter web interfaces"
 optional_depends perl      "--with-perl"       "--without-perl"     "for Perl interpreter web interfaces"
 optional_depends %PHP      "--with-php"        "--without-php"      "for PHP interpreter web interfaces"
-optional_depends Python-2  "--with-python"     "--without-python"   "for Python 2 interpreter web interfaces"
+optional_depends python2  "--with-python"     "--without-python"   "for Python 2 interpreter web interfaces"
 optional_depends heimdal   "--enable-gssapi"   "--disable-gssapi"   "for Heimdal support"
 optional_depends avahi     "--enable-avahi"    "--disable-avahi"    "for avahi support"
 optional_depends xinetd    "--with-xinetd"     "--without-xinetd"   "for xinetd support"

--- a/python/M2Crypto/BUILD
+++ b/python/M2Crypto/BUILD
@@ -5,6 +5,6 @@ prepare_install &&
 python3 setup.py install --root=/ &&
 
 if module_installed setuptools; then
-  python setup.py config &&
-  python setup.py install --root=/
+  python2 setup.py config &&
+  python2 setup.py install --root=/
 fi

--- a/python/Mako/BUILD
+++ b/python/Mako/BUILD
@@ -6,6 +6,6 @@ python3 setup.py install --root=/ &&
 
 # Do the Python2 part if installed
 if module_installed setuptools; then
-  python setup.py build &&
-  python setup.py install --root=/
+  python2 setup.py build &&
+  python2 setup.py install --root=/
 fi

--- a/python/MarkupSafe/BUILD
+++ b/python/MarkupSafe/BUILD
@@ -5,6 +5,6 @@ prepare_install &&
 python3 setup.py install --skip-build --optimize=1 --root=/ &&
 
 if module_installed setuptools; then
-  python setup.py build &&
-  python setup.py install --skip-build --optimize=1 --root=/
+  python2 setup.py build &&
+  python2 setup.py install --skip-build --optimize=1 --root=/
 fi

--- a/python/MySQL-python/BUILD
+++ b/python/MySQL-python/BUILD
@@ -1,3 +1,3 @@
 prepare_install &&
 
-python setup.py install
+python2 setup.py install

--- a/python/MySQL-python/DEPENDS
+++ b/python/MySQL-python/DEPENDS
@@ -1,3 +1,3 @@
-depends Python
+depends Python-2
 depends setuptools
 depends mariadb

--- a/python/MySQL-python/DEPENDS
+++ b/python/MySQL-python/DEPENDS
@@ -1,3 +1,3 @@
-depends Python-2
+depends python2
 depends setuptools
 depends mariadb

--- a/python/OWSLib/BUILD
+++ b/python/OWSLib/BUILD
@@ -3,6 +3,6 @@ prepare_install &&
 python3 setup.py install --root=/ --optimize=1
 
 if in_depends $MODULE Python ; then
-  python setup.py install --root=/ --optimize=1
+  python2 setup.py install --root=/ --optimize=1
 fi
 

--- a/python/OWSLib/DEPENDS
+++ b/python/OWSLib/DEPENDS
@@ -1,3 +1,3 @@
 depends Python-3
 
-optional_depends Python "" "" "for python 2 support"
+optional_depends Python-2 "" "" "for python 2 support"

--- a/python/OWSLib/DEPENDS
+++ b/python/OWSLib/DEPENDS
@@ -1,3 +1,3 @@
 depends Python-3
 
-optional_depends Python-2 "" "" "for python 2 support"
+optional_depends python2 "" "" "for python 2 support"

--- a/python/Pillow/BUILD
+++ b/python/Pillow/BUILD
@@ -5,6 +5,6 @@ prepare_install &&
 python3 setup.py install --root=/ &&
 
 if module_installed setuptools; then
-  python setup.py config &&
-  python setup.py install --root=/
+  python2 setup.py config &&
+  python2 setup.py install --root=/
 fi

--- a/python/PyBluez/BUILD
+++ b/python/PyBluez/BUILD
@@ -1,5 +1,5 @@
-python setup.py build &&
+python2 setup.py build &&
 
 prepare_install &&
 
-python setup.py install
+python2 setup.py install

--- a/python/PyBluez/DEPENDS
+++ b/python/PyBluez/DEPENDS
@@ -1,2 +1,2 @@
-depends Python
+depends Python-2
 depends %BLUEZ

--- a/python/PyBluez/DEPENDS
+++ b/python/PyBluez/DEPENDS
@@ -1,2 +1,2 @@
-depends Python-2
+depends python2
 depends %BLUEZ

--- a/python/PyPDF2/BUILD
+++ b/python/PyPDF2/BUILD
@@ -1,5 +1,5 @@
-python setup.py config &&
+python2 setup.py config &&
 
 prepare_install &&
 
-python setup.py install
+python2 setup.py install

--- a/python/PyPDF2/DEPENDS
+++ b/python/PyPDF2/DEPENDS
@@ -1,2 +1,2 @@
-depends Python-2
+depends python2
 

--- a/python/PyPDF2/DEPENDS
+++ b/python/PyPDF2/DEPENDS
@@ -1,2 +1,2 @@
-depends Python
+depends Python-2
 

--- a/python/PySide/BUILD
+++ b/python/PySide/BUILD
@@ -1,5 +1,5 @@
-python setup.py build &&
+python2 setup.py build &&
 
 prepare_install &&
 
-python setup.py install
+python2 setup.py install

--- a/python/PySide/DEPENDS
+++ b/python/PySide/DEPENDS
@@ -1,4 +1,4 @@
-depends Python
+depends Python-2
 depends setuptools
 depends qt4
 depends cmake

--- a/python/PySide/DEPENDS
+++ b/python/PySide/DEPENDS
@@ -1,4 +1,4 @@
-depends Python-2
+depends python2
 depends setuptools
 depends qt4
 depends cmake

--- a/python/PyXML/BUILD
+++ b/python/PyXML/BUILD
@@ -1,3 +1,3 @@
 prepare_install &&
 
-python setup.py install --root=/ --optimize=1
+python2 setup.py install --root=/ --optimize=1

--- a/python/PyXML/DEPENDS
+++ b/python/PyXML/DEPENDS
@@ -1,1 +1,1 @@
-depends Python
+depends Python-2

--- a/python/PyXML/DEPENDS
+++ b/python/PyXML/DEPENDS
@@ -1,1 +1,1 @@
-depends Python-2
+depends python2

--- a/python/PyYAML/BUILD
+++ b/python/PyYAML/BUILD
@@ -6,6 +6,6 @@ python3 setup.py install --optimize=1 &&
 
 # Now for Python2
 if module_installed setuptools; then
-  python setup.py build &&
-  python setup.py install --optimize=1
+  python2 setup.py build &&
+  python2 setup.py install --optimize=1
 fi

--- a/python/Pygments/BUILD
+++ b/python/Pygments/BUILD
@@ -5,6 +5,6 @@ prepare_install &&
 python3 setup.py install --root=/ &&
 
 if module_installed Python; then
-  python setup.py config &&
-  python setup.py install --root=/
+  python2 setup.py config &&
+  python2 setup.py install --root=/
 fi

--- a/python/Pyrex/BUILD
+++ b/python/Pyrex/BUILD
@@ -1,5 +1,5 @@
-python ./setup.py build &&
+python2 ./setup.py build &&
 
 prepare_install &&
 
-python ./setup.py install
+python2 ./setup.py install

--- a/python/Pyrex/DEPENDS
+++ b/python/Pyrex/DEPENDS
@@ -1,1 +1,1 @@
-depends Python
+depends Python-2

--- a/python/Pyrex/DEPENDS
+++ b/python/Pyrex/DEPENDS
@@ -1,1 +1,1 @@
-depends Python-2
+depends python2

--- a/python/SOAPpy/BUILD
+++ b/python/SOAPpy/BUILD
@@ -1,5 +1,5 @@
-python setup.py build &&
+python2 setup.py build &&
 
 prepare_install &&
 
-python setup.py install
+python2 setup.py install

--- a/python/SQLAlchemy/BUILD
+++ b/python/SQLAlchemy/BUILD
@@ -5,6 +5,6 @@ prepare_install &&
 python3 setup.py install --root=/ &&
 
 if module_installed setuptools; then
-  python setup.py config &&
-  python setup.py install --root=/
+  python2 setup.py config &&
+  python2 setup.py install --root=/
 fi

--- a/python/Sphinx/BUILD
+++ b/python/Sphinx/BUILD
@@ -5,6 +5,6 @@ prepare_install &&
 python3 setup.py install --root=/ &&
 
 if module_installed setuptools; then
-  python setup.py build &&
-  python setup.py install --root=/
+  python2 setup.py build &&
+  python2 setup.py install --root=/
 fi

--- a/python/alabaster/BUILD
+++ b/python/alabaster/BUILD
@@ -1,5 +1,5 @@
-python setup.py build &&
+python2 setup.py build &&
 
 prepare_install &&
 
-python setup.py install --root=/
+python2 setup.py install --root=/

--- a/python/alabaster/DEPENDS
+++ b/python/alabaster/DEPENDS
@@ -1,2 +1,2 @@
-depends Python-2
+depends python2
 

--- a/python/alabaster/DEPENDS
+++ b/python/alabaster/DEPENDS
@@ -1,2 +1,2 @@
-depends Python
+depends Python-2
 

--- a/python/apsw/BUILD
+++ b/python/apsw/BUILD
@@ -1,6 +1,5 @@
-python setup.py build &&
+python2 setup.py build &&
 
 prepare_install &&
 
-python setup.py install --root=/
-
+python2 setup.py install --root=/

--- a/python/apsw/DEPENDS
+++ b/python/apsw/DEPENDS
@@ -1,2 +1,2 @@
-depends Python
+depends Python-2
 depends sqlite

--- a/python/apsw/DEPENDS
+++ b/python/apsw/DEPENDS
@@ -1,2 +1,2 @@
-depends Python-2
+depends python2
 depends sqlite

--- a/python/babel/BUILD
+++ b/python/babel/BUILD
@@ -1,6 +1,6 @@
-python setup.py build &&
-python setup.py import_cldr &&
+python2 setup.py build &&
+python2 setup.py import_cldr &&
 
 prepare_install &&
 
-python setup.py install --root=/
+python2 setup.py install --root=/

--- a/python/beautifulsoup4/BUILD
+++ b/python/beautifulsoup4/BUILD
@@ -1,3 +1,3 @@
 prepare_install &&
 
-python setup.py install
+python2 setup.py install

--- a/python/cffi/BUILD
+++ b/python/cffi/BUILD
@@ -7,6 +7,6 @@ python3 setup.py install --root=/ --optimize=1 &&
 
 # Python2 build
 if module_installed setuptools; then
-  python ./setup.py build &&
-  python setup.py install --root=/ --optimize=1
+  python2 ./setup.py build &&
+  python2 setup.py install --root=/ --optimize=1
 fi

--- a/python/chardet/BUILD
+++ b/python/chardet/BUILD
@@ -5,6 +5,6 @@ prepare_install &&
 python3 setup.py install --optimize=1
 
 if module_installed setuptools; then
-  python setup.py build &&
-  python setup.py install --optimize=1
+  python2 setup.py build &&
+  python2 setup.py install --optimize=1
 fi

--- a/python/cssselect/BUILD
+++ b/python/cssselect/BUILD
@@ -7,6 +7,6 @@ python3 setup.py install --root=/ &&
 
 # Python2 build
 if module_installed setuptools; then
-  python ./setup.py build &&
-  python setup.py install --root=/
+  python2 ./setup.py build &&
+  python2 setup.py install --root=/
 fi

--- a/python/cssutils/BUILD
+++ b/python/cssutils/BUILD
@@ -1,10 +1,3 @@
-
-python3 setup.py build &&
+python2 setup.py build &&
 prepare_install &&
-python3 setup.py install --root=/
-
-if in_depends $MODULE Python ; then
-  python setup.py build &&
-  prepare_install &&
-  python setup.py install --root=/
-fi
+python2 setup.py install --root=/

--- a/python/cssutils/DEPENDS
+++ b/python/cssutils/DEPENDS
@@ -1,3 +1,1 @@
-depends Python-3
-
-optional_depends Python "" "" "for python 2 support"
+depends Python-2

--- a/python/cssutils/DEPENDS
+++ b/python/cssutils/DEPENDS
@@ -1,1 +1,1 @@
-depends Python-2
+depends python2

--- a/python/cycler/BUILD
+++ b/python/cycler/BUILD
@@ -5,6 +5,6 @@ prepare_install &&
 python3 ./setup.py install --root=/ &&
 
 if module_installed setuptools; then
-  python ./setup.py build &&
-  python ./setup.py install --root=/
+  python2 ./setup.py build &&
+  python2 ./setup.py install --root=/
 fi

--- a/python/dbus-python/BUILD
+++ b/python/dbus-python/BUILD
@@ -2,7 +2,7 @@ prepare_install &&
 
 mkdir python2 &&
 pushd python2 &&
-PYTHON=/usr/bin/python ../configure --prefix=/usr PYTHON_VERSION=2 &&
+PYTHON=/usr/bin/python2 ../configure --prefix=/usr PYTHON_VERSION=2 &&
 make &&
 make python2 install
 popd

--- a/python/decorator/BUILD
+++ b/python/decorator/BUILD
@@ -1,3 +1,3 @@
 prepare_install &&
 
-python setup.py install --root=/
+python2 setup.py install --root=/

--- a/python/decorator/DEPENDS
+++ b/python/decorator/DEPENDS
@@ -1,1 +1,1 @@
-depends Python
+depends Python-2

--- a/python/decorator/DEPENDS
+++ b/python/decorator/DEPENDS
@@ -1,1 +1,1 @@
-depends Python-2
+depends python2

--- a/python/dnspython/BUILD
+++ b/python/dnspython/BUILD
@@ -1,6 +1,6 @@
 prepare_install &&
 
-python setup.py install --root=/ &&
+python2 setup.py install --root=/ &&
 
 if in_depends $MODULE Python-3 ; then
   python3 setup.py install --root=/

--- a/python/dnspython/DEPENDS
+++ b/python/dnspython/DEPENDS
@@ -1,3 +1,3 @@
-depends Python
+depends Python-2
 
 optional_depends Python-3 "" "" "For python 3 support"

--- a/python/dnspython/DEPENDS
+++ b/python/dnspython/DEPENDS
@@ -1,3 +1,3 @@
-depends Python-2
+depends python2
 
 optional_depends Python-3 "" "" "For python 3 support"

--- a/python/dot2tex/BUILD
+++ b/python/dot2tex/BUILD
@@ -1,3 +1,3 @@
 prepare_install &&
 
-python ./setup.py install
+python2 ./setup.py install

--- a/python/empy/BUILD
+++ b/python/empy/BUILD
@@ -5,5 +5,5 @@ prepare_install &&
 python3 setup.py install --optimize=1 &&
 
 if module_installed setuptools; then
-  python setup.py install --optimize=1
+  python2 setup.py install --optimize=1
 fi

--- a/python/fpconst/BUILD
+++ b/python/fpconst/BUILD
@@ -1,5 +1,5 @@
-python setup.py build &&
+python2 setup.py build &&
 
 prepare_install &&
 
-python setup.py install
+python2 setup.py install

--- a/python/fpconst/DEPENDS
+++ b/python/fpconst/DEPENDS
@@ -1,1 +1,1 @@
-depends Python
+depends Python-2

--- a/python/fpconst/DEPENDS
+++ b/python/fpconst/DEPENDS
@@ -1,1 +1,1 @@
-depends Python-2
+depends python2

--- a/python/gcalcli/BUILD
+++ b/python/gcalcli/BUILD
@@ -1,5 +1,5 @@
-python setup.py build_ext -i &&
+python2 setup.py build_ext -i &&
 
 prepare_install &&
 
-python setup.py install --root=/
+python2 setup.py install --root=/

--- a/python/google-api-python-client/BUILD
+++ b/python/google-api-python-client/BUILD
@@ -1,5 +1,5 @@
-python setup.py build_ext -i &&
+python2 setup.py build_ext -i &&
 
 prepare_install &&
 
-python setup.py install --root=/
+python2 setup.py install --root=/

--- a/python/html5-parser/BUILD
+++ b/python/html5-parser/BUILD
@@ -1,9 +1,4 @@
-python3 setup.py build &&
-prepare_install &&
-python3 setup.py install --root=/ &&
+python2 setup.py build &&
 
-if in_depends $MODULE Python ; then
-  python setup.py build &&
-  prepare_install &&
-  python setup.py install --root=/
-fi
+prepare_install &&
+python2 setup.py install --root=/

--- a/python/html5-parser/DEPENDS
+++ b/python/html5-parser/DEPENDS
@@ -1,4 +1,4 @@
-depends Python-3
+depends Python-2
 depends chardet
 depends lxml
 depends beautifulsoup4

--- a/python/html5-parser/DEPENDS
+++ b/python/html5-parser/DEPENDS
@@ -1,4 +1,4 @@
-depends Python-2
+depends python2
 depends chardet
 depends lxml
 depends beautifulsoup4

--- a/python/httplib2/BUILD
+++ b/python/httplib2/BUILD
@@ -1,11 +1,5 @@
-python3 setup.py build &&
+python2 setup.py build &&
 
 prepare_install &&
 
-python3 setup.py install --optimize=1 &&
-
-# Now for Python2
-if module_installed setuptools; then
-  python setup.py build &&
-  python setup.py install --optimize=1
-fi
+python2 setup.py install

--- a/python/httplib2/DEPENDS
+++ b/python/httplib2/DEPENDS
@@ -1,2 +1,2 @@
-depends Python
+depends Python-2
 depends setuptools

--- a/python/httplib2/DEPENDS
+++ b/python/httplib2/DEPENDS
@@ -1,2 +1,2 @@
-depends Python-2
+depends python2
 depends setuptools

--- a/python/imagesize/BUILD
+++ b/python/imagesize/BUILD
@@ -5,6 +5,6 @@ prepare_install &&
 python3 setup.py install --root=/ &&
 
 if module_install setuptools; then
-  python setup.py build &&
-  python setup.py install --root=/
+  python2 setup.py build &&
+  python2 setup.py install --root=/
 fi

--- a/python/ipython/BUILD
+++ b/python/ipython/BUILD
@@ -1,3 +1,3 @@
 prepare_install &&
 
-python setup.py install
+python2 setup.py install

--- a/python/ipython/DEPENDS
+++ b/python/ipython/DEPENDS
@@ -1,4 +1,4 @@
-depends Python-2
+depends python2
 depends sqlite
 depends setuptools
 depends pexpect

--- a/python/ipython/DEPENDS
+++ b/python/ipython/DEPENDS
@@ -1,4 +1,4 @@
-depends Python
+depends Python-2
 depends sqlite
 depends setuptools
 depends pexpect

--- a/python/isodate/BUILD
+++ b/python/isodate/BUILD
@@ -6,6 +6,6 @@ python3 setup.py install --root=/ &&
 
 # Do the Python2 part if installed
 if module_installed setuptools; then
-  python setup.py build &&
-  python setup.py install --root=/
+  python2 setup.py build &&
+  python2 setup.py install --root=/
 fi

--- a/python/isodate/DEPENDS
+++ b/python/isodate/DEPENDS
@@ -1,4 +1,4 @@
 depends Python-3
 depends setuptools-3
 
-optional_depends Python "" "" "For python2 support"
+optional_depends Python-2 "" "" "For python2 support"

--- a/python/isodate/DEPENDS
+++ b/python/isodate/DEPENDS
@@ -1,4 +1,4 @@
 depends Python-3
 depends setuptools-3
 
-optional_depends Python-2 "" "" "For python2 support"
+optional_depends python2 "" "" "For python2 support"

--- a/python/jinja/BUILD
+++ b/python/jinja/BUILD
@@ -7,6 +7,6 @@ python3 setup.py install --optimize=1 --root=/ &&
 
 # Can live side by side with the Python2 stuff
 if module_installed setuptools; then
-  python setup.py build &&
-  python setup.py install --optimize=1 --root=/
+  python2 setup.py build &&
+  python2 setup.py install --optimize=1 --root=/
 fi

--- a/python/kitchen/BUILD
+++ b/python/kitchen/BUILD
@@ -6,6 +6,6 @@ python3 setup.py install --root=/ &&
 
 # Do the Python2 part if installed
 if module_installed setuptools; then
-  python setup.py build &&
-  python setup.py install --root=/
+  python2 setup.py build &&
+  python2 setup.py install --root=/
 fi

--- a/python/ldap3/BUILD
+++ b/python/ldap3/BUILD
@@ -5,6 +5,6 @@ prepare_install &&
 python3 setup.py install --skip-build --optimize=1 --root=/ &&
 
 if module_installed setuptools; then
-  python setup.py build &&
-  python setup.py install --skip-build --optimize=1 --root=/
+  python2 setup.py build &&
+  python2 setup.py install --skip-build --optimize=1 --root=/
 fi

--- a/python/libnacl/BUILD
+++ b/python/libnacl/BUILD
@@ -5,6 +5,6 @@ prepare_install &&
 python3 setup.py install --root=/ &&
 
 if module_installed setuptools; then
-  python ./setup.py build &&
-  python setup.py install --root=/
+  python2 ./setup.py build &&
+  python2 setup.py install --root=/
 fi

--- a/python/lxml/BUILD
+++ b/python/lxml/BUILD
@@ -5,6 +5,6 @@ prepare_install &&
 python3 setup.py install --skip-build --optimize=1 --root=/ &&
 
 if module_installed setuptools; then
-  python setup.py build &&
-  python setup.py install --skip-build --optimize=1 --root=/
+  python2 setup.py build &&
+  python2 setup.py install --skip-build --optimize=1 --root=/
 fi

--- a/python/matplotlib/BUILD
+++ b/python/matplotlib/BUILD
@@ -5,6 +5,6 @@ prepare_install &&
 python3 ./setup.py install --root=/ &&
 
 if module_installed setuptools; then
-  python ./setup.py build &&
-  python ./setup.py install --root=/
+  python2 ./setup.py build &&
+  python2 ./setup.py install --root=/
 fi

--- a/python/mechanize/BUILD
+++ b/python/mechanize/BUILD
@@ -1,9 +1,5 @@
-python3 setup.py build &&
-prepare_install &&
-python3 setup.py install --root=/
+python2 setup.py build &&
 
-if in_depends $MODULE Python ; then
-  python setup.py build &&
-  prepare_install &&
-  python setup.py install --root=/
-fi
+prepare_install &&
+
+python2 setup.py install --root=/

--- a/python/mechanize/DEPENDS
+++ b/python/mechanize/DEPENDS
@@ -1,3 +1,1 @@
-depends Python-3
-
-optional_depends Python "" "" "for python 2 support"
+depends Python-2

--- a/python/mechanize/DEPENDS
+++ b/python/mechanize/DEPENDS
@@ -1,1 +1,1 @@
-depends Python-2
+depends python2

--- a/python/msgpack/BUILD
+++ b/python/msgpack/BUILD
@@ -1,5 +1,5 @@
-python setup.py build &&
+python2 setup.py build &&
 
 prepare_install &&
 
-python setup.py install --root=/
+python2 setup.py install --root=/

--- a/python/msgpack/DEPENDS
+++ b/python/msgpack/DEPENDS
@@ -1,3 +1,3 @@
-depends Python-2
+depends python2
 depends Cython
 depends six

--- a/python/msgpack/DEPENDS
+++ b/python/msgpack/DEPENDS
@@ -1,3 +1,3 @@
-depends Python
+depends Python-2
 depends Cython
 depends six

--- a/python/netaddr/BUILD
+++ b/python/netaddr/BUILD
@@ -5,6 +5,6 @@ prepare_install &&
 python3 setup.py install --optimize=1
 
 if module_installed setuptools; then
-  python setup.py build &&
-  python setup.py install --optimize=1
+  python2 setup.py build &&
+  python2 setup.py install --optimize=1
 fi

--- a/python/netifaces/BUILD
+++ b/python/netifaces/BUILD
@@ -1,5 +1,5 @@
-python setup.py build &&
+python2 setup.py build &&
 
 prepare_install &&
 
-python setup.py install --root=/
+python2 setup.py install --root=/

--- a/python/nose/BUILD
+++ b/python/nose/BUILD
@@ -1,5 +1,5 @@
-python ./setup.py build &&
+python2 ./setup.py build &&
 
 prepare_install &&
 
-python setup.py install --root=/
+python2 setup.py install --root=/

--- a/python/nose/DEPENDS
+++ b/python/nose/DEPENDS
@@ -1,1 +1,1 @@
-depends Python
+depends Python-2

--- a/python/nose/DEPENDS
+++ b/python/nose/DEPENDS
@@ -1,1 +1,1 @@
-depends Python-2
+depends python2

--- a/python/numarray/BUILD
+++ b/python/numarray/BUILD
@@ -1,4 +1,4 @@
 prepare_install &&
 
-python setup.py install
+python2 setup.py install
 

--- a/python/numarray/DEPENDS
+++ b/python/numarray/DEPENDS
@@ -1,1 +1,1 @@
-depends Python
+depends Python-2

--- a/python/numarray/DEPENDS
+++ b/python/numarray/DEPENDS
@@ -1,1 +1,1 @@
-depends Python-2
+depends python2

--- a/python/numpy/BUILD
+++ b/python/numpy/BUILD
@@ -8,6 +8,6 @@ python3 setup.py install --root=/ &&
 
 # If installed do the Python2 install
 if module_installed setuptools; then
-  python setup.py build &&
-  python setup.py install --root=/
+  python2 setup.py build &&
+  python2 setup.py install --root=/
 fi

--- a/python/oauth2client/BUILD
+++ b/python/oauth2client/BUILD
@@ -1,5 +1,5 @@
-python setup.py build_ext -i &&
+python2 setup.py build_ext -i &&
 
 prepare_install &&
 
-python setup.py install --root=/
+python2 setup.py install --root=/

--- a/python/paramiko/BUILD
+++ b/python/paramiko/BUILD
@@ -5,6 +5,6 @@ prepare_install &&
 python3 setup.py install --optimize=1
 
 if module_installed setuptools; then
-  python setup.py build &&
-  python setup.py install --optimize=1
+  python2 setup.py build &&
+  python2 setup.py install --optimize=1
 fi

--- a/python/parsedatetime/BUILD
+++ b/python/parsedatetime/BUILD
@@ -1,5 +1,5 @@
-python setup.py build_ext -i &&
+python2 setup.py build_ext -i &&
 
 prepare_install&&
 
-python setup.py install --root=/
+python2 setup.py install --root=/

--- a/python/parsedatetime/PRE_BUILD
+++ b/python/parsedatetime/PRE_BUILD
@@ -1,4 +1,4 @@
 default_pre_build &&
 
 # get rid of the sedit when gcalcli's author fixes it
-sedit 's/from oauth2client.tools import run$/&_flow as run/' gcalcli
+# sedit 's/from oauth2client.tools import run$/&_flow as run/' gcalcli

--- a/python/path.py/BUILD
+++ b/python/path.py/BUILD
@@ -1,3 +1,3 @@
 prepare_install &&
 
-python setup.py install --root=/
+python2 setup.py install --root=/

--- a/python/path.py/DEPENDS
+++ b/python/path.py/DEPENDS
@@ -1,1 +1,1 @@
-depends Python
+depends Python-2

--- a/python/path.py/DEPENDS
+++ b/python/path.py/DEPENDS
@@ -1,1 +1,1 @@
-depends Python-2
+depends python2

--- a/python/pexpect/BUILD
+++ b/python/pexpect/BUILD
@@ -1,3 +1,3 @@
 prepare_install &&
 
-python setup.py install
+python2 setup.py install

--- a/python/pexpect/DEPENDS
+++ b/python/pexpect/DEPENDS
@@ -1,1 +1,1 @@
-depends Python
+depends Python-2

--- a/python/pexpect/DEPENDS
+++ b/python/pexpect/DEPENDS
@@ -1,1 +1,1 @@
-depends Python-2
+depends python2

--- a/python/pickleshare/BUILD
+++ b/python/pickleshare/BUILD
@@ -1,3 +1,3 @@
 prepare_install &&
 
-python setup.py install --root=/
+python2 setup.py install --root=/

--- a/python/pip/BUILD
+++ b/python/pip/BUILD
@@ -6,7 +6,7 @@ python3 setup.py install --root=/ &&
 
 # Do the Python2 part if installed
 if module_installed setuptools; then
-  python setup.py build &&
+  python2 setup.py build &&
   prepare_install &&
-  python setup.py install --root=/
+  python2 setup.py install --root=/
 fi

--- a/python/ply/BUILD
+++ b/python/ply/BUILD
@@ -7,6 +7,6 @@ python3 setup.py install --root=/
 
 # Do Python2 build
 if module_installed setuptools; then
-  python ./setup.py build &&
-  python setup.py install --root=/
+  python2 ./setup.py build &&
+  python2 setup.py install --root=/
 fi

--- a/python/powerline/BUILD
+++ b/python/powerline/BUILD
@@ -5,8 +5,8 @@ prepare_install &&
 python3 setup.py install --install-data=usr --install-scripts=usr/bin --optimize=1 --root=/ &&
 
 if module_installed setuptools; then
-  python setup.py build &&
-  python setup.py install --install-data=usr --install-scripts=usr/bin --optimize=1 --root=/
+  python2 setup.py build &&
+  python2 setup.py install --install-data=usr --install-scripts=usr/bin --optimize=1 --root=/
 fi &&
 
 install -dm755 /etc/fonts/conf.d &&

--- a/python/psycopg2/BUILD
+++ b/python/psycopg2/BUILD
@@ -6,7 +6,7 @@ python3 setup.py install --root=/ &&
 
 # Do the Python2 part if installed
 if module_installed setuptools; then
-  python setup.py build &&
+  python2 setup.py build &&
   prepare_install &&
-  python setup.py install --root=/
+  python2 setup.py install --root=/
 fi

--- a/python/pyPEG2/BUILD
+++ b/python/pyPEG2/BUILD
@@ -1,3 +1,3 @@
 prepare_install &&
 
-python setup.py install --optimize=1
+python2 setup.py install --optimize=1

--- a/python/pyPEG2/DEPENDS
+++ b/python/pyPEG2/DEPENDS
@@ -1,1 +1,1 @@
-depends Python
+depends Python-2

--- a/python/pyPEG2/DEPENDS
+++ b/python/pyPEG2/DEPENDS
@@ -1,1 +1,1 @@
-depends Python-2
+depends python2

--- a/python/pyasn1/BUILD
+++ b/python/pyasn1/BUILD
@@ -6,6 +6,6 @@ python3 setup.py install --optimize=1 &&
 
 # Now for Python2
 if module_installed setuptools; then
-  python setup.py build &&
-  python setup.py install --optimize=1
+  python2 setup.py build &&
+  python2 setup.py install --optimize=1
 fi

--- a/python/pyasn1/DEPENDS
+++ b/python/pyasn1/DEPENDS
@@ -1,2 +1,2 @@
-depends Python
+depends Python-2
 depends setuptools

--- a/python/pyasn1/DEPENDS
+++ b/python/pyasn1/DEPENDS
@@ -1,2 +1,2 @@
-depends Python-2
+depends python2
 depends setuptools

--- a/python/pybluez/BUILD
+++ b/python/pybluez/BUILD
@@ -5,6 +5,6 @@ prepare_install &&
 python3 setup.py install --optimize=1 &&
 
 if module_installed setuptools; then
-  python setup.py build &&
-  python setup.py install --optimize=1
+  python2 setup.py build &&
+  python2 setup.py install --optimize=1
 fi

--- a/python/pycairo/BUILD
+++ b/python/pycairo/BUILD
@@ -6,6 +6,6 @@ python3 setup.py install --root=/ &&
 
 # If installed do the Python2 install
 if in_depends $MODULE setuptools; then
-  python setup.py build &&
-  python setup.py install --root=/
+  python2 setup.py build &&
+  python2 setup.py install --root=/
 fi

--- a/python/pycairo/DEPENDS
+++ b/python/pycairo/DEPENDS
@@ -1,4 +1,4 @@
 depends six
 depends cairo
 
-optional_depends setuptools "" " " "install for Python-2"
+optional_depends setuptools "" " " "install for python2"

--- a/python/pycparser/BUILD
+++ b/python/pycparser/BUILD
@@ -2,10 +2,10 @@ prepare_install &&
 
 # Do Python2 build
 if module_installed setuptools; then
-  python ./setup.py build &&
+  python2 ./setup.py build &&
 
   pushd pycparser &&
-  python _build_tables.py &&
+  python2 _build_tables.py &&
   popd &&
 
   python setup.py install --root=/ --optimize=1

--- a/python/pycrypto/BUILD
+++ b/python/pycrypto/BUILD
@@ -1,5 +1,5 @@
-python setup.py build &&
+python2 setup.py build &&
 
 prepare_install &&
 
-python setup.py install
+python2 setup.py install

--- a/python/pycrypto/DEPENDS
+++ b/python/pycrypto/DEPENDS
@@ -1,2 +1,2 @@
-depends Python-2
+depends python2
 depends gmp

--- a/python/pycrypto/DEPENDS
+++ b/python/pycrypto/DEPENDS
@@ -1,2 +1,2 @@
-depends Python
+depends Python-2
 depends gmp

--- a/python/pycups/BUILD
+++ b/python/pycups/BUILD
@@ -1,5 +1,5 @@
-python setup.py build &&
+python2 setup.py build &&
 
 prepare_install &&
 
-python setup.py install --root=/
+python2 setup.py install --root=/

--- a/python/pycups/DEPENDS
+++ b/python/pycups/DEPENDS
@@ -1,2 +1,2 @@
-depends Python
+depends Python-2
 depends cups

--- a/python/pycups/DEPENDS
+++ b/python/pycups/DEPENDS
@@ -1,2 +1,2 @@
-depends Python-2
+depends python2
 depends cups

--- a/python/pycurl/BUILD
+++ b/python/pycurl/BUILD
@@ -4,8 +4,8 @@ fi &&
 
 make &&
 
-python setup.py build $OPTS &&
+python2 setup.py build $OPTS &&
 
 prepare_install &&
 
-python setup.py install
+python2 setup.py install

--- a/python/pycurl/DEPENDS
+++ b/python/pycurl/DEPENDS
@@ -1,4 +1,4 @@
-depends Python-2
+depends python2
 depends curl
 
 optional_depends %OSSL  "--with-ssl"    "" "for SSL support ${PROBLEM_COLOR}(Choose only openssl OR gnutls OR nss, the same as curl)" y

--- a/python/pycurl/DEPENDS
+++ b/python/pycurl/DEPENDS
@@ -1,4 +1,4 @@
-depends Python
+depends Python-2
 depends curl
 
 optional_depends %OSSL  "--with-ssl"    "" "for SSL support ${PROBLEM_COLOR}(Choose only openssl OR gnutls OR nss, the same as curl)" y

--- a/python/pydot/BUILD
+++ b/python/pydot/BUILD
@@ -1,3 +1,3 @@
 prepare_install &&
 
-python ./setup.py install
+python2 ./setup.py install

--- a/python/pyfits/BUILD
+++ b/python/pyfits/BUILD
@@ -6,6 +6,6 @@ python3 setup.py install --root=/ &&
 
 # Do the Python2 part if installed
 if module_installed setuptools; then
-  python setup.py build &&
-  python setup.py install --root=/
+  python2 setup.py build &&
+  python2 setup.py install --root=/
 fi

--- a/python/pygame/BUILD
+++ b/python/pygame/BUILD
@@ -1,9 +1,9 @@
 if in_depends $MODULE Sphinx; then
-  python ./makeref.py
+  python2 ./makeref.py
 fi &&
 
-python setup.py build &&
+python2 setup.py build &&
 
 prepare_install &&
 
-python setup.py install --root=/
+python2 setup.py install --root=/

--- a/python/pygame/PRE_BUILD
+++ b/python/pygame/PRE_BUILD
@@ -3,7 +3,7 @@ mk_source_dir &&
 cd $SOURCE_DIRECTORY &&
 tar -x --strip-components=1 -f $SOURCE_CACHE/$SOURCE &&
 
-yes | python config.py &&
+yes | python2 config.py &&
 
 #linux removed v4l1 support -> camera is broken
 #see e.g. http://lists.fedoraproject.org/pipermail/devel/2011-February/148519.html

--- a/python/pygit2/BUILD
+++ b/python/pygit2/BUILD
@@ -6,6 +6,6 @@ python3 setup.py install --root=/ &&
 
 # Do the Python2 part if installed
 if module_installed setuptools; then
-  python setup.py build &&
-  python setup.py install --root=/
+  python2 setup.py build &&
+  python2 setup.py install --root=/
 fi

--- a/python/pyicqt/BUILD
+++ b/python/pyicqt/BUILD
@@ -25,5 +25,5 @@ import re
 compileall.compile_dir('$python_dir', rx=re.compile('/[.]svn'), force=True)
 EOF
 
-python /tmp/$$-compileall.py &&
+python2 /tmp/$$-compileall.py &&
 rm -f /tmp/$$-compileall.py

--- a/python/pyicqt/init.d/pyicqt
+++ b/python/pyicqt/init.d/pyicqt
@@ -9,7 +9,7 @@
 
 start ()
 {
-    python /usr/lib/python2.5/site-packages/pyicq-t/pyicqt.py -c /etc/jabber/pyicqt.xml -b
+    python2 /usr/lib/python2.5/site-packages/pyicq-t/pyicqt.py -c /etc/jabber/pyicqt.xml -b
 }
 
 stop ()

--- a/python/pyinotify/BUILD
+++ b/python/pyinotify/BUILD
@@ -1,5 +1,5 @@
-python setup.py build &&
+python2 setup.py build &&
 
 prepare_install &&
 
-python setup.py install --root=/
+python2 setup.py install --root=/

--- a/python/pyinotify/DEPENDS
+++ b/python/pyinotify/DEPENDS
@@ -1,1 +1,1 @@
-depends Python
+depends Python-2

--- a/python/pyinotify/DEPENDS
+++ b/python/pyinotify/DEPENDS
@@ -1,1 +1,1 @@
-depends Python-2
+depends python2

--- a/python/pymsnt/BUILD
+++ b/python/pymsnt/BUILD
@@ -15,5 +15,5 @@ import re
 compileall.compile_dir('/usr/lib/pymsnt', rx=re.compile('/[.]svn'), force=True)
 EOF
 
-python /tmp/$$-compileall.py &&
+python2 /tmp/$$-compileall.py &&
 rm -f /tmp/$$-compileall.py

--- a/python/pymsnt/init.d/pymsnt
+++ b/python/pymsnt/init.d/pymsnt
@@ -10,7 +10,7 @@ start ()
 {
   echo -n "Starting pymsnt jabber transport: "
   cd /usr/lib/pymsnt &&
-  exec python ./PyMSNt.py -c /etc/jabber/pymsnt.xml &> /dev/null &
+  exec python2 ./PyMSNt.py -c /etc/jabber/pymsnt.xml &> /dev/null &
   if [ $? -eq 0 ]; then
     echo -e "$RESULT_OK"
   else

--- a/python/pymsnt/systemd.d/pymsnt.service
+++ b/python/pymsnt/systemd.d/pymsnt.service
@@ -5,7 +5,7 @@ After=network.target ejabberd.service
 [Service]
 Type=forking
 PIDFile=/var/run/pymsnt.pid
-ExecStart=/usr/bin/python /usr/lib/pymsnt/PyMSNt.py -c /etc/jabber/pymsnt.xml
+ExecStart=/usr/bin/python2 /usr/lib/pymsnt/PyMSNt.py -c /etc/jabber/pymsnt.xml
 
 [Install]
 WantedBy=multi-user.target

--- a/python/pyopenssl/BUILD
+++ b/python/pyopenssl/BUILD
@@ -1,11 +1,5 @@
-python3 setup.py build &&
+python2 setup.py build &&
 
 prepare_install &&
 
-python3 setup.py install --root=/ &&
-
-# Do the Python2 part if installed
-if module_installed setuptools; then
-  python setup.py build &&
-  python setup.py install --root=/
-fi
+python2 ./setup.py install --root=/

--- a/python/pyparsing/BUILD
+++ b/python/pyparsing/BUILD
@@ -6,6 +6,6 @@ python3 setup.py install --root=/ &&
 
 # Do the Python2 part if installed
 if module_installed setuptools; then
-  python setup.py build &&
-  python setup.py install --root=/
+  python2 setup.py build &&
+  python2 setup.py install --root=/
 fi

--- a/python/python-dateutil/BUILD
+++ b/python/python-dateutil/BUILD
@@ -6,6 +6,6 @@ python3 setup.py install --root=/ &&
 
 # Do the Python2 part if installed
 if module_installed setuptools; then
-  python setup.py build &&
-  python setup.py install --root=/
+  python2 setup.py build &&
+  python2 setup.py install --root=/
 fi

--- a/python/python-distutils-extra/BUILD
+++ b/python/python-distutils-extra/BUILD
@@ -6,6 +6,6 @@ python3 setup.py install --root=/ &&
 
 # Do the Python2 part if installed
 if module_installed setuptools; then
-  python setup.py build &&
-  python setup.py install --root=/
+  python2 setup.py build &&
+  python2 setup.py install --root=/
 fi

--- a/python/python-gflags/BUILD
+++ b/python/python-gflags/BUILD
@@ -1,5 +1,5 @@
-python setup.py build_ext -i &&
+python2 setup.py build_ext -i &&
 
 prepare_install &&
 
-python setup.py install --root=/
+python2 setup.py install --root=/

--- a/python/python-poppler-qt5/BUILD
+++ b/python/python-poppler-qt5/BUILD
@@ -6,4 +6,4 @@ CXXFLAGS+=" -std=c++11" &&
 
 prepare_install &&
 
-python setup.py install --prefix=/usr --root=/
+python2 setup.py install --prefix=/usr --root=/

--- a/python/python-slip/BUILD
+++ b/python/python-slip/BUILD
@@ -10,6 +10,6 @@ python3 setup.py install --root=/ &&
 
 # If installed do the Python2 install
 if module_installed setuptools; then
-  python setup.py build &&
-  python setup.py install --root=/
+  python2 setup.py build &&
+  python2 setup.py install --root=/
 fi

--- a/python/python2-ipaddr/BUILD
+++ b/python/python2-ipaddr/BUILD
@@ -1,5 +1,5 @@
-python setup.py build &&
+python2 setup.py build &&
 
 prepare_install &&
 
-python setup.py install
+python2 setup.py install

--- a/python/python2-ipaddr/DEPENDS
+++ b/python/python2-ipaddr/DEPENDS
@@ -1,2 +1,2 @@
-depends Python
+depends Python-2
 depends setuptools

--- a/python/python2-ipaddr/DEPENDS
+++ b/python/python2-ipaddr/DEPENDS
@@ -1,2 +1,2 @@
-depends Python-2
+depends python2
 depends setuptools

--- a/python/python2-ipy/BUILD
+++ b/python/python2-ipy/BUILD
@@ -1,3 +1,3 @@
 prepare_install &&
 
-python setup.py install --prefix=/usr
+python2 setup.py install --prefix=/usr

--- a/python/python2-ipy/DEPENDS
+++ b/python/python2-ipy/DEPENDS
@@ -1,1 +1,1 @@
-depends Python
+depends Python-2

--- a/python/python2-ipy/DEPENDS
+++ b/python/python2-ipy/DEPENDS
@@ -1,1 +1,1 @@
-depends Python-2
+depends python2

--- a/python/python2-rsa/BUILD
+++ b/python/python2-rsa/BUILD
@@ -1,5 +1,5 @@
-python setup.py build_ext -i &&
+python2 setup.py build_ext -i &&
 
 prepare_install &&
 
-python setup.py install --root=/
+python2 setup.py install --root=/

--- a/python/python2-typing/BUILD
+++ b/python/python2-typing/BUILD
@@ -1,5 +1,5 @@
-python setup.py build &&
+python2 setup.py build &&
 
 prepare_install &&
 
-python setup.py install --optimize=1
+python2 setup.py install --optimize=1

--- a/python/pytz/BUILD
+++ b/python/pytz/BUILD
@@ -5,7 +5,7 @@ prepare_install &&
 python3 setup.py install --root=/
 
 if in_depends $MODULE Python ; then
-  python setup.py build &&
+  python2 setup.py build &&
   prepare_install &&
-  python setup.py install --root=/
+  python2 setup.py install --root=/
 fi

--- a/python/pytz/DEPENDS
+++ b/python/pytz/DEPENDS
@@ -1,3 +1,3 @@
 depends Python-3
 
-optional_depends Python-2 "" "" "For python2 support"
+optional_depends python2 "" "" "For python2 support"

--- a/python/pytz/DEPENDS
+++ b/python/pytz/DEPENDS
@@ -1,3 +1,3 @@
 depends Python-3
 
-optional_depends Python "" "" "For python2 support"
+optional_depends Python-2 "" "" "For python2 support"

--- a/python/pyusb/BUILD
+++ b/python/pyusb/BUILD
@@ -1,5 +1,5 @@
-python setup.py build &&
+python2 setup.py build &&
 
 prepare_install &&
 
-python setup.py install
+python2 setup.py install

--- a/python/pyusb/DEPENDS
+++ b/python/pyusb/DEPENDS
@@ -1,2 +1,2 @@
-depends Python-2
+depends python2
 depends libusb

--- a/python/pyusb/DEPENDS
+++ b/python/pyusb/DEPENDS
@@ -1,2 +1,2 @@
-depends Python
+depends Python-2
 depends libusb

--- a/python/pyxdg/BUILD
+++ b/python/pyxdg/BUILD
@@ -6,6 +6,6 @@ python3 setup.py install --root=/ &&
 
 # Do the Python2 part if installed
 if module_installed setuptools; then
-  python setup.py build &&
-  python setup.py install --root=/
+  python2 setup.py build &&
+  python2 setup.py install --root=/
 fi

--- a/python/pyzmq/BUILD
+++ b/python/pyzmq/BUILD
@@ -1,3 +1,3 @@
 prepare_install &&
 
-python ./setup.py install --root=/
+python2 ./setup.py install --root=/

--- a/python/rdflib/BUILD
+++ b/python/rdflib/BUILD
@@ -6,6 +6,6 @@ python3 setup.py install --root=/ &&
 
 # Do the Python2 part if installed
 if module_installed setuptools; then
-  python setup.py build &&
-  python setup.py install --root=/
+  python2 setup.py build &&
+  python2 setup.py install --root=/
 fi

--- a/python/regex/BUILD
+++ b/python/regex/BUILD
@@ -1,5 +1,5 @@
-python setup.py build &&
+python2 setup.py build &&
 
 prepare_install &&
 
-python setup.py install --root=/
+python2 setup.py install --root=/

--- a/python/regex/DEPENDS
+++ b/python/regex/DEPENDS
@@ -1,2 +1,2 @@
-depends Python-2
+depends python2
 

--- a/python/regex/DEPENDS
+++ b/python/regex/DEPENDS
@@ -1,2 +1,2 @@
-depends Python
+depends Python-2
 

--- a/python/requests/BUILD
+++ b/python/requests/BUILD
@@ -5,6 +5,6 @@ prepare_install &&
 python3 setup.py install --optimize=1
 
 if module_installed setuptools; then
-  python setup.py build &&
-  python setup.py install --optimize=1
+  python2 setup.py build &&
+  python2 setup.py install --optimize=1
 fi

--- a/python/scikit/BUILD
+++ b/python/scikit/BUILD
@@ -5,6 +5,6 @@ prepare_install &&
 python3 setup.py install --optimize=1 &&
 
 if module_installed setuptools; then
-  python setup.py build &&
-  python setup.py install --optimize=1
+  python2 setup.py build &&
+  python2 setup.py install --optimize=1
 fi

--- a/python/scipy/BUILD
+++ b/python/scipy/BUILD
@@ -8,6 +8,6 @@ python3 setup.py install --root=/ &&
 
 # Do the Python2 part if installed
 if module_installed setuptools; then
-  python setup.py build &&
-  python setup.py install --root=/
+  python2 setup.py build &&
+  python2 setup.py install --root=/
 fi

--- a/python/setconf/DEPENDS
+++ b/python/setconf/DEPENDS
@@ -1,1 +1,1 @@
-depends Python
+depends Python-2

--- a/python/setconf/DEPENDS
+++ b/python/setconf/DEPENDS
@@ -1,1 +1,1 @@
-depends Python-2
+depends python2

--- a/python/setuptools/BUILD
+++ b/python/setuptools/BUILD
@@ -1,5 +1,5 @@
-python setup.py build &&
+python2 setup.py build &&
 
 prepare_install &&
 
-python setup.py install --optimize=1
+python2 setup.py install --optimize=1

--- a/python/setuptools/DEPENDS
+++ b/python/setuptools/DEPENDS
@@ -1,2 +1,2 @@
-depends Python
+depends Python-2
 depends six

--- a/python/setuptools/DEPENDS
+++ b/python/setuptools/DEPENDS
@@ -1,2 +1,2 @@
-depends Python-2
+depends python2
 depends six

--- a/python/simplegeneric/BUILD
+++ b/python/simplegeneric/BUILD
@@ -1,3 +1,3 @@
 prepare_install &&
 
-python setup.py install --root=/
+python2 setup.py install --root=/

--- a/python/simplegeneric/DEPENDS
+++ b/python/simplegeneric/DEPENDS
@@ -1,1 +1,1 @@
-depends Python
+depends Python-2

--- a/python/simplegeneric/DEPENDS
+++ b/python/simplegeneric/DEPENDS
@@ -1,1 +1,1 @@
-depends Python-2
+depends python2

--- a/python/simplejson/BUILD
+++ b/python/simplejson/BUILD
@@ -5,6 +5,6 @@ prepare_install &&
 python3 setup.py install --optimize=1
 
 if module_installed setuptools; then
-  python setup.py build &&
-  python setup.py install --optimize=1
+  python2 setup.py build &&
+  python2 setup.py install --optimize=1
 fi

--- a/python/six/DEPENDS
+++ b/python/six/DEPENDS
@@ -1,3 +1,3 @@
 depends Python-3
 
-optional_depends Python "" "" "for Python 2.x support"
+optional_depends Python-2 "" "" "for Python 2.x support"

--- a/python/six/DEPENDS
+++ b/python/six/DEPENDS
@@ -1,3 +1,3 @@
 depends Python-3
 
-optional_depends Python-2 "" "" "for Python 2.x support"
+optional_depends python2 "" "" "for Python 2.x support"

--- a/python/snowballstemmer/BUILD
+++ b/python/snowballstemmer/BUILD
@@ -5,6 +5,6 @@ prepare_install &&
 python3 setup.py install --optimize=1 &&
 
 if module_installed setuptools; then
-  python setup.py build &&
-  python setup.py install --optimize=1
+  python2 setup.py build &&
+  python2 setup.py install --optimize=1
 fi

--- a/python/sphinxcontrib-doxylink/BUILD
+++ b/python/sphinxcontrib-doxylink/BUILD
@@ -7,6 +7,6 @@ prepare_install &&
 python3 setup.py install --optimize=1 &&
 
 if module_installed setuptools; then
-  python setup.py build &&
-  python setup.py install --optimize=1
+  python2 setup.py build &&
+  python2 setup.py install --optimize=1
 fi

--- a/python/tornado/BUILD
+++ b/python/tornado/BUILD
@@ -5,6 +5,6 @@ prepare_install &&
 python3 setup.py install --optimize=1
 
 if module_installed setuptools; then
-  python setup.py build &&
-  python setup.py install --optimize=1
+  python2 setup.py build &&
+  python2 setup.py install --optimize=1
 fi

--- a/python/twisted/BUILD
+++ b/python/twisted/BUILD
@@ -5,6 +5,6 @@ prepare_install &&
 python3 setup.py install --optimize=1
 
 if module_installed setuptools; then
-  python setup.py build &&
-  python setup.py install --optimize=1
+  python2 setup.py build &&
+  python2 setup.py install --optimize=1
 fi

--- a/python/unidecode/BUILD
+++ b/python/unidecode/BUILD
@@ -5,6 +5,6 @@ prepare_install &&
 python3 setup.py install --root=/ &&
 
 if module_installed Python; then
-  python setup.py config &&
-  python setup.py install --root=/
+  python2 setup.py config &&
+  python2 setup.py install --root=/
 fi

--- a/python/uritemplate/BUILD
+++ b/python/uritemplate/BUILD
@@ -5,6 +5,6 @@ prepare_install &&
 python3 setup.py install --optimize=1 &&
 
 if module_installed setuptools; then
-  python setup.py build &&
-  python setup.py install --optimize=1
+  python2 setup.py build &&
+  python2 setup.py install --optimize=1
 fi

--- a/python/urlgrabber/BUILD
+++ b/python/urlgrabber/BUILD
@@ -1,3 +1,3 @@
 prepare_install &&
 
-python setup.py install --prefix=/usr --optimize=1
+python2 setup.py install --prefix=/usr --optimize=1

--- a/python/urwid/BUILD
+++ b/python/urwid/BUILD
@@ -5,6 +5,6 @@ prepare_install &&
 python3 setup.py install --optimize=1
 
 if module_installed setuptools; then
-  python setup.py build &&
-  python setup.py install --optimize=1
+  python2 setup.py build &&
+  python2 setup.py install --optimize=1
 fi

--- a/python/vcstools/BUILD
+++ b/python/vcstools/BUILD
@@ -5,6 +5,6 @@ prepare_install &&
 python3 setup.py install --optimize=1 &&
 
 if module_install setuptools; then
-  python setup.py build &&
-  python setup.py install --optimize=1
+  python2 setup.py build &&
+  python2 setup.py install --optimize=1
 fi

--- a/python/wxPython/BUILD
+++ b/python/wxPython/BUILD
@@ -2,7 +2,7 @@ cd $SOURCE_DIRECTORY/wxPython &&
 
 prepare_install &&
 
-python setup.py install WXPORT=gtk2 UNICODE=1 \
+python2 setup.py install WXPORT=gtk2 UNICODE=1 \
                         BUILD_GLCANVAS=0 \
                         WX_CONFIG=/usr/bin/wx-config
 

--- a/python/wxPython/DEPENDS
+++ b/python/wxPython/DEPENDS
@@ -1,2 +1,2 @@
-depends Python-2
+depends python2
 depends wxGTK

--- a/python/wxPython/DEPENDS
+++ b/python/wxPython/DEPENDS
@@ -1,2 +1,2 @@
-depends Python
+depends Python-2
 depends wxGTK

--- a/python/zope.interface/BUILD
+++ b/python/zope.interface/BUILD
@@ -5,6 +5,6 @@ prepare_install &&
 python3 setup.py install --install-scripts=zope --root=/ &&
 
 if module_installed setuptools; then
-  python setup.py config &&
-  python setup.py install --install-scripts=zope --root=/
+  python2 setup.py config &&
+  python2 setup.py install --install-scripts=zope --root=/
 fi

--- a/science/geos/DEPENDS
+++ b/science/geos/DEPENDS
@@ -1,4 +1,4 @@
 depends swig
-optional_depends "Python" "" "" "for python bindings support"
+optional_depends "Python-2" "" "" "for python 2 bindings support"
 optional_depends "ruby"   "" "" "for ruby bindings support"
 

--- a/science/geos/DEPENDS
+++ b/science/geos/DEPENDS
@@ -1,4 +1,4 @@
 depends swig
-optional_depends "Python-2" "" "" "for python 2 bindings support"
+optional_depends "python2" "" "" "for python 2 bindings support"
 optional_depends "ruby"   "" "" "for ruby bindings support"
 

--- a/science/gpsd/DEPENDS
+++ b/science/gpsd/DEPENDS
@@ -2,7 +2,7 @@ depends dbus
 depends ntp
 depends scons
 
-optional_depends "Python"        "python=yes" "python=no" "Python support and modules"
+optional_depends "Python-2"      "python=yes" "python=no" "Python 2 support and modules"
 optional_depends "ncurses"       "ncurses=yes" "ncurses=no" "for ncurses terminal support"
 optional_depends "%UDEV"         "" "" "for udev (hotplug) support"
 optional_depends "libusb-compat" "usb=yes" "usb=no" "for usb device support"

--- a/science/gpsd/DEPENDS
+++ b/science/gpsd/DEPENDS
@@ -2,7 +2,7 @@ depends dbus
 depends ntp
 depends scons
 
-optional_depends "Python-2"      "python=yes" "python=no" "Python 2 support and modules"
+optional_depends "python2"      "python=yes" "python=no" "Python 2 support and modules"
 optional_depends "ncurses"       "ncurses=yes" "ncurses=no" "for ncurses terminal support"
 optional_depends "%UDEV"         "" "" "for udev (hotplug) support"
 optional_depends "libusb-compat" "usb=yes" "usb=no" "for usb device support"

--- a/science/mapnik/BUILD
+++ b/science/mapnik/BUILD
@@ -2,7 +2,7 @@
 
  export JOBS=${MAKES} &&
 
-  PYTHON=python
+  PYTHON=python2
   scons configure \
     PREFIX="/usr" \
     INPUT_PLUGINS=all \

--- a/science/sphinx/sphinxbase/DEPENDS
+++ b/science/sphinx/sphinxbase/DEPENDS
@@ -1,7 +1,7 @@
 depends libsamplerate
 depends libsndfile
 
-optional_depends Python-2 "" "--without-python" "build Python 2 extension"
+optional_depends python2 "" "--without-python" "build Python 2 extension"
 optional_depends lapack "" "--without-lapack" "for matrix algebra support"
 optional_depends pulseaudio "" "" "PulseAudio support"
 optional_depends jack "" "" "JACK audio support"

--- a/science/sphinx/sphinxbase/DEPENDS
+++ b/science/sphinx/sphinxbase/DEPENDS
@@ -1,7 +1,7 @@
 depends libsamplerate
 depends libsndfile
 
-optional_depends Python "" "--without-python" "build Python extension"
+optional_depends Python-2 "" "--without-python" "build Python 2 extension"
 optional_depends lapack "" "--without-lapack" "for matrix algebra support"
 optional_depends pulseaudio "" "" "PulseAudio support"
 optional_depends jack "" "" "JACK audio support"

--- a/security/ecryptfs-utils/DEPENDS
+++ b/security/ecryptfs-utils/DEPENDS
@@ -1,4 +1,4 @@
-depends Python-2
+depends python2
 depends libgcrypt
 depends gpgme
 depends gettext

--- a/security/ecryptfs-utils/DEPENDS
+++ b/security/ecryptfs-utils/DEPENDS
@@ -1,4 +1,4 @@
-depends Python
+depends Python-2
 depends libgcrypt
 depends gpgme
 depends gettext

--- a/security/fail2ban/BUILD
+++ b/security/fail2ban/BUILD
@@ -1,8 +1,8 @@
-python setup.py build_ext -i &&
+python2 setup.py build_ext -i &&
 
 prepare_install &&
 
-python setup.py install --prefix /usr --optimize=1 &&
+python2 setup.py install --prefix /usr --optimize=1 &&
 
 for man in man/*.1 man/*.5; do
   install -Dm644 $man /usr/share/man/man${man##*.}/${man#*/}

--- a/security/ufw/DEPENDS
+++ b/security/ufw/DEPENDS
@@ -1,2 +1,2 @@
 depends iptables
-depends Python
+depends Python-2

--- a/security/ufw/DEPENDS
+++ b/security/ufw/DEPENDS
@@ -1,2 +1,2 @@
 depends iptables
-depends Python-2
+depends python2

--- a/sql/postgresql/DEPENDS
+++ b/sql/postgresql/DEPENDS
@@ -2,7 +2,7 @@ depends ncurses
 
 optional_depends %OSSL     "--with-openssl" "" "for SSL connections"
 optional_depends perl      "--with-perl"    "" "for perl programming"
-optional_depends Python-2  "--with-python"  "" "for python 2 programming"
+optional_depends python2  "--with-python"  "" "for python 2 programming"
 optional_depends Linux-PAM "--with-pam"     "" "for user authentication"
 optional_depends heimdal   "--with-gssapi"  "" "for gssapi support"
 optional_depends openldap  "--with-ldap"    "" "for ldap support"

--- a/sql/postgresql/DEPENDS
+++ b/sql/postgresql/DEPENDS
@@ -2,7 +2,7 @@ depends ncurses
 
 optional_depends %OSSL     "--with-openssl" "" "for SSL connections"
 optional_depends perl      "--with-perl"    "" "for perl programming"
-optional_depends Python    "--with-python"  "" "for python programming"
+optional_depends Python-2  "--with-python"  "" "for python 2 programming"
 optional_depends Linux-PAM "--with-pam"     "" "for user authentication"
 optional_depends heimdal   "--with-gssapi"  "" "for gssapi support"
 optional_depends openldap  "--with-ldap"    "" "for ldap support"

--- a/sql/virtuoso/DEPENDS
+++ b/sql/virtuoso/DEPENDS
@@ -7,7 +7,7 @@ depends libiodbc
 
 optional_depends perl        "--enable-perl"           "--disable-perl"        "for perl hosting support" y
 optional_depends libedit     "--with-editline"         "--with-editline=no"    "for editline support" y
-optional_depends Python-2    "--enable-python"         "--disable-python"      "for python 2 hosting support" y
+optional_depends python2    "--enable-python"         "--disable-python"      "for python 2 hosting support" y
 optional_depends ruby        "--enable-ruby"           "--disable-ruby"        "for ruby hosting support" y
 optional_depends ImageMagick "--enable-imagemagick"    "--disable-imagemagick" "for ImageMagick plugin" n
 optional_depends %PHP        "--enable-php5"           "--disable-php5 "       "for PHP extension support" n

--- a/sql/virtuoso/DEPENDS
+++ b/sql/virtuoso/DEPENDS
@@ -7,7 +7,7 @@ depends libiodbc
 
 optional_depends perl        "--enable-perl"           "--disable-perl"        "for perl hosting support" y
 optional_depends libedit     "--with-editline"         "--with-editline=no"    "for editline support" y
-optional_depends Python      "--enable-python"         "--disable-python"      "for python hosting support" y
+optional_depends Python-2    "--enable-python"         "--disable-python"      "for python 2 hosting support" y
 optional_depends ruby        "--enable-ruby"           "--disable-ruby"        "for ruby hosting support" y
 optional_depends ImageMagick "--enable-imagemagick"    "--disable-imagemagick" "for ImageMagick plugin" n
 optional_depends %PHP        "--enable-php5"           "--disable-php5 "       "for PHP extension support" n

--- a/utils/iotop/BUILD
+++ b/utils/iotop/BUILD
@@ -1,5 +1,5 @@
-python setup.py build &&
+python2 setup.py build &&
 
 prepare_install &&
 
-python setup.py install --optimize=1
+python2 setup.py install --optimize=1

--- a/utils/iotop/DEPENDS
+++ b/utils/iotop/DEPENDS
@@ -1,1 +1,1 @@
-depends Python
+depends Python-2

--- a/utils/iotop/DEPENDS
+++ b/utils/iotop/DEPENDS
@@ -1,1 +1,1 @@
-depends Python-2
+depends python2

--- a/utils/mailutils/DEPENDS
+++ b/utils/mailutils/DEPENDS
@@ -1,3 +1,3 @@
 depends ncurses
 
-optional_depends guile  "--with-guild"  "--without-guile"  "for Guile interface (unmaintained, so not recommended)" n
+optional_depends Python-2 "--with-python" "--without-python" "for python 2 interface"

--- a/utils/mailutils/DEPENDS
+++ b/utils/mailutils/DEPENDS
@@ -1,3 +1,3 @@
 depends ncurses
 
-optional_depends Python-2 "--with-python" "--without-python" "for python 2 interface"
+optional_depends python2 "--with-python" "--without-python" "for python 2 interface"

--- a/utils/pcsc-lite/DEPENDS
+++ b/utils/pcsc-lite/DEPENDS
@@ -1,3 +1,3 @@
 depends %PKGCONF
 depends systemd
-depends Python
+depends Python-2

--- a/utils/pcsc-lite/DEPENDS
+++ b/utils/pcsc-lite/DEPENDS
@@ -1,3 +1,3 @@
 depends %PKGCONF
 depends systemd
-depends Python-2
+depends python2

--- a/utils/pilot-link/DEPENDS
+++ b/utils/pilot-link/DEPENDS
@@ -1,6 +1,6 @@
 optional_depends "popt"        ""                   "--with-included-popt" "defaults to system popt"
 optional_depends "libpng"      "--with-libpng=/usr" "--without-libpng"     "Enables PNG userland support"
-optional_depends "Python"      "--with-python"      "--without-python"     "for Python scripting support"
+optional_depends "Python-2"    "--with-python"      "--without-python"     "for Python 2 scripting support"
 optional_depends "perl"        "--with-perl"        "--without-perl"       "for perl scripting support"
 
 optional_depends "tcl"         "--with-tcl=/usr/lib  --with-tclinclude=/usr/include"  \

--- a/utils/pilot-link/DEPENDS
+++ b/utils/pilot-link/DEPENDS
@@ -1,6 +1,6 @@
 optional_depends "popt"        ""                   "--with-included-popt" "defaults to system popt"
 optional_depends "libpng"      "--with-libpng=/usr" "--without-libpng"     "Enables PNG userland support"
-optional_depends "Python-2"    "--with-python"      "--without-python"     "for Python 2 scripting support"
+optional_depends "python2"    "--with-python"      "--without-python"     "for Python 2 scripting support"
 optional_depends "perl"        "--with-perl"        "--without-perl"       "for perl scripting support"
 
 optional_depends "tcl"         "--with-tcl=/usr/lib  --with-tclinclude=/usr/include"  \

--- a/utils/speedfreq/DEPENDS
+++ b/utils/speedfreq/DEPENDS
@@ -1,1 +1,1 @@
-depends Python
+depends Python-2

--- a/utils/speedfreq/DEPENDS
+++ b/utils/speedfreq/DEPENDS
@@ -1,1 +1,1 @@
-depends Python-2
+depends python2

--- a/utils/trash-cli/BUILD
+++ b/utils/trash-cli/BUILD
@@ -1,5 +1,5 @@
-python setup.py build &&
+python2 setup.py build &&
 
 prepare_install &&
 
-python setup.py install --optimize=1
+python2 setup.py install --optimize=1

--- a/utils/units/DEPENDS
+++ b/utils/units/DEPENDS
@@ -1,4 +1,4 @@
-depends Python
+depends Python-2
 depends readline
 
 optional_depends requests  "" "" "for live currency rates"

--- a/utils/units/DEPENDS
+++ b/utils/units/DEPENDS
@@ -1,4 +1,4 @@
-depends Python-2
+depends python2
 depends readline
 
 optional_depends requests  "" "" "for live currency rates"

--- a/video/libfreenect/DEPENDS
+++ b/video/libfreenect/DEPENDS
@@ -1,6 +1,6 @@
 depends cmake
 depends libusb
-depends Python-2
+depends python2
 
 depends mesa-lib
 depends freeglut

--- a/video/libfreenect/DEPENDS
+++ b/video/libfreenect/DEPENDS
@@ -1,6 +1,6 @@
 depends cmake
 depends libusb
-depends Python
+depends Python-2
 
 depends mesa-lib
 depends freeglut

--- a/video/oggconvert/BUILD
+++ b/video/oggconvert/BUILD
@@ -1,3 +1,3 @@
-python setup.py build  &&
-prepare_install        &&
-python setup.py install
+python2 setup.py build  &&
+prepare_install         &&
+python2 setup.py install

--- a/video/oggconvert/DEPENDS
+++ b/video/oggconvert/DEPENDS
@@ -1,4 +1,4 @@
-depends Python-2
+depends python2
 depends pygtk
 depends gst-python
 

--- a/video/oggconvert/DEPENDS
+++ b/video/oggconvert/DEPENDS
@@ -1,4 +1,4 @@
-depends Python
+depends Python-2
 depends pygtk
 depends gst-python
 

--- a/virtual/libvirt-glib/BUILD
+++ b/virtual/libvirt-glib/BUILD
@@ -1,3 +1,3 @@
-OPTS+=" --disable-static --with-python=/usr/bin/python" &&
+OPTS+=" --disable-static --with-python=/usr/bin/python2" &&
 
 default_build

--- a/virtual/libvirt-python/BUILD
+++ b/virtual/libvirt-python/BUILD
@@ -1,6 +1,6 @@
-python setup.py config &&
+python2 setup.py config &&
 prepare_install &&
-python setup.py install --root=/ &&
+python2 setup.py install --root=/ &&
 
 if in_depends $MODULE Python-3; then
   devoke_installwatch &&

--- a/virtual/libvirt/DEPENDS
+++ b/virtual/libvirt/DEPENDS
@@ -1,4 +1,4 @@
-depends Python
+depends Python-2
 depends iproute2
 depends iptables
 depends libxml2

--- a/virtual/libvirt/DEPENDS
+++ b/virtual/libvirt/DEPENDS
@@ -1,4 +1,4 @@
-depends Python-2
+depends python2
 depends iproute2
 depends iptables
 depends libxml2

--- a/virtual/lxc/DEPENDS
+++ b/virtual/lxc/DEPENDS
@@ -1,5 +1,5 @@
 depends perl
-depends Python-2
+depends python2
 depends libcap
 depends libseccomp
 depends rsync

--- a/virtual/lxc/DEPENDS
+++ b/virtual/lxc/DEPENDS
@@ -1,5 +1,5 @@
 depends perl
-depends Python
+depends Python-2
 depends libcap
 depends libseccomp
 depends rsync

--- a/virtual/virt-manager/BUILD
+++ b/virtual/virt-manager/BUILD
@@ -1,5 +1,5 @@
-python setup.py build &&
+python2 setup.py build &&
 
 prepare_install &&
 
-python setup.py --no-compile-schemas install
+python2 setup.py --no-compile-schemas install

--- a/web/grafana/DETAILS
+++ b/web/grafana/DETAILS
@@ -1,12 +1,12 @@
          MODULE=grafana
-        VERSION=2.1.3
+        VERSION=5.0.0
          COMMIT=7f6eccb5e2d0bc946cd4426405483f46f96ce814
          SOURCE=$MODULE-$VERSION.tar.gz
 SOURCE_URL_FULL=http://github.com/grafana/grafana/archive/v$VERSION.tar.gz
-     SOURCE_VFY=sha256:83414fadbbaeb938b69166f3079d54b65abf1e1f048c4c0b74ecda43f848cfdd
+     SOURCE_VFY=sha256:fe06eeef2d15c019ae777c6a27c6b392a3ccdfb0d63dead67e50f6ff2e34f881
        WEB_SITE=http://grafana.org/
         ENTERED=20150919
-        UPDATED=20150919
+        UPDATED=20180305
           SHORT="A general purpose dashboard and graph composer"
 
 cat <<EOF

--- a/web/node/DEPENDS
+++ b/web/node/DEPENDS
@@ -1,4 +1,4 @@
-depends Python-2
+depends python2
 depends procps
 depends c-ares
 

--- a/web/node/DEPENDS
+++ b/web/node/DEPENDS
@@ -1,4 +1,4 @@
-depends Python
+depends Python-2
 depends procps
 depends c-ares
 

--- a/web/seamonkey/DEPENDS
+++ b/web/seamonkey/DEPENDS
@@ -11,7 +11,7 @@ depends libvpx
 
 
 optional_depends "%FLASH"           ""  ""  "To enable Flash plugin"
-optional_depends "Python"           ""  ""  "Needed to do a Profile Guided Optimization build"
+optional_depends "Python-2"         ""  ""  "Needed to do a Profile Guided Optimization build"
 
 optional_depends "sqlite"           "--enable-system-sqlite"   "--disable-system-sqlite"   "Use system sqlite. ${PROBLEM_COLOR}Not recommended${DEFAULT_COLOR}"
 optional_depends "gnome-vfs"        "--enable-gnomevfs"        "--disable-gnomevfs"        "For Gnome VFS support"

--- a/web/seamonkey/DEPENDS
+++ b/web/seamonkey/DEPENDS
@@ -11,7 +11,7 @@ depends libvpx
 
 
 optional_depends "%FLASH"           ""  ""  "To enable Flash plugin"
-optional_depends "Python-2"         ""  ""  "Needed to do a Profile Guided Optimization build"
+optional_depends "python2"         ""  ""  "Needed to do a Profile Guided Optimization build"
 
 optional_depends "sqlite"           "--enable-system-sqlite"   "--disable-system-sqlite"   "Use system sqlite. ${PROBLEM_COLOR}Not recommended${DEFAULT_COLOR}"
 optional_depends "gnome-vfs"        "--enable-gnomevfs"        "--disable-gnomevfs"        "For Gnome VFS support"

--- a/x11-utils/conkyforecast/BUILD
+++ b/x11-utils/conkyforecast/BUILD
@@ -1,8 +1,8 @@
 (
 
   cd src &&
-  python setup.py build &&
+  python2 setup.py build &&
   prepare_install &&
-  python setup.py install
+  python2 setup.py install
 
 ) > $C_FIFO 2>&1

--- a/x11-utils/conkyforecast/DEPENDS
+++ b/x11-utils/conkyforecast/DEPENDS
@@ -1,3 +1,3 @@
 depends conky
-depends Python-2
+depends python2
 depends fontconfig

--- a/x11-utils/conkyforecast/DEPENDS
+++ b/x11-utils/conkyforecast/DEPENDS
@@ -1,3 +1,3 @@
 depends conky
-depends Python
+depends Python-2
 depends fontconfig

--- a/x11-utils/obkey/BUILD
+++ b/x11-utils/obkey/BUILD
@@ -1,5 +1,5 @@
-python setup.py build &&
+python2 setup.py build &&
 
 prepare_install &&
 
-python setup.py install
+python2 setup.py install

--- a/x11-utils/variety/BUILD
+++ b/x11-utils/variety/BUILD
@@ -1,4 +1,4 @@
 prepare_install &&
 
 export XDG_RUNTIME_DIR="/tmp/$MODULE"
-python setup.py install --optimize=1
+python2 setup.py install --optimize=1

--- a/zbeta/collectd/DEPENDS
+++ b/zbeta/collectd/DEPENDS
@@ -13,7 +13,7 @@ optional_depends libnotify   "--enable-notify_desktop" "--disable-notify_desktop
 optional_depends libpcap     "--with-libpcap"          "--without-libpcap"        "for dns plugin?"
 optional_depends postgresql  "--with-libpq"            "--without-libpq"          "for postgresql plugin?"
 optional_depends %MYSQL      "--with-libmysql"         "--without-libmysql"       "for mysql plugin?"
-optional_depends Python      "--with-python"           "--without-python"         "for python plugin?"
+optional_depends Python-2    "--with-python"           "--without-python"         "for python 2 plugin?"
 optional_depends rrdtool     "--with-librrd"           "--without-librrd"         "for rrdtool and rrdcached plugins?"
 optional_depends libvirt     "--enable-virt"           "--disable-virt"           "for libvirt plugin?"
 optional_depends lm_sensors  "--with-libsensors"       "--without-libsensors"     "for lm_sensors and sensors plugins?"

--- a/zbeta/collectd/DEPENDS
+++ b/zbeta/collectd/DEPENDS
@@ -13,7 +13,7 @@ optional_depends libnotify   "--enable-notify_desktop" "--disable-notify_desktop
 optional_depends libpcap     "--with-libpcap"          "--without-libpcap"        "for dns plugin?"
 optional_depends postgresql  "--with-libpq"            "--without-libpq"          "for postgresql plugin?"
 optional_depends %MYSQL      "--with-libmysql"         "--without-libmysql"       "for mysql plugin?"
-optional_depends Python-2    "--with-python"           "--without-python"         "for python 2 plugin?"
+optional_depends python2    "--with-python"           "--without-python"         "for python 2 plugin?"
 optional_depends rrdtool     "--with-librrd"           "--without-librrd"         "for rrdtool and rrdcached plugins?"
 optional_depends libvirt     "--enable-virt"           "--disable-virt"           "for libvirt plugin?"
 optional_depends lm_sensors  "--with-libsensors"       "--without-libsensors"     "for lm_sensors and sensors plugins?"

--- a/zbeta/rpm/DEPENDS
+++ b/zbeta/rpm/DEPENDS
@@ -1,4 +1,4 @@
-depends Python-2
+depends python2
 depends beecrypt
 
 optional_depends "elfutils" ""  ""  "use external rather than internal elfutils"

--- a/zbeta/rpm/DEPENDS
+++ b/zbeta/rpm/DEPENDS
@@ -1,4 +1,4 @@
-depends Python
+depends Python-2
 depends beecrypt
 
 optional_depends "elfutils" ""  ""  "use external rather than internal elfutils"


### PR DESCRIPTION
See https://github.com/lunar-linux/moonbase-core/pull/1841 for more information.

In preparation for making Python 3 be the default python module, this pull changes "Python" to "Python-2" in all of the DEPENDS files which include it.