### PR TITLE
python2-httplib2: New module

### DIFF
--- a/python/python2-httplib2/DEPENDS
+++ b/python/python2-httplib2/DEPENDS
@@ -1,0 +1,2 @@
+depends Python
+depends setuptools

--- a/python/python2-httplib2/DETAILS
+++ b/python/python2-httplib2/DETAILS
@@ -1,0 +1,16 @@
+          MODULE=python2-httplib2
+         VERSION=0.9.2
+          SOURCE=${MODULE#python2-}-$VERSION.tar.gz
+ SOURCE_URL_FULL=https://github.com/httplib2/httplib2/archive/$VERSION.tar.gz
+SOURCE_DIRECTORY=$BUILD_DIRECTORY/${MODULE#python2-}-$VERSION
+      SOURCE_VFY=sha256:ce1041b5780737ac13521479fefcdc3c1b9ec2f2d5970307fb56ec49364a6290
+        WEB_SITE=http://github.com/httplib2/httplib2/
+         ENTERED=20160604
+         UPDATED=20160604
+            TYPE=python2
+           SHORT="A comprehensive HTTP client library"
+
+cat << EOF
+httplib2 is a comprehensive HTTP client library, httplib2.py
+supports many features left out of other HTTP libraries.
+EOF


### PR DESCRIPTION
Newer releases of httplib2 don't work with Python 2 any more.

(This also requires the next release of "Lunar", because it uses
the default Python2 build, instead of having its own BUILD.)