### PR TITLE
emacs: Version bumped to 26.1.

### DIFF
--- a/editors/emacs/DEPENDS
+++ b/editors/emacs/DEPENDS
@@ -9,6 +9,7 @@ optional_depends libpng      "--with-png"             "--without-png"         "f
 optional_depends librsvg     "--with-rsvg"            "--without-rsvg"        "for SVG image support"
 optional_depends libXpm      "--with-x --with-xpm"    "--without-xpm"         "for XPM support if you use faces"
 optional_depends libXft      "--with-xft"             "--without-xft"         "for anti alias font support"
+optional_depends lcms2       "--with-lcms2"           "--without-lcms2"       "for colour management support"
 optional_depends cairo       "--with-cairo"           "--without-cairo"       "for cairo drawing support"
 optional_depends libxml2     "--with-xml2"            "--without-xml2"        "for XML parsing support"
 optional_depends dbus        "--with-dbus"            "--without-dbus"        "for D-BUS support"
@@ -16,6 +17,8 @@ optional_depends gnutls      "--with-gnutls"          "--without-gnutls"      "f
 optional_depends ImageMagick "--with-imagemagick"     "--without-imagemagick" "for ImageMagick support"
 optional_depends gpm         "--with-gpm"             "--without-gpm"         "for terminal mouse support"
 optional_depends zlib        "--with-zlib"            "--without-zlib"        "for zlib decompression support"
+optional_depends systemd     ""                       "--disable-libsystemd"  "for systemd socket-launching support"
+optional_depends mailutils   "--with-mailutils"       "--without-mailutils"   "for using GNU Mailutils to retrieve email"
 
 optional_depends gtk+-3    "--with-x-toolkit=gtk3"  "" "for gtk+ support GUI"
 optional_depends gtk+-2    "--with-x-toolkit=gtk2"  "" "for gtk+ support GUI"

--- a/editors/emacs/DETAILS
+++ b/editors/emacs/DETAILS
@@ -1,11 +1,11 @@
           MODULE=emacs
-         VERSION=25.3
+         VERSION=26.1
           SOURCE=$MODULE-$VERSION.tar.gz
       SOURCE_URL=$GNU_URL/$MODULE
-      SOURCE_VFY=sha256:f72c6a1b48b6fbaca2b991eed801964a208a2f8686c70940013db26cd37983c9
+      SOURCE_VFY=sha256:760382d5e8cdc5d0d079e8f754bce1136fbe1473be24bb885669b0e38fc56aa3
         WEB_SITE=http://www.gnu.org/software/emacs
          ENTERED=20010922
-         UPDATED=20170912
+         UPDATED=20180529
            SHORT="An extensible, self-documenting real-time display editor"
 
 cat << EOF


### PR DESCRIPTION
Also added the new optional dependencies as outlined in the release notes.