### PR TITLE
Lots and lots of modules: Got rid of the BUILD file, added perl TYPE.

### DIFF
--- a/net/libnet/DETAILS
+++ b/net/libnet/DETAILS
@@ -1,11 +1,11 @@
           MODULE=libnet
-         VERSION=1.1.6
+         VERSION=1.2-rc3
           SOURCE=$MODULE-$VERSION.tar.gz
-      SOURCE_URL=$SFORGE_URL/libnet-dev
-       SOURCE_VFY=sha256:d392bb5825c4b6b672fc93a0268433c86dc964e1500c279dc6d0711ea6ec467a
+      SOURCE_URL=http://downloads.sourceforge.net/project/libnet-dev
+       SOURCE_VFY=sha256:72c380785ad44183005e654b47cc12485ee0228d7fa6b0a87109ff7614be4a63
         WEB_SITE=http://www.packetfactory.net/libnet
          ENTERED=20011021
-         UPDATED=20121022
+         UPDATED=20180626
         SHORT="A library to send raw network packages"
 
 cat << EOF

--- a/perl/Algorithm-Annotate/BUILD
+++ b/perl/Algorithm-Annotate/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/Algorithm-Annotate/DETAILS
+++ b/perl/Algorithm-Annotate/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/C/CL/CLKAO/
       SOURCE_VFY=sha256:c9b1764643933eb1a3356906cc372d483a99416207a31df3e58ee9892d9922f9
         WEB_SITE=http://www.perl.com/CPAN/modules/by-module/CPAN/
+            TYPE=perl
          ENTERED=20070310
          UPDATED=20170301
            SHORT="Perl module to represent a series of changes in annotate form"

--- a/perl/Algorithm-Diff/BUILD
+++ b/perl/Algorithm-Diff/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/Algorithm-Diff/DETAILS
+++ b/perl/Algorithm-Diff/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/T/TY/TYEMQ/
       SOURCE_VFY=sha256:30e84ac4b31d40b66293f7b1221331c5a50561a39d580d85004d9c1fff991751
         WEB_SITE=http://search.cpan.org/~tyemq/Algorithm-Diff/
+            TYPE=perl
          ENTERED=20060310
          UPDATED=20150705
            SHORT="Perl module to compute differences between two files / lists"

--- a/perl/Apache-DBI/BUILD
+++ b/perl/Apache-DBI/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/Apache-DBI/DETAILS
+++ b/perl/Apache-DBI/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/P/PH/PHRED/
       SOURCE_VFY=sha256:9d7d520da7e579756a032021bcdbe61a3a3e5fae90df767f0cea08b3c666e677
         WEB_SITE=http://search.cpan.org/~abh/Apache-DBI/
+            TYPE=perl
          ENTERED=20020727
          UPDATED=20150705
            SHORT="a perl module for Apache::DBI and Apache::AuthDBI"

--- a/perl/App-CLI/BUILD
+++ b/perl/App-CLI/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/App-CLI/DETAILS
+++ b/perl/App-CLI/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/C/CO/CORNELIUS/
       SOURCE_VFY=sha256:67806256dc16f90e74c7e56a931d8b82dec492ca7f3089c9302be8d849f8215a
         WEB_SITE=http://search.cpan.org/~alexmv/App-CLI/
+            TYPE=perl
          ENTERED=20070310
          UPDATED=20100222
            SHORT="Perl dispatcher module for command line interface programs"

--- a/perl/Archive-Zip/BUILD
+++ b/perl/Archive-Zip/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/Archive-Zip/DETAILS
+++ b/perl/Archive-Zip/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/P/PH/PHRED
       SOURCE_VFY=sha256:eac75b05f308e860aa860c3094aa4e7915d3d31080e953e49bc9c38130f5c20b
         WEB_SITE=http://search.cpan.org/~phred/Archive-Zip
+            TYPE=perl
          ENTERED=20030309
          UPDATED=20180219
            SHORT="Perl module for manipulation of zip archives"

--- a/perl/Audio-FLAC-Header/BUILD
+++ b/perl/Audio-FLAC-Header/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/Audio-FLAC-Header/DETAILS
+++ b/perl/Audio-FLAC-Header/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/D/DA/DANIEL/
       SOURCE_VFY=sha256:fba5911d6c22d81506565cd9a1438e8605420ff7986cf03d1a12d006a4070543
         WEB_SITE=http://search.cpan.org/~daniel/Audio-FLAC-Header/
+            TYPE=perl
          ENTERED=20090320
          UPDATED=20110416
            SHORT="Audio::FLAC"

--- a/perl/Audio-Musepack/BUILD
+++ b/perl/Audio-Musepack/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/Audio-Musepack/DETAILS
+++ b/perl/Audio-Musepack/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/D/DA/DANIEL/
       SOURCE_VFY=sha1:abe52ff24d6f8ab93b3d35353b595c265e6615a3
         WEB_SITE=http://search.cpan.org/~daniel/Audio-Musepack/
+            TYPE=perl
          ENTERED=20090320
          UPDATED=20110416
            SHORT="Audio::Musepack"

--- a/perl/Audio-Scan/BUILD
+++ b/perl/Audio-Scan/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/Audio-Scan/DETAILS
+++ b/perl/Audio-Scan/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/A/AG/AGRUNDMA/
       SOURCE_VFY=sha256:aad64aa1e4f4abd964e9d00fc5edc79f45f2231ed595b1520057272425130900
         WEB_SITE=http://search.cpan.org/~agrundma/Audio-Scan/
+            TYPE=perl
          ENTERED=20110416
          UPDATED=20180219
            SHORT="Fast C metadata and tag reader for all common audio file formats"

--- a/perl/Audio-WMA/BUILD
+++ b/perl/Audio-WMA/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/Audio-WMA/DETAILS
+++ b/perl/Audio-WMA/DETAILS
@@ -4,6 +4,7 @@
    SOURCE_URL[0]=http://search.cpan.org/CPAN/authors/id/D/DA/DANIEL/
       SOURCE_VFY=sha1:4be4bb804f119489cddb111c5d2d065723611058
         WEB_SITE=http://search.cpan.org/~daniel/Audio-WMA/
+            TYPE=perl
          ENTERED=20090320
          UPDATED=20090320
            SHORT="perl Audio/WMA"

--- a/perl/BerkeleyDB/BUILD
+++ b/perl/BerkeleyDB/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/BerkeleyDB/DETAILS
+++ b/perl/BerkeleyDB/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/P/PM/PMQS
       SOURCE_VFY=sha256:6f28e141c7e2fbc455621bc809d6e7d84a3640cc77568b07798ae3933107e44f
         WEB_SITE=http://search.cpan.org/dist/BerkeleyDB
+            TYPE=perl
          ENTERED=20100426
          UPDATED=20150705
            SHORT="Perl extension for Berkeley DB version 2, 3 or 4"

--- a/perl/Bit-Vector/BUILD
+++ b/perl/Bit-Vector/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/Bit-Vector/DETAILS
+++ b/perl/Bit-Vector/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/S/ST/STBEY
       SOURCE_VFY=sha256:3c6daa671fecfbc35f92a9385b563d65f50dfc6bdc8b4805f9ef46c0d035a926
         WEB_SITE=http://search.cpan.org/~stbey/Bit-Vector
+            TYPE=perl
          ENTERED=20020727
          UPDATED=20150704
            SHORT="for efficient bit vectors and big int math library"

--- a/perl/CDDB_get/BUILD
+++ b/perl/CDDB_get/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/CDDB_get/DETAILS
+++ b/perl/CDDB_get/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/F/FO/FONKIE
       SOURCE_VFY=sha256:bdccba1fa8e4c1cf3189c5e5a3529a6693a648aa5282b597538c7aaddce6d9c9
         WEB_SITE=http://search.cpan.org/~fonkie/CDDB_get
+            TYPE=perl
          ENTERED=20090320
          UPDATED=20150705
            SHORT="Read the CDDB entry for an audio CD in your drive"

--- a/perl/CGI-Lite/BUILD
+++ b/perl/CGI-Lite/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/CGI-Lite/DETAILS
+++ b/perl/CGI-Lite/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://www.cpan.org/authors/id/S/SM/SMYLERS/
       SOURCE_VFY=sha1:30171a52171bb59805eca07bcb7d9e9622ebc7c3
         WEB_SITE=http://search.cpan.org/dist/CGI-Lite/Lite.pm
+            TYPE=perl
          ENTERED=20011108
          UPDATED=20090704
            SHORT="Perl module to process and decode WWW forms and cookies"

--- a/perl/CGI.pm/BUILD
+++ b/perl/CGI.pm/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/CGI.pm/DETAILS
+++ b/perl/CGI.pm/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/M/MA/MARKSTOS/
       SOURCE_VFY=sha1:5d74cec07d61c88af69de7bb54c6f9130c3b83e7
         WEB_SITE=http://search.cpan.org/dist/CGI/
+            TYPE=perl
          ENTERED=20020507
          UPDATED=20111006
            SHORT="Common Gateway Interface for perl"

--- a/perl/CPAN-Meta-Requirements/BUILD
+++ b/perl/CPAN-Meta-Requirements/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/CPAN-Meta-Requirements/DETAILS
+++ b/perl/CPAN-Meta-Requirements/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/D/DA/DAGOLDEN/
       SOURCE_VFY=sha1:6587695c2dfb2ec2266880075abfa70c0c3dbdb1
         WEB_SITE=http://search.cpan.org/~dagolden/CPAN-Meta-Requirements
+            TYPE=perl
          ENTERED=20130405
          UPDATED=20130405
            SHORT="version requirements for a CPAN dist"

--- a/perl/CPAN-Meta-YAML/BUILD
+++ b/perl/CPAN-Meta-YAML/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/CPAN-Meta-YAML/DETAILS
+++ b/perl/CPAN-Meta-YAML/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/D/DA/DAGOLDEN
       SOURCE_VFY=sha256:347b70915839482ba6a375a973874faf9a0b6b17e0fe1071741d7fe9321dbba4
         WEB_SITE=http://search.cpan.org/~dagolden/CPAN-Meta-YAML
+            TYPE=perl
          ENTERED=20110416
          UPDATED=20150705
            SHORT="Read and write a subset of YAML for CPAN Meta files"

--- a/perl/CPAN-Meta/BUILD
+++ b/perl/CPAN-Meta/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/CPAN-Meta/DETAILS
+++ b/perl/CPAN-Meta/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/D/DA/DAGOLDEN/
       SOURCE_VFY=sha256:d218aeedf8ff9de167b8661f08f69a35ee92feb067f39b189e28eed39763e711
         WEB_SITE=http://search.cpan.org/~dagolden/CPAN-Meta/
+            TYPE=perl
          ENTERED=20110416
          UPDATED=20150925
            SHORT="The distribution metadata for a CPAN dist"

--- a/perl/CPAN/BUILD
+++ b/perl/CPAN/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/CPAN/DETAILS
+++ b/perl/CPAN/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/A/AN/ANDK/
       SOURCE_VFY=sha1:888e6f6ee53cc4c0d739e7374ef1642a970eacfd
         WEB_SITE=http://www.perl.com/CPAN/modules/by-module/CPAN/
+            TYPE=perl
          ENTERED=20020212
          UPDATED=20111008
            SHORT="Aids searching and installing of perl modules."

--- a/perl/Cairo-Perl/BUILD
+++ b/perl/Cairo-Perl/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/Cairo-Perl/DETAILS
+++ b/perl/Cairo-Perl/DETAILS
@@ -6,6 +6,7 @@
 SOURCE_DIRECTORY=$BUILD_DIRECTORY/Cairo-$VERSION
       SOURCE_VFY=sha256:98201dea8f31a369bbf9b276065425dd58b710a8d14478d6e1868ce07911a046
         WEB_SITE=http://sourceforge.net/projects/gtk2-perl/
+            TYPE=perl
          ENTERED=20060924
          UPDATED=20150705
            SHORT="Perl interface to the cairo library"

--- a/perl/Canary-Stability/BUILD
+++ b/perl/Canary-Stability/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/Canary-Stability/DETAILS
+++ b/perl/Canary-Stability/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/M/ML/MLEHMANN
       SOURCE_VFY=sha256:fd240b111d834dbae9630c59b42fae2145ca35addc1965ea311edf0d07817107
         WEB_SITE=http://search.cpan.org/~mlehmann/Canary-Stability
+            TYPE=perl
          ENTERED=20150705
          UPDATED=20180219
            SHORT="canary to check perl compatibility for schmorp's modules"

--- a/perl/Carp-Clan/BUILD
+++ b/perl/Carp-Clan/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/Carp-Clan/DETAILS
+++ b/perl/Carp-Clan/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/S/ST/STBEY
       SOURCE_VFY=sha256:542e13ece92d40545b8ba6626cfc6ed73071c6cbf6a5537ca126c41b349ae1ec
         WEB_SITE=http://search.cpan.org/~stbey/Carp-Clan/
+            TYPE=perl
          ENTERED=20150705
          UPDATED=20150705
            SHORT="report errors from perspective of caller of a clan of module"

--- a/perl/Class-Accessor/BUILD
+++ b/perl/Class-Accessor/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/Class-Accessor/DETAILS
+++ b/perl/Class-Accessor/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/K/KA/KASEI/
       SOURCE_VFY=sha1:e91317b429f5618c4d0264c699a1f266635f87df
         WEB_SITE=http://search.cpan.org/~kasei/Class-Accessor/
+            TYPE=perl
          ENTERED=20060310
          UPDATED=20100222
            SHORT="provide automated accessor generation"

--- a/perl/Class-Autouse/BUILD
+++ b/perl/Class-Autouse/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/Class-Autouse/DETAILS
+++ b/perl/Class-Autouse/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/A/AD/ADAMK
       SOURCE_VFY=sha256:c05b3236c05719d819c20db0fdeb6d0954747e43d7a738294eed7fbcf36ecf1b
         WEB_SITE=http://search.cpan.org/~adamk/Class-Autouse
+            TYPE=perl
          ENTERED=20070310
          UPDATED=20150705
            SHORT="Perl module to load a class the first time you call a method ni it"

--- a/perl/Class-Data-Inheritable/BUILD
+++ b/perl/Class-Data-Inheritable/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/Class-Data-Inheritable/DETAILS
+++ b/perl/Class-Data-Inheritable/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/T/TM/TMTM/
       SOURCE_VFY=sha1:522c7e948f126c0d0ab1f37b5e993f4fc5ce65de
         WEB_SITE=http://www.perl.com/CPAN/modules/by-module/CPAN/
+            TYPE=perl
          ENTERED=20070310
          UPDATED=20080309
            SHORT="Perl module to provide inheritable, overridable class data"

--- a/perl/Class-Factory-Util/BUILD
+++ b/perl/Class-Factory-Util/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/Class-Factory-Util/DETAILS
+++ b/perl/Class-Factory-Util/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/D/DR/DROLSKY/
       SOURCE_VFY=sha1:d7d3f27b3d7af789ea58e1acdf0ea9da3251d239
         WEB_SITE=http://search.cpan.org/~drolsky/Class-Factory-Util/
+            TYPE=perl
          ENTERED=20111009
          UPDATED=20111009
            SHORT="Provide utility methods for factory classes"

--- a/perl/Class-Inspector/BUILD
+++ b/perl/Class-Inspector/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/Class-Inspector/DETAILS
+++ b/perl/Class-Inspector/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/P/PL/PLICEASE/
       SOURCE_VFY=sha256:cefadc8b5338e43e570bc43f583e7c98d535c17b196bcf9084bb41d561cc0535
         WEB_SITE=http://search.cpan.org/~adamk/Class-Inspector
+            TYPE=perl
          ENTERED=20111009
          UPDATED=20180218
            SHORT="Get information about a class and its structure"

--- a/perl/Class-MethodMaker/BUILD
+++ b/perl/Class-MethodMaker/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/Class-MethodMaker/DETAILS
+++ b/perl/Class-MethodMaker/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/S/SC/SCHWIGON/class-methodmaker
       SOURCE_VFY=sha256:5eef58ccb27ebd01bcde5b14bcc553b5347a0699e5c3e921c7780c3526890328
         WEB_SITE=http://search.cpan.org/dist/Class-MethodMaker
+            TYPE=perl
          ENTERED=20100606
          UPDATED=20150705
            SHORT="Create generic methods for OO Perl"

--- a/perl/Clipboard/BUILD
+++ b/perl/Clipboard/BUILD
@@ -1,4 +1,0 @@
-perl Makefile.PL &&
-
-default_make
-

--- a/perl/Clipboard/DETAILS
+++ b/perl/Clipboard/DETAILS
@@ -5,6 +5,7 @@
       SOURCE_VFY=sha1:d3ebf93947c438dc7c33b3dcd5d7d380d366a1e4
         WEB_SITE=http://search.cpan.org/~king/Clipboard/
       MAINTAINER=perldude@lunar-linux.org
+            TYPE=perl
          ENTERED=20060807
          UPDATED=20101109
            SHORT="Clipboard - Copy and paste with any OS"

--- a/perl/Clone/BUILD
+++ b/perl/Clone/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/Clone/DETAILS
+++ b/perl/Clone/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/G/GA/GARU
       SOURCE_VFY=sha256:9fb0534bb7ef6ca1f6cc1dc3f29750d6d424394d14c40efdc77832fad3cebde8
         WEB_SITE=http://search.cpan.org/~garu/Clone
+            TYPE=perl
          ENTERED=20070310
          UPDATED=20150705
            SHORT="Perl module to recursively copy Perl datatypes"

--- a/perl/Compress-Zlib/BUILD
+++ b/perl/Compress-Zlib/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/Compress-Zlib/DETAILS
+++ b/perl/Compress-Zlib/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://www.cpan.org/authors/id/P/PM/PMQS/
       SOURCE_VFY=sha1:022daac3d0590b156dde207afdd2c374e6f70ef4
         WEB_SITE=http://search.cpan.org/search?dist=Compress-Zlib
+            TYPE=perl
          ENTERED=20030309
          UPDATED=20090628
            SHORT="Perl interface to zlib"

--- a/perl/Convert-BinHex/BUILD
+++ b/perl/Convert-BinHex/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/Convert-BinHex/DETAILS
+++ b/perl/Convert-BinHex/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/S/ST/STEPHEN
       SOURCE_VFY=sha256:513591b4be46bd7eb91e83197721b4a045a9753a3dd2f11de82c9d3013226397
         WEB_SITE=http://search.cpan.org/~stephen/Convert-BinHex
+            TYPE=perl
          ENTERED=20100426
          UPDATED=20180219
            SHORT="extract data from Macintosh BinHex files"

--- a/perl/Convert-TNEF/BUILD
+++ b/perl/Convert-TNEF/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/Convert-TNEF/DETAILS
+++ b/perl/Convert-TNEF/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://www.cpan.org/authors/id/D/DO/DOUGW
       SOURCE_VFY=sha256:9df692e7e90536c28edea2c09ec4c45ac49af789fb2863248cc723210c785403
         WEB_SITE=http://search.cpan.org/search?dist=Convert-TNEF
+            TYPE=perl
          ENTERED=20030309
          UPDATED=20150705
            SHORT="Perl module to read TNEF files"

--- a/perl/Convert-UUlib/DETAILS
+++ b/perl/Convert-UUlib/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/M/ML/MLEHMANN/
       SOURCE_VFY=sha256:0cd81bc21377fad191f89aa427733efe5b7e75ca1889e9317945ad448c6388ea
         WEB_SITE=http://search.cpan.org/search?dist=Convert-UUlib
+            TYPE=perl
          ENTERED=20030309
          UPDATED=20180219
            SHORT="PERL interface to the uulib library"

--- a/perl/Crypt-OpenSSL-Bignum/BUILD
+++ b/perl/Crypt-OpenSSL-Bignum/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/Crypt-OpenSSL-Bignum/DETAILS
+++ b/perl/Crypt-OpenSSL-Bignum/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/K/KM/KMX
       SOURCE_VFY=sha256:c7ccafa9108524b9a6f63bf4ac3377f9d7e978fee7b83c430af7e74c5fcbdf17
         WEB_SITE=http://search.cpan.org/~kmx/Crypt-OpenSSL-Bignum
+            TYPE=perl
          ENTERED=20131012
          UPDATED=20150705
            SHORT="OpenSSL's multiprecision integer arithmetic"

--- a/perl/Crypt-OpenSSL-RSA/BUILD
+++ b/perl/Crypt-OpenSSL-RSA/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/Crypt-OpenSSL-RSA/DETAILS
+++ b/perl/Crypt-OpenSSL-RSA/DETAILS
@@ -4,6 +4,7 @@
    SOURCE_URL[0]=http://search.cpan.org/CPAN/authors/id/P/PE/PERLER/
       SOURCE_VFY=sha1:9978e5fcac15ea691030181d2d12564fa3902e5e
         WEB_SITE=http://search.cpan.org/~iroberts/Crypt-OpenSSL-RSA
+            TYPE=perl
          ENTERED=20100414
          UPDATED=20111008
            SHORT="RSA encoding and decoding, using the openSSL libraries"

--- a/perl/DBD-Pg/BUILD
+++ b/perl/DBD-Pg/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/DBD-Pg/DETAILS
+++ b/perl/DBD-Pg/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/T/TU/TURNSTEP
       SOURCE_VFY=sha256:fdbf175cfb6371169d4638bcbe696a4998d3b375220e93ad7125ae276770137c
         WEB_SITE=http://search.cpan.org/~turnstep/DBD-Pg/
+            TYPE=perl
          ENTERED=20030823
          UPDATED=20150705
            SHORT="DBD-Pg (PostgreSQL) module for perl DBI"

--- a/perl/DBD-SQLite/BUILD
+++ b/perl/DBD-SQLite/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/DBD-SQLite/DETAILS
+++ b/perl/DBD-SQLite/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://www.cpan.org/authors/id/I/IS/ISHIGAKI
       SOURCE_VFY=sha256:a6da099e9b953262afafea18335930bede1f195fdead45bd3f00e690b158354e
         WEB_SITE=http://search.cpan.org/~adamk/DBD-SQLite
+            TYPE=perl
          ENTERED=20061023
          UPDATED=20161124
            SHORT="Perl bindings for SQLite"

--- a/perl/DBD-mysql/BUILD
+++ b/perl/DBD-mysql/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/DBD-mysql/DETAILS
+++ b/perl/DBD-mysql/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/C/CA/CAPTTOFU/
       SOURCE_VFY=sha256:6165652ec959d05b97f5413fa3dff014b78a44cf6de21ae87283b28378daf1f7
         WEB_SITE=http://search.cpan.org/~capttofu/DBD-mysql/
+            TYPE=perl
          ENTERED=20020727
          UPDATED=20180210
            SHORT="The MySQL and mSQL DBD modules for perl DBI"

--- a/perl/DBI/BUILD
+++ b/perl/DBI/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/DBI/DETAILS
+++ b/perl/DBI/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/T/TI/TIMB
       SOURCE_VFY=sha256:5509e532cdd0e3d91eda550578deaac29e2f008a12b64576e8c261bb92e8c2c1
         WEB_SITE=http://search.cpan.org/~timb/DBI
+            TYPE=perl
          ENTERED=20011108
          UPDATED=20180320
            SHORT="The Perl Database Interface"

--- a/perl/Data-Dump/BUILD
+++ b/perl/Data-Dump/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/Data-Dump/DETAILS
+++ b/perl/Data-Dump/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/G/GA/GAAS
       SOURCE_VFY=sha256:af53b05ef1387b4cab4427e6789179283e4f0da8cf036e8db516ddb344512b65
         WEB_SITE=http://search.cpan.org/~gaas/Data-Dump
+            TYPE=perl
          ENTERED=20111008
          UPDATED=20150705
            SHORT="Pretty printing of data structures"

--- a/perl/Data-Hierarchy/BUILD
+++ b/perl/Data-Hierarchy/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/Data-Hierarchy/DETAILS
+++ b/perl/Data-Hierarchy/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/C/CL/CLKAO/
       SOURCE_VFY=sha1:23c1c0462b399395117be24f2c834e844c7acd73
         WEB_SITE=http://www.perl.com/CPAN/modules/by-module/CPAN/
+            TYPE=perl
          ENTERED=20070310
          UPDATED=20070310
            SHORT="Perl module to handle data in a hierarchical structure"

--- a/perl/Date-Calc/BUILD
+++ b/perl/Date-Calc/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/Date-Calc/DETAILS
+++ b/perl/Date-Calc/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/S/ST/STBEY
       SOURCE_VFY=sha256:7ce137b2e797b7c0901f3adf1a05a19343356cd1f04676aa1c56a9f624f859ad
         WEB_SITE=http://search.cpan.org/~stbey/Date-Calc
+            TYPE=perl
          ENTERED=20020727
          UPDATED=20150705
            SHORT="perl module for Gregorian calendar date calculations"

--- a/perl/DateTime-Format-Builder/BUILD
+++ b/perl/DateTime-Format-Builder/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/DateTime-Format-Builder/DETAILS
+++ b/perl/DateTime-Format-Builder/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/D/DR/DROLSKY
       SOURCE_VFY=sha256:7cd58a8cb53bf698407cc992f89e4d49bf3dc55baf4f3f00f1def63a0fff33ef
         WEB_SITE=http://search.cpan.org/~drolsky/DateTime-Format-Builder
+            TYPE=perl
          ENTERED=20111009
          UPDATED=20150705
            SHORT="Create DateTime parser classes and objects"

--- a/perl/DateTime-Format-ISO8601/BUILD
+++ b/perl/DateTime-Format-ISO8601/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/DateTime-Format-ISO8601/DETAILS
+++ b/perl/DateTime-Format-ISO8601/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/J/JH/JHOBLITT/
       SOURCE_VFY=sha1:8ce5223900989394197b5dbae615d1545bb5a4d3
         WEB_SITE=http://search.cpan.org/~jhoblitt/DateTime-Format-ISO8601/
+            TYPE=perl
          ENTERED=20111006
          UPDATED=20130405
            SHORT="Parses ISO8601 formats"

--- a/perl/DateTime-Format-Strptime/BUILD
+++ b/perl/DateTime-Format-Strptime/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/DateTime-Format-Strptime/DETAILS
+++ b/perl/DateTime-Format-Strptime/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/D/DR/DROLSKY/
       SOURCE_VFY=sha256:4fcfb2ac4f79d7ff2855a405f39050d2ea691ee098ce54ede8af79c8d6ab3c19
         WEB_SITE=http://search.cpan.org/~drolsky/DateTime-Format-Strptime/
+            TYPE=perl
          ENTERED=20111009
          UPDATED=20180218
            SHORT="Parse and format strp and strf time patterns"

--- a/perl/DateTime-Locale/BUILD
+++ b/perl/DateTime-Locale/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/DateTime-Locale/DETAILS
+++ b/perl/DateTime-Locale/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/D/DR/DROLSKY/
       SOURCE_VFY=sha256:0ca6598b3f89e92e3d1140e5685c69f6f795f6eed158fa482f33ce2122b35cc9
         WEB_SITE=http://search.cpan.org/~drolsky/DateTime-Locale
+            TYPE=perl
          ENTERED=20111008
          UPDATED=20150705
            SHORT="Localization support for DateTime.pm"

--- a/perl/DateTime-TimeZone/BUILD
+++ b/perl/DateTime-TimeZone/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/DateTime-TimeZone/DETAILS
+++ b/perl/DateTime-TimeZone/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/D/DR/DROLSKY
       SOURCE_VFY=sha256:1d0a0adc8a14adc8033b5e5391f1b2b87fe48151d95c019601a390020f9770b2
         WEB_SITE=http://search.cpan.org/~drolsky/DateTime-TimeZone
+            TYPE=perl
          ENTERED=20111009
          UPDATED=20180218
            SHORT="Time zone object base class and factory"

--- a/perl/DateTime/BUILD
+++ b/perl/DateTime/BUILD
@@ -1,4 +1,0 @@
-perl Makefile.PL &&
-
-default_make
-

--- a/perl/DateTime/DETAILS
+++ b/perl/DateTime/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/D/DR/DROLSKY
       SOURCE_VFY=sha256:e9fcf859103e9a8067d5e11b7b14e956c8fd4ad6402124fb1221d527b0688788
         WEB_SITE=http://search.cpan.org/~drolsky/DateTime
+            TYPE=perl
          ENTERED=20111009
          UPDATED=20180218
            SHORT="A date and time object"

--- a/perl/Digest-HMAC/BUILD
+++ b/perl/Digest-HMAC/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/Digest-HMAC/DETAILS
+++ b/perl/Digest-HMAC/DETAILS
@@ -4,6 +4,7 @@
    SOURCE_URL[0]=http://search.cpan.org/CPAN/authors/id/G/GA/GAAS/
       SOURCE_VFY=sha1:b3f931032a9a8d9ba42d1c5d4684b06e60e183c7
         WEB_SITE=http://search.cpan.org/~gaas/Digest-HMAC
+            TYPE=perl
          ENTERED=20020619
          UPDATED=20111008
       MAINTAINER=kongar@tsrsb.org.tr

--- a/perl/Digest-MD5/BUILD
+++ b/perl/Digest-MD5/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/Digest-MD5/DETAILS
+++ b/perl/Digest-MD5/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/G/GA/GAAS
       SOURCE_VFY=sha256:90de11e3743ef1c753a5c2032b434e09472046fbcf346996cbe5d135b217f390
         WEB_SITE=http://search.cpan.org/~gaas/Digest-MD5
+            TYPE=perl
          ENTERED=20020507
          UPDATED=20150705
            SHORT="perl interface to the MD5 Algorithm"

--- a/perl/Digest-SHA1/BUILD
+++ b/perl/Digest-SHA1/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/Digest-SHA1/DETAILS
+++ b/perl/Digest-SHA1/DETAILS
@@ -4,6 +4,7 @@
    SOURCE_URL[0]=http://search.cpan.org/CPAN/authors/id/G/GA/GAAS/
       SOURCE_VFY=sha1:77379a2775c744dd7a9890f5638da6362ae58013
         WEB_SITE=http://search.cpan.org/search?dist=Digest-SHA1
+            TYPE=perl
          ENTERED=20020619
          UPDATED=20101109
       MAINTAINER=kongar@tsrsb.org.tr

--- a/perl/Encode-Detect/BUILD
+++ b/perl/Encode-Detect/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/Encode-Detect/DETAILS
+++ b/perl/Encode-Detect/DETAILS
@@ -4,6 +4,7 @@
    SOURCE_URL[0]=http://search.cpan.org/CPAN/authors/id/J/JG/JGMYERS
       SOURCE_VFY=sha1:c2285d5b0678ceeb93508ee09d30386a59053c08
         WEB_SITE=http://search.cpan.org/~jgmyers/Encode-Detect
+            TYPE=perl
          ENTERED=20100414
          UPDATED=20100414
            SHORT="An Encode::Encoding subclass that detects the encoding of data"

--- a/perl/Encode-Locale/BUILD
+++ b/perl/Encode-Locale/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/Encode-Locale/DETAILS
+++ b/perl/Encode-Locale/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/G/GA/GAAS
       SOURCE_VFY=sha256:176fa02771f542a4efb1dbc2a4c928e8f4391bf4078473bd6040d8f11adb0ec1
         WEB_SITE=http://search.cpan.org/~gaas/Encode-Locale
+            TYPE=perl
          ENTERED=20111006
          UPDATED=20150705
            SHORT="determine what encodings should be used"

--- a/perl/ExtUtils-CBuilder/BUILD
+++ b/perl/ExtUtils-CBuilder/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/ExtUtils-CBuilder/DETAILS
+++ b/perl/ExtUtils-CBuilder/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/A/AM/AMBS
       SOURCE_VFY=sha256:116cb3ec29f42d9d03c1b06eb5c7382ae121f32e83b73fd8fc226c6275f15a33
         WEB_SITE=http://search.cpan.org/~dagolden/ExtUtils-CBuilder
+            TYPE=perl
          ENTERED=20070610
          UPDATED=20150705
            SHORT="Compile and link C code for Perl modules."

--- a/perl/ExtUtils-Depends/BUILD
+++ b/perl/ExtUtils-Depends/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/ExtUtils-Depends/DETAILS
+++ b/perl/ExtUtils-Depends/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/X/XA/XAOC
       SOURCE_VFY=sha256:8bec0a8f67ac7cf5c7bc48aff4b7cf8a771ef97f0ea7894bcdd0e9079ba24fec
         WEB_SITE=http://search.cpan.org/~xaoc/ExtUtils-Depends
+            TYPE=perl
          ENTERED=20040712
          UPDATED=20150705
            SHORT="Easily build XS extensions"

--- a/perl/ExtUtils-PkgConfig/BUILD
+++ b/perl/ExtUtils-PkgConfig/BUILD
@@ -1,2 +1,0 @@
-perl Makefile.PL &&
-default_make

--- a/perl/ExtUtils-PkgConfig/DETAILS
+++ b/perl/ExtUtils-PkgConfig/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/X/XA/XAOC
       SOURCE_VFY=sha256:69b3192e22b37e930238f332b5bfa9e14e69bec1427ba70c8515fbba1137b0b3
         WEB_SITE=http://search.cpan.org/~xaoc/ExtUtils-PkgConfig
+            TYPE=perl
          ENTERED=20040712
          UPDATED=20150705
            SHORT="simplistic interface to pkg-config"

--- a/perl/File-BaseDir/BUILD
+++ b/perl/File-BaseDir/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/File-BaseDir/DETAILS
+++ b/perl/File-BaseDir/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/K/KI/KIMRYAN
       SOURCE_VFY=sha256:120a57ef78535e13e1465717b4056aff4ce69af1e31c67c65d1177a52169082b
         WEB_SITE=http://search.cpan.org/search?dist=File-BaseDir
+            TYPE=perl
          ENTERED=20040729
          UPDATED=20150705
            SHORT="Use the freedesktop basedir spec"

--- a/perl/File-DesktopEntry/BUILD
+++ b/perl/File-DesktopEntry/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/File-DesktopEntry/DETAILS
+++ b/perl/File-DesktopEntry/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/M/MI/MICHIELB
       SOURCE_VFY=sha256:b5448c064bfedaf9c13e838f2213d1dfbcbfb5b95a3a0d0a06bef8487b7a4910
         WEB_SITE=http://search.cpan.org/~michielb/File-DesktopEntry
+            TYPE=perl
          ENTERED=20060813
          UPDATED=20150705
            SHORT="Object to handle .desktop files"

--- a/perl/File-DirWalk/BUILD
+++ b/perl/File-DirWalk/BUILD
@@ -1,4 +1,0 @@
-perl Makefile.PL &&
-
-default_make
-

--- a/perl/File-DirWalk/DETAILS
+++ b/perl/File-DirWalk/DETAILS
@@ -5,6 +5,7 @@
       SOURCE_VFY=sha1:309964552dca240f39a2cf37d3c9632b0c384999
         WEB_SITE=http://search.cpan.org/~jensl/File-DirWalk-$VERSION/
       MAINTAINER=perldude@lunar-linux.org
+            TYPE=perl
          ENTERED=20040729
          UPDATED=20060805
            SHORT="File::DirWalk - walk through a directory tree"

--- a/perl/File-Find-Rule/BUILD
+++ b/perl/File-Find-Rule/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/File-Find-Rule/DETAILS
+++ b/perl/File-Find-Rule/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/R/RC/RCLAMP/
       SOURCE_VFY=sha1:d9f846664f5bc092051645dbf9b77d0bbb9d3299
         WEB_SITE=http://search.cpan.org/~rclamp/File-Find-Rule/
+            TYPE=perl
          ENTERED=20111009
          UPDATED=20111009
            SHORT="Alternative interface to File::Find"

--- a/perl/File-HomeDir/BUILD
+++ b/perl/File-HomeDir/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/File-HomeDir/DETAILS
+++ b/perl/File-HomeDir/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/A/AD/ADAMK
       SOURCE_VFY=sha256:85b94f3513093ec0a25b91f9f2571918519ae6f2b7a1e8546f8f78d09a877143
         WEB_SITE=http://search.cpan.org/~adamk/File-HomeDir
+            TYPE=perl
          ENTERED=20070310
          UPDATED=20150705
            SHORT="Find your home and other directories on any platform"

--- a/perl/File-Listing/BUILD
+++ b/perl/File-Listing/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/File-Listing/DETAILS
+++ b/perl/File-Listing/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/G/GA/GAAS/
       SOURCE_VFY=sha1:02a41fe1b91f3f198712965360192f31d6d8d74e
         WEB_SITE=http://search.cpan.org/~gaas/MIME-Base64/
+            TYPE=perl
          ENTERED=20111006
          UPDATED=20150217
            SHORT="parse directory listing"

--- a/perl/File-MimeInfo/BUILD
+++ b/perl/File-MimeInfo/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/File-MimeInfo/DETAILS
+++ b/perl/File-MimeInfo/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/M/MI/MICHIELB
       SOURCE_VFY=sha256:579cf826fed7fe276636531a53291550c9ac36781dcd9e07e52ee7e784667234
         WEB_SITE=http://search.cpan.org/search?dist=File-MimeInfo
+            TYPE=perl
          ENTERED=20040728
          UPDATED=20150705
            SHORT="determine the mime type of a file"

--- a/perl/File-Next/BUILD
+++ b/perl/File-Next/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/File-Next/DETAILS
+++ b/perl/File-Next/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/P/PE/PETDANCE/
       SOURCE_VFY=sha256:6965f25c2c132d0ba7a6f72b57b8bc6d25cf8c1b7032caa3a9bda8612e41d759
         WEB_SITE=http://search.cpan.org/dist/File-Next/
+            TYPE=perl
          ENTERED=20170301
          UPDATED=20170301
            SHORT="A file finding module for Perl"

--- a/perl/File-ShareDir-Install/BUILD
+++ b/perl/File-ShareDir-Install/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/File-ShareDir-Install/DETAILS
+++ b/perl/File-ShareDir-Install/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/E/ET/ETHER/
       SOURCE_VFY=sha256:32bf8772e9fea60866074b27ff31ab5bc3f88972d61915e84cbbb98455e00cc8
         WEB_SITE=http://search.cpan.org/dist/File-ShareDir/
+            TYPE=perl
          ENTERED=20180218
          UPDATED=20180218
            SHORT="Install shared files"

--- a/perl/File-ShareDir/BUILD
+++ b/perl/File-ShareDir/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/File-ShareDir/DETAILS
+++ b/perl/File-ShareDir/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/R/RE/REHSACK/
       SOURCE_VFY=sha256:07b628efcdf902d6a32e6a8e084497e8593d125c03ad12ef5cc03c87c7841caf
         WEB_SITE=http://search.cpan.org/dist/File-ShareDir/
+            TYPE=perl
          ENTERED=20180218
          UPDATED=20180218
            SHORT="Locate per-dist and per-module shared files"

--- a/perl/File-Slurp/BUILD
+++ b/perl/File-Slurp/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/File-Slurp/DETAILS
+++ b/perl/File-Slurp/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/U/UR/URI/
       SOURCE_VFY=sha256:ce29ebe995097ebd6e9bc03284714cdfa0c46dc94f6b14a56980747ea3253643
         WEB_SITE=http://search.cpan.org/~uri/File-Slurp-$VERSION/
+            TYPE=perl
          ENTERED=20090328
          UPDATED=20111008
            SHORT="Perl module for efficient reading/writing of complete files"

--- a/perl/File-Temp/BUILD
+++ b/perl/File-Temp/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/File-Temp/DETAILS
+++ b/perl/File-Temp/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/D/DA/DAGOLDEN
       SOURCE_VFY=sha256:13415323e48f7c9f34efdedf3d35141a7c3435e2beb8c6b922229dc317d321ac
         WEB_SITE=http://search.cpan.org/~dagolden/File-Temp
+            TYPE=perl
          ENTERED=20070310
          UPDATED=20150705
            SHORT="Perl module to handle temporary files safely"

--- a/perl/File-Type/BUILD
+++ b/perl/File-Type/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/File-Type/DETAILS
+++ b/perl/File-Type/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/P/PM/PMISON/
       SOURCE_VFY=sha1:4ddd879f91a92a8ec66a3dbaa43bf5df617acd14
         WEB_SITE=http://www.perl.com/CPAN/modules/by-module/CPAN/
+            TYPE=perl
          ENTERED=20070310
          UPDATED=20070310
            SHORT="Perl module to determine file type using magic"

--- a/perl/File-Which/BUILD
+++ b/perl/File-Which/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/File-Which/DETAILS
+++ b/perl/File-Which/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/P/PL/PLICEASE
       SOURCE_VFY=sha256:9def5f10316bfd944e56b7f8a2501be1d44c288325309462aa9345e340854bcc
         WEB_SITE=http:/search.cpan.org/search?query=File-Which
+            TYPE=perl
          ENTERED=20150705
          UPDATED=20160813
            SHORT="Perl implementation of the which utility as an API"

--- a/perl/File-chdir/BUILD
+++ b/perl/File-chdir/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/File-chdir/DETAILS
+++ b/perl/File-chdir/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/D/DA/DAGOLDEN
       SOURCE_VFY=sha256:efc121f40bd7a0f62f8ec9b8bc70f7f5409d81cd705e37008596c8efc4452b01
         WEB_SITE=http://search.cpan.org/~dagolden/File-chdir
+            TYPE=perl
          ENTERED=20060310
          UPDATED=20150705
            SHORT="Perl module to provide a more sensible way to change directories"

--- a/perl/Filesys-Statvfs/BUILD
+++ b/perl/Filesys-Statvfs/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/Filesys-Statvfs/DETAILS
+++ b/perl/Filesys-Statvfs/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/I/IG/IGUTHRIE
       SOURCE_VFY=sha256:dc9494ca17af2b5226d50313efc5f02f3ff268d71c653cdb39bdd65fb3cf916a
         WEB_SITE=http:/search.cpan.org/search?query=Filesys-Statvfs
+            TYPE=perl
          ENTERED=20150705
          UPDATED=20150705
            SHORT="Perl extension for statvfs() and fstatvfs()"

--- a/perl/FreezeThaw/BUILD
+++ b/perl/FreezeThaw/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/FreezeThaw/DETAILS
+++ b/perl/FreezeThaw/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/I/IL/ILYAZ/modules/
       SOURCE_VFY=sha1:73a175385ab15bc8ca860eee769305488a881ab3
         WEB_SITE=http://search.cpan.org/~ilyaz/FreezeThaw/
+            TYPE=perl
          ENTERED=20070310
          UPDATED=20101110
            SHORT="Perl module to convert Perl structures to strings and back"

--- a/perl/Fuse/BUILD
+++ b/perl/Fuse/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/Fuse/DETAILS
+++ b/perl/Fuse/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/D/DP/DPATES
       SOURCE_VFY=sha256:30a939fe5816b00ba9cabb6cd811f894e6a74361ce29d786ae1811b0021d7aa1
         WEB_SITE=http://search.cpan.org/~dpates/Fuse
+            TYPE=perl
          ENTERED=20061023
          UPDATED=20150705
            SHORT="write filesystems in Perl using FUSE"

--- a/perl/GDGraph/BUILD
+++ b/perl/GDGraph/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/GDGraph/DETAILS
+++ b/perl/GDGraph/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/R/RU/RUZ
       SOURCE_VFY=sha256:d26538c827e35c1d4b27f3c045b60f1ab6b45401c54a87e86103cd7c2374cff5
         WEB_SITE=http://search.cpan.org/search?dist=GDGraph
+            TYPE=perl
          ENTERED=20011108
          UPDATED=20150705
            SHORT="Graph Plotting Module for Perl 5"

--- a/perl/GStreamer/BUILD
+++ b/perl/GStreamer/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/GStreamer/DETAILS
+++ b/perl/GStreamer/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/X/XA/XAOC
       SOURCE_VFY=sha256:5469e0433481cecef67d988eb039d719a229bfd6884d0d90cda69fef7f4bf8b7
         WEB_SITE=http://search.cpan.org/~xaoc/GStreamer
+            TYPE=perl
          ENTERED=20040712
          UPDATED=20150705
            SHORT="Perl interface to gstreamer"

--- a/perl/Geography-Countries/BUILD
+++ b/perl/Geography-Countries/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/Geography-Countries/DETAILS
+++ b/perl/Geography-Countries/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/A/AB/ABIGAIL
       SOURCE_VFY=sha1:2d3d8cdec27bea21ce7c7d3a1765ef86dceeec0c
         WEB_SITE=http://search.cpan.org/dist/Geography-Countries/
+            TYPE=perl
          ENTERED=20090810
          UPDATED=20090810
            SHORT="2-letter, 3-letter, and numerical codes for countries"

--- a/perl/Getopt-ArgvFile/BUILD
+++ b/perl/Getopt-ArgvFile/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/Getopt-ArgvFile/DETAILS
+++ b/perl/Getopt-ArgvFile/DETAILS
@@ -4,6 +4,7 @@
    SOURCE_URL[0]=http://search.cpan.org/CPAN/authors/id/J/JS/JSTENZEL/
       SOURCE_VFY=sha1:1c9b2b11f60617e198847876ea42fb6bd011d78e
         WEB_SITE=http://search.cpan.org/dist/Getopt-ArgvFile/
+            TYPE=perl
          ENTERED=20050929
          UPDATED=20070607
            SHORT="supplement to other option handling modules"

--- a/perl/Getopt-Long/BUILD
+++ b/perl/Getopt-Long/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/Getopt-Long/DETAILS
+++ b/perl/Getopt-Long/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/J/JV/JV
       SOURCE_VFY=sha256:20881adb2b73e83825f9a0a3b141db11b3a555e1d3775b13d81d0481623e4b67
         WEB_SITE=http://search.cpan.org/~jv/Getopt-Long
+            TYPE=perl
          ENTERED=20070604
          UPDATED=20171207
            SHORT="an extended getopt function"

--- a/perl/Glib-Perl/BUILD
+++ b/perl/Glib-Perl/BUILD
@@ -1,0 +1,3 @@
+perl -I$(pwd) Makefile.PL &&
+
+PERLLIB=$(pwd) default_make

--- a/perl/Glib-Perl/BUILD
+++ b/perl/Glib-Perl/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/Glib-Perl/DETAILS
+++ b/perl/Glib-Perl/DETAILS
@@ -6,6 +6,7 @@
 SOURCE_DIRECTORY=$BUILD_DIRECTORY/${MODULE%-*}-$VERSION
       SOURCE_VFY=sha256:f9d9b36226adbdb65b376d4bc9f00237a4ed85c4975e7cceff4acda28211a4ce
         WEB_SITE=http://search.cpan.org/~tsch/Glib/
+            TYPE=perl
          ENTERED=20040712
          UPDATED=20150705
            SHORT="Perl wrappers for the GLib utility and Object libraries"

--- a/perl/Gtk2-Ex-FormFactory/BUILD
+++ b/perl/Gtk2-Ex-FormFactory/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/Gtk2-Ex-FormFactory/DETAILS
+++ b/perl/Gtk2-Ex-FormFactory/DETAILS
@@ -4,6 +4,7 @@
    SOURCE_URL[0]=http://search.cpan.org/CPAN/authors/id/J/JR/JRED/
       SOURCE_VFY=sha1:1d42ad798a16efb212d984b3d38b630a8bf1cdb3
         WEB_SITE=http://search.cpan.org/~jred/Gtk2-Ex-FormFactory-0.65/
+            TYPE=perl
          ENTERED=20110327
          UPDATED=20111008
            SHORT="Makes building complex GUI's easy"

--- a/perl/Gtk2-Perl/BUILD
+++ b/perl/Gtk2-Perl/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/Gtk2-Perl/DETAILS
+++ b/perl/Gtk2-Perl/DETAILS
@@ -5,6 +5,7 @@ SOURCE_DIRECTORY=$BUILD_DIRECTORY/Gtk2-$VERSION
       SOURCE_URL=$SFORGE_URL/gtk2-perl
       SOURCE_VFY=sha256:6abcc772491f88308327e57f0de827b2abffd67ba677f2c82f291f893c9bfdd6
         WEB_SITE=http://gtk2-perl.sourceforge.net
+            TYPE=perl
          ENTERED=20040712
          UPDATED=20150705
            SHORT="Perl interface to gtk+-2"

--- a/perl/Gtk2-Spell/BUILD
+++ b/perl/Gtk2-Spell/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/Gtk2-Spell/DETAILS
+++ b/perl/Gtk2-Spell/DETAILS
@@ -5,6 +5,7 @@
       SOURCE_VFY=sha1:c4c042bbdf8e247b6c8a7f8fa8f27f295bc3adb1
         WEB_SITE=http://search.cpan.org/~mlehmann/Gtk2-Spell
       MAINTAINER=perldude@lunar-linux.org
+            TYPE=perl
          ENTERED=20060813
          UPDATED=20130606
            SHORT="Gtk2::Spell - Bindings for GtkSpell with Gtk2"

--- a/perl/Gtk2-TrayIcon/BUILD
+++ b/perl/Gtk2-TrayIcon/BUILD
@@ -1,4 +1,0 @@
-perl Makefile.PL &&
-
-default_make
-

--- a/perl/Gtk2-TrayIcon/DETAILS
+++ b/perl/Gtk2-TrayIcon/DETAILS
@@ -5,6 +5,7 @@
       SOURCE_VFY=sha1:aff8cb22ecc5ce4f8898cd7d8183a41f0e507b79
         WEB_SITE=http://search.cpan.org/~borup/Gtk2-TrayIcon/
       MAINTAINER=perldude@lunar-linux.org
+            TYPE=perl
          ENTERED=20060813
          UPDATED=20100222
            SHORT="Gtk2::TrayIcon - Perl interface to the EggTrayIcon library"

--- a/perl/HTML-Form/BUILD
+++ b/perl/HTML-Form/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/HTML-Form/DETAILS
+++ b/perl/HTML-Form/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/G/GA/GAAS/
       SOURCE_VFY=sha1:4b501ae3a5682a1efb1a8a34b19882244e6ecef1
         WEB_SITE=http://search.cpan.org/~gaas/HTML-Form/
+            TYPE=perl
          ENTERED=20111006
          UPDATED=20141021
            SHORT="Class that represents an HTML form element"

--- a/perl/HTML-Parser/BUILD
+++ b/perl/HTML-Parser/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/HTML-Parser/DETAILS
+++ b/perl/HTML-Parser/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/G/GA/GAAS/
       SOURCE_VFY=sha1:4f1968db53154ec54675e639000b5881962e8848
         WEB_SITE=http://search.cpan.org/~gaas/HTML-Parser
+            TYPE=perl
          ENTERED=20020727
          UPDATED=20141021
            SHORT="perl module for working with HTML"

--- a/perl/HTML-Tagset/BUILD
+++ b/perl/HTML-Tagset/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/HTML-Tagset/DETAILS
+++ b/perl/HTML-Tagset/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/P/PE/PETDANCE/
       SOURCE_VFY=sha1:cc906acec09b23d5ffa5e1d4f40441f9de1ad777
         WEB_SITE=http://search.cpan.org/~petdance/HTML-Tagset/
+            TYPE=perl
          ENTERED=20020727
          UPDATED=20100222
            SHORT="perl module of data tables used in parsing HTML"

--- a/perl/HTML-Template/BUILD
+++ b/perl/HTML-Template/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/HTML-Template/DETAILS
+++ b/perl/HTML-Template/DETAILS
@@ -5,6 +5,7 @@
    SOURCE_URL[1]=$SFORGE_URL/html-template/
       SOURCE_VFY=sha256:78100adaea7a56ae65826220fcb0c18a188df25a27227f96175cf7169fbb501d
         WEB_SITE=http://search.cpan.org/~wonko/HTML-Template
+            TYPE=perl
          ENTERED=20011108
          UPDATED=20150705
            SHORT="Perl module to use HTML Templates from CGI scripts"

--- a/perl/HTTP-Cache-Transparent/BUILD
+++ b/perl/HTTP-Cache-Transparent/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/HTTP-Cache-Transparent/DETAILS
+++ b/perl/HTTP-Cache-Transparent/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/M/MA/MATTIASH
       SOURCE_VFY=sha256:0abf7b7d972abcd5d77aa4d138ad58406948e7f276f4071e13097b841f7c7eda
         WEB_SITE=http://search.cpan.org/~mattiash/HTTP-Cache-Transparent
+            TYPE=perl
          ENTERED=20090328
          UPDATED=20150705
            SHORT="Perl module to cache the result of http get-requests"

--- a/perl/HTTP-Cookies/BUILD
+++ b/perl/HTTP-Cookies/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/HTTP-Cookies/DETAILS
+++ b/perl/HTTP-Cookies/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/G/GA/GAAS
       SOURCE_VFY=sha256:f5d3ade383ce6389d80cb0d0356b643af80435bb036afd8edce335215ec5eb20
         WEB_SITE=http://search.cpan.org/~gaas/HTTP-Cookies/
+            TYPE=perl
          ENTERED=20111006
          UPDATED=20150705
            SHORT="HTTP cookie jars"

--- a/perl/HTTP-Daemon/BUILD
+++ b/perl/HTTP-Daemon/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/HTTP-Daemon/DETAILS
+++ b/perl/HTTP-Daemon/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/G/GA/GAAS/
       SOURCE_VFY=sha1:d3b7614d4b3be4b61d26011efe90026c955102a4
         WEB_SITE=http://search.cpan.org/~gaas/HTTP-Daemon
+            TYPE=perl
          ENTERED=20111006
          UPDATED=20141021
            SHORT="a simple http server class"

--- a/perl/HTTP-Date/BUILD
+++ b/perl/HTTP-Date/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/HTTP-Date/DETAILS
+++ b/perl/HTTP-Date/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/G/GA/GAAS/
       SOURCE_VFY=sha1:85f8dbcad22f2680775a185ce91a42c89e0ad2a8
         WEB_SITE=http://search.cpan.org/~gaas/HTTP-Cookies/
+            TYPE=perl
          ENTERED=20111006
          UPDATED=20150217
            SHORT="date conversion routines"

--- a/perl/HTTP-Message/BUILD
+++ b/perl/HTTP-Message/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/HTTP-Message/DETAILS
+++ b/perl/HTTP-Message/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/O/OA/OALDERS/
       SOURCE_VFY=sha256:b0ba6cadff95367dfc97eaf63eea95cd795eeacf61f7bcdfa169127e015c6984
         WEB_SITE=http://search.cpan.org/~gaas/HTTP-Message/
+            TYPE=perl
          ENTERED=20111006
          UPDATED=20180605
            SHORT="HTTP style message"

--- a/perl/HTTP-Negotiate/BUILD
+++ b/perl/HTTP-Negotiate/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/HTTP-Negotiate/DETAILS
+++ b/perl/HTTP-Negotiate/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/G/GA/GAAS
       SOURCE_VFY=sha256:1c729c1ea63100e878405cda7d66f9adfd3ed4f1d6cacaca0ee9152df728e016
         WEB_SITE=http://search.cpan.org/search?query=http-negotiate
+            TYPE=perl
          ENTERED=20111006
          UPDATED=20150705
            SHORT="choose a variant to serve"

--- a/perl/IO-All/BUILD
+++ b/perl/IO-All/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/IO-All/DETAILS
+++ b/perl/IO-All/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/I/IN/INGY
       SOURCE_VFY=sha256:4574c2cfb8ca591783a62744d51952452e9304ff103865f2ee8c9c23a7e928d8
         WEB_SITE=http://search.cpan.org/~ingy/IO-All
+            TYPE=perl
          ENTERED=20050731
          UPDATED=20150705
            SHORT="combines all of the best Perl IO modules into a single package"

--- a/perl/IO-Capture/BUILD
+++ b/perl/IO-Capture/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/IO-Capture/DETAILS
+++ b/perl/IO-Capture/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/R/RE/REYNOLDS/
       SOURCE_VFY=sha1:8b1562675adfe70a789a3c14e7e14d7885ba8b85
         WEB_SITE=http://search.cpan.org/~reynolds/IO-Capture-0.05/
+            TYPE=perl
          ENTERED=20070607
          UPDATED=20070607
            SHORT="Abstract Base Class to build modules to capture output"

--- a/perl/IO-Compress-Base/BUILD
+++ b/perl/IO-Compress-Base/BUILD
@@ -1,0 +1,3 @@
+perl -I`pwd` Makefile.PL &&
+
+default_make

--- a/perl/IO-Compress-Base/BUILD
+++ b/perl/IO-Compress-Base/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/IO-Compress-Base/DETAILS
+++ b/perl/IO-Compress-Base/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/P/PM/PMQS
       SOURCE_VFY=sha1:595529168a46e8b195b7b0942c107f5fa2206af2
         WEB_SITE=http://search.cpan.org/~pmqs/IO-Compress-Base
+            TYPE=perl
          ENTERED=20061225
          UPDATED=20090628
            SHORT="Perl base class for IO::Compress and IO::Uncompress modules"

--- a/perl/IO-Compress-Zlib/BUILD
+++ b/perl/IO-Compress-Zlib/BUILD
@@ -1,0 +1,3 @@
+perl -I`pwd` Makefile.PL &&
+
+default_make

--- a/perl/IO-Compress-Zlib/BUILD
+++ b/perl/IO-Compress-Zlib/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/IO-Compress-Zlib/DETAILS
+++ b/perl/IO-Compress-Zlib/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/P/PM/PMQS
       SOURCE_VFY=sha1:a2dd277f083b53d50d683dcf8bff4c7b9177d295
         WEB_SITE=http://search.cpan.org/~pmqs/IO-Compress-Zlib
+            TYPE=perl
          ENTERED=20061225
          UPDATED=20090628
            SHORT="Perl module for manipulation of Zip files/buffers"

--- a/perl/IO-Digest/BUILD
+++ b/perl/IO-Digest/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/IO-Digest/DETAILS
+++ b/perl/IO-Digest/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/C/CL/CLKAO/
       SOURCE_VFY=sha256:8ffcf85a7f6213e5e94140adcc2b179ed02498eadc84309457e904dec93f7f92
         WEB_SITE=http://search.cpan.org/~clkao/IO-Digest
+            TYPE=perl
          ENTERED=20070310
          UPDATED=20150705
            SHORT="Perl module to calculate digests while reading or writing"

--- a/perl/IO-Pager/BUILD
+++ b/perl/IO-Pager/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/IO-Pager/DETAILS
+++ b/perl/IO-Pager/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/J/JP/JPIERCE
       SOURCE_VFY=sha256:31569ca0af93139e3ca7ce8aae38992930df95b047cffec2db165befca3ce00b
         WEB_SITE=http://www.perl.com/CPAN/modules/by-module/CPAN/
+            TYPE=perl
          ENTERED=20070310
          UPDATED=20150705
            SHORT="Perl module to select a pager"

--- a/perl/IO-Socket-INET6/BUILD
+++ b/perl/IO-Socket-INET6/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/IO-Socket-INET6/DETAILS
+++ b/perl/IO-Socket-INET6/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/S/SH/SHLOMIF
       SOURCE_VFY=sha256:85e020fa179284125fc1d08e60a9022af3ec1271077fe14b133c1785cdbf1ebb
         WEB_SITE=http://search.cpan.org/~shlomif/IO-Socket-INET6
+            TYPE=perl
          ENTERED=20100414
          UPDATED=20150705
            SHORT="Object interface for AF_INET|AF_INET6 domain sockets"

--- a/perl/IO-Socket-SSL/DETAILS
+++ b/perl/IO-Socket-SSL/DETAILS
@@ -7,6 +7,7 @@
    SOURCE_URL[3]=http://mirror.internode.on.net/pub/gentoo/distfiles
       SOURCE_VFY=sha256:b0f2199adf0f688a11357151fb47cd91b417a73d910539d4d48b5ac7e267ee07
         WEB_SITE=http://search.cpan.org/dist/IO-Socket-SSL
+            TYPE=perl
          ENTERED=20090328
          UPDATED=20170505
            SHORT="Nearly transparent SSL encapsulation for IO::Socket::INET"

--- a/perl/IO-String/BUILD
+++ b/perl/IO-String/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/IO-String/DETAILS
+++ b/perl/IO-String/DETAILS
@@ -4,6 +4,7 @@
    SOURCE_URL[0]=http://search.cpan.org/CPAN/authors/id/G/GA/GAAS/
       SOURCE_VFY=sha1:1a8cea5b19b6abb7f3731d6804073c0dd911d944
         WEB_SITE=http://search.cpan.org/~gaas/IO-String/
+            TYPE=perl
          ENTERED=20090320
          UPDATED=20090320
            SHORT="IO::File (and IO::Handle) compatible class"

--- a/perl/IO-Zlib/BUILD
+++ b/perl/IO-Zlib/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/IO-Zlib/DETAILS
+++ b/perl/IO-Zlib/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/T/TO/TOMHUGHES
       SOURCE_VFY=sha1:8d530d2268e3c32f7644495287219361e6e262fb
         WEB_SITE=http://search.cpan.org/~tomhughes/IO-Zlib/
+            TYPE=perl
          ENTERED=20100414
          UPDATED=20100426
            SHORT="IO:: style interface to Compress::Zlib"

--- a/perl/IO-stringy/BUILD
+++ b/perl/IO-stringy/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/IO-stringy/DETAILS
+++ b/perl/IO-stringy/DETAILS
@@ -4,6 +4,7 @@
    SOURCE_URL[0]=http://search.cpan.org/CPAN/authors/id/D/DS/DSKOLL/
       SOURCE_VFY=sha256:8c67fd6608c3c4e74f7324f1404a856c331dbf48d9deda6aaa8296ea41bf199d
         WEB_SITE=http://search.cpan.org/search?dist=IO-stringy
+            TYPE=perl
          ENTERED=20030309
          UPDATED=20150705
            SHORT="PERL IO string handling"

--- a/perl/IO/BUILD
+++ b/perl/IO/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/IP-Country/BUILD
+++ b/perl/IP-Country/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/IP-Country/DETAILS
+++ b/perl/IP-Country/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/N/NW/NWETTERS
       SOURCE_VFY=sha256:88db833a5ab22ed06cb53d6f205725e3b5371b254596053738885e91fa105f75
         WEB_SITE=http://search.cpan.org/dist/IP-Country
+            TYPE=perl
          ENTERED=20090810
          UPDATED=20150705
            SHORT="Fast lookup of country codes from IP addresses"

--- a/perl/IPC-Run3/BUILD
+++ b/perl/IPC-Run3/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/IPC-Run3/DETAILS
+++ b/perl/IPC-Run3/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/R/RJ/RJBS
       SOURCE_VFY=sha256:3d81c3cc1b5cff69cca9361e2c6e38df0352251ae7b41e2ff3febc850e463565
         WEB_SITE=http://search.cpan.org/~rjbs/IPC-Run3
+            TYPE=perl
          ENTERED=20071221
          UPDATED=20150705
            SHORT="Perl module to run a subprocess in batch mode"

--- a/perl/IPC-System-Simple/BUILD
+++ b/perl/IPC-System-Simple/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/IPC-System-Simple/DETAILS
+++ b/perl/IPC-System-Simple/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/P/PJ/PJF
       SOURCE_VFY=sha256:f1b6aa1dfab886e8e4ea825f46a1cbb26038ef3e727fef5d84444aa8035a4d3b
         WEB_SITE=http://search.cpan.org/search?query=IPC-System
+            TYPE=perl
          ENTERED=20150705
          UPDATED=20150705
            SHORT="Run commands simply, with detailed diagnostics"

--- a/perl/Image-ExifTool/BUILD
+++ b/perl/Image-ExifTool/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/Image-ExifTool/DETAILS
+++ b/perl/Image-ExifTool/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://www.sno.phy.queensu.ca/~phil/exiftool
       SOURCE_VFY=sha256:e3376f2c1ec4f256fe3810808bc7b16076c6e6364bc5719f3fa82abb6adf5608
         WEB_SITE=http://www.sno.phy.queensu.ca/~phil/exiftool
+            TYPE=perl
          ENTERED=20080913
          UPDATED=20170402
            SHORT="perl module for editing, writing and editing meta information"

--- a/perl/Image-Size/BUILD
+++ b/perl/Image-Size/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/Image-Size/DETAILS
+++ b/perl/Image-Size/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/R/RJ/RJRAY
       SOURCE_VFY=sha256:53c9b1f86531cde060ee63709d1fda73cabc0cf2d581d29b22b014781b9f026b
         WEB_SITE=http://search.cpan.org/~rjray/Image-Size
+            TYPE=perl
          ENTERED=20111006
          UPDATED=20150705
            SHORT="read the dimensions of an image in several popular formats"

--- a/perl/Inline/BUILD
+++ b/perl/Inline/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/Inline/DETAILS
+++ b/perl/Inline/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/I/IN/INGY
       SOURCE_VFY=sha256:7e2bd984b1ebd43e336b937896463f2c6cb682c956cbd2c311a464363d2ccef6
         WEB_SITE=http://search.cpan.org/search?dist=Inline
+            TYPE=perl
          ENTERED=20061023
          UPDATED=20150705
            SHORT="Write Perl subroutines in other programming languages."

--- a/perl/JSON-PP/BUILD
+++ b/perl/JSON-PP/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/JSON-PP/DETAILS
+++ b/perl/JSON-PP/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/M/MA/MAKAMAKA
       SOURCE_VFY=sha256:5feef3067be4acd99ca0ebb29cf1ac1cdb338fe46977585bd1e473ea4bab71a3
         WEB_SITE=http://search.cpan.org/~makamaka/JSON-PP-$VERSION/
+            TYPE=perl
          ENTERED=20110430
          UPDATED=20150705
            SHORT="parameterized JSON with padding"

--- a/perl/JSON/BUILD
+++ b/perl/JSON/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/JSON/DETAILS
+++ b/perl/JSON/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/M/MA/MAKAMAKA
       SOURCE_VFY=sha256:4ddbb3cb985a79f69a34e7c26cde1c81120d03487e87366f9a119f90f7bdfe88
         WEB_SITE=http://search.cpan.org/~makamaka/JSON
+            TYPE=perl
          ENTERED=20111009
          UPDATED=20150705
            SHORT="JSON (JavaScript Object Notation) encoder/decoder"

--- a/perl/LWP-MediaTypes/BUILD
+++ b/perl/LWP-MediaTypes/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/LWP-MediaTypes/DETAILS
+++ b/perl/LWP-MediaTypes/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/G/GA/GAAS/
       SOURCE_VFY=sha1:f56891f4e718a5f1f16f09ae37d32e454095cbed
         WEB_SITE=http://search.cpan.org/~gaas/LWP-MediaTypes
+            TYPE=perl
          ENTERED=20111006
          UPDATED=20141021
            SHORT="guess media type for a file or a URL"

--- a/perl/Lchown/BUILD
+++ b/perl/Lchown/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/Lchown/DETAILS
+++ b/perl/Lchown/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/N/NC/NCLEATON
       SOURCE_VFY=sha256:9c0a13e279ad92208fb8fac73001635b0689251dd41b597522e1b3501ba0f76f
         WEB_SITE=http:/search.cpan.org/search?query=Lchown
+            TYPE=perl
          ENTERED=20150705
          UPDATED=20150705
            SHORT="use the lchown(2) system call from Perl"

--- a/perl/Lingua-EN-Numbers-Ordinate/BUILD
+++ b/perl/Lingua-EN-Numbers-Ordinate/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/Lingua-EN-Numbers-Ordinate/DETAILS
+++ b/perl/Lingua-EN-Numbers-Ordinate/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/N/NE/NEILB
       SOURCE_VFY=sha256:26973c2eb43672c3f61ad7d3fef12ef1c64a034da494a0ee0d910c3e0808019f
         WEB_SITE=http://search.cpan.org/search?dist=Lingua-EN-Numbers-Ordinate
+            TYPE=perl
          ENTERED=20040911
          UPDATED=20150705
            SHORT="Perl module for going from cardinal numbers to ordinals"

--- a/perl/Lingua-Preferred/BUILD
+++ b/perl/Lingua-Preferred/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/Lingua-Preferred/DETAILS
+++ b/perl/Lingua-Preferred/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://www.cpan.org/authors/id/E/ED/EDAVIS/
       SOURCE_VFY=sha1:b8c08b30fd17ebd691f37cc9e142306769990ccb
         WEB_SITE=http://search.cpan.org/search?dist=Lingua-Preferred
+            TYPE=perl
          ENTERED=20040911
          UPDATED=20040911
            SHORT="Perl module for choosing a language"

--- a/perl/Linux-DVB/DETAILS
+++ b/perl/Linux-DVB/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/M/ML/MLEHMANN
       SOURCE_VFY=sha256:52e66c76dedea3d0546497b3eeb0fdd8b6b3dfe7a29c7f7ec87daeda4c88b2db
         WEB_SITE=http://search.cpan.org/~mlehmann/Linux-DVB
+            TYPE=perl
          ENTERED=20111008
          UPDATED=20150705
            SHORT="interface to (some parts of) the Linux DVB API"

--- a/perl/List-MoreUtils/BUILD
+++ b/perl/List-MoreUtils/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/List-MoreUtils/DETAILS
+++ b/perl/List-MoreUtils/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/R/RE/REHSACK/
       SOURCE_VFY=sha256:713e0945d5f16e62d81d5f3da2b6a7b14a4ce439f6d3a7de74df1fd166476cc2
         WEB_SITE=http://search.cpan.org/~vparseval/List-MoreUtils/
+            TYPE=perl
          ENTERED=20070310
          UPDATED=20150615
            SHORT="Perl module to provide the stuff missing in List::Util"

--- a/perl/Locale-Maketext-Lexicon/BUILD
+++ b/perl/Locale-Maketext-Lexicon/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/Locale-Maketext-Lexicon/DETAILS
+++ b/perl/Locale-Maketext-Lexicon/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/D/DR/DRTECH
       SOURCE_VFY=sha256:b73f6b04a58d3f0e38ebf2115a4c1532f1a4eef6fac5c6a2a449e4e14c1ddc7c
         WEB_SITE=http://search.cpan.org/~drtech/Locale-Maketext-Lexicon
+            TYPE=perl
          ENTERED=20060310
          UPDATED=20150705
            SHORT="Perl module to use other catalog formats in Maketext"

--- a/perl/Locale-Maketext-Simple/BUILD
+++ b/perl/Locale-Maketext-Simple/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/Locale-Maketext-Simple/DETAILS
+++ b/perl/Locale-Maketext-Simple/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/J/JE/JESSE/
       SOURCE_VFY=sha1:951ad01d0969d0a895c719edfaeb0c2c097fda68
         WEB_SITE=http://search.cpan.org/~jesse/Locale-Maketext-Simple/
+            TYPE=perl
          ENTERED=20070310
          UPDATED=20100222
            SHORT="Perl module to provide a simple interface to Locale::Maketext::Lexicon"

--- a/perl/Locale-gettext/BUILD
+++ b/perl/Locale-gettext/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/Locale-gettext/DETAILS
+++ b/perl/Locale-gettext/DETAILS
@@ -8,6 +8,7 @@
      SOURCE2_VFY=sha1:ab07595023a5f7dc59606b6386376151e01af2ef
 SOURCE_DIRECTORY=$BUILD_DIRECTORY/gettext-$VERSION
         WEB_SITE=http://search.cpan.org/search?dist=gettext
+            TYPE=perl
          ENTERED=20061110
          UPDATED=20110530
            SHORT="message handling functions"

--- a/perl/Log-Log4perl/BUILD
+++ b/perl/Log-Log4perl/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/Log-Log4perl/DETAILS
+++ b/perl/Log-Log4perl/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/M/MS/MSCHILLI/
       SOURCE_VFY=sha256:31011a17c04e78016e73eaa4865d0481d2ffc3dc22813c61065d90ad73c64e6f
         WEB_SITE=http://search.cpan.org/~mschilli/Log-Log4perl/
+            TYPE=perl
          ENTERED=20070310
          UPDATED=20150615
            SHORT="Log4j implementation for Perl"

--- a/perl/MD5/BUILD
+++ b/perl/MD5/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/MD5/DETAILS
+++ b/perl/MD5/DETAILS
@@ -3,6 +3,7 @@
           SOURCE=$MODULE-$VERSION.tar.gz
    SOURCE_URL[0]=http://www.cpan.org/authors/id/GAAS/
         WEB_SITE=http://search.cpan.org/search?dist=MD5
+            TYPE=perl
          ENTERED=20020507
          UPDATED=20040427
       MAINTAINER=kongar@tsrsb.org.tr

--- a/perl/MIME-Base64/BUILD
+++ b/perl/MIME-Base64/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/MIME-Base64/DETAILS
+++ b/perl/MIME-Base64/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/G/GA/GAAS
       SOURCE_VFY=sha256:7f863566a6a9cb93eda93beadb77d9aa04b9304d769cea3bb921b9a91b3a1eb9
         WEB_SITE=http://search.cpan.org/~gaas/MIME-Base64
+            TYPE=perl
          ENTERED=20111006
          UPDATED=20150705
            SHORT="Encoding and decoding of base64 strings"

--- a/perl/MIME-Lite/BUILD
+++ b/perl/MIME-Lite/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/MIME-Lite/DETAILS
+++ b/perl/MIME-Lite/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/R/RJ/RJBS
       SOURCE_VFY=sha256:8f39901bc580bc3dce69e10415305e4435ff90264c63d29f707b4566460be962
         WEB_SITE=http://search.cpan.org/~rjbs/MIME-Lite
+            TYPE=perl
          ENTERED=20020729
          UPDATED=20150705
            SHORT="perl module for generating MIME messages"

--- a/perl/MIME-Types/BUILD
+++ b/perl/MIME-Types/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/MIME-Types/DETAILS
+++ b/perl/MIME-Types/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/M/MA/MARKOV
       SOURCE_VFY=sha256:8c51fd21d5c5c5b3469672faeb76caa02c77f537a3139e018ffed0e521956dec
         WEB_SITE=http://search.cpan.org/~markov/MIME-Types
+            TYPE=perl
          ENTERED=20150705
          UPDATED=20150705
            SHORT="data-structure to keep knowledge about various data types are defined by MIME"

--- a/perl/MIME-tools/BUILD
+++ b/perl/MIME-tools/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/MIME-tools/DETAILS
+++ b/perl/MIME-tools/DETAILS
@@ -5,6 +5,7 @@ SOURCE_DIRECTORY=$BUILD_DIRECTORY/$MODULE-$VERSION
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/D/DS/DSKOLL
       SOURCE_VFY=sha256:dbed9bf46830c4a1df9840a546824ee44d14902012870f0c34bc4f5cc86af812
         WEB_SITE=http://search.cpan.org/~doneill/MIME-tools
+            TYPE=perl
          ENTERED=20030107
          UPDATED=20150705
            SHORT="modules for parsing (and creating!) MIME entities"

--- a/perl/MP3-Info/BUILD
+++ b/perl/MP3-Info/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/MP3-Info/DETAILS
+++ b/perl/MP3-Info/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/J/JM/JMERELO/
       SOURCE_VFY=sha256:5762340732421f2502a770d6a126e584f2cd963351d2bc257bd278c39bce8be7
         WEB_SITE=http://search.cpan.org/~daniel/MP3-Info-1.24/
+            TYPE=perl
          ENTERED=20090320
          UPDATED=20171007
            SHORT="for getting info out of and into MP3 files"

--- a/perl/MP3-Tag/BUILD
+++ b/perl/MP3-Tag/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/MP3-Tag/DETAILS
+++ b/perl/MP3-Tag/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/I/IL/ILYAZ/modules/
       SOURCE_VFY=sha1:df14d4dc39b76956f1c664ed3d3a6de2a9117895
         WEB_SITE=http://search.cpan.org/~ilyaz/MP3-Tag/
+            TYPE=perl
          ENTERED=20061023
          UPDATED=20101110
            SHORT="Module for reading tags of MP3 audio files"

--- a/perl/MP4-Info/BUILD
+++ b/perl/MP4-Info/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/MP4-Info/DETAILS
+++ b/perl/MP4-Info/DETAILS
@@ -4,6 +4,7 @@
    SOURCE_URL[0]=http://search.cpan.org/CPAN/authors/id/J/JH/JHAR/
       SOURCE_VFY=sha1:b27127d547d1ee5c8531b6e9d0224d66b6611436
         WEB_SITE=http://search.cpan.org/~jhar/MP4-Info-$VERSION/
+            TYPE=perl
          ENTERED=20090320
          UPDATED=20110415
            SHORT="Fetch info from MPEG-4 files"

--- a/perl/Mail-Audit/BUILD
+++ b/perl/Mail-Audit/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/Mail-Audit/DETAILS
+++ b/perl/Mail-Audit/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/R/RJ/RJBS
       SOURCE_VFY=sha256:41a42dc3fbead585c732de5e35b46c3d3511358458bc31520abac1946c99d2e4
         WEB_SITE=http://search.cpan.org/~rjbs/Mail-Audit
+            TYPE=perl
          ENTERED=20030107
          UPDATED=20150705
            SHORT="Library for creating easy mail filters"

--- a/perl/Mail-DKIM/BUILD
+++ b/perl/Mail-DKIM/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/Mail-DKIM/DETAILS
+++ b/perl/Mail-DKIM/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/J/JA/JASLONG
       SOURCE_VFY=sha256:3c5ea0c3a2028a5a2c3b64bbcd6bd9de6a5fa5ee4e16046dd8875c4796aaa6f1
         WEB_SITE=http://search.cpan.org/~jaslong/Mail-DKIM
+            TYPE=perl
          ENTERED=20100414
          UPDATED=20150705
            SHORT="Implements DomainKeys Identified Mail (DKIM)"

--- a/perl/Mail-POP3Client/BUILD
+++ b/perl/Mail-POP3Client/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/Mail-POP3Client/DETAILS
+++ b/perl/Mail-POP3Client/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/S/SD/SDOWD
       SOURCE_VFY=sha256:1142d6247a93cb86b23ed8835553bb2d227ff8213ee2743e4155bb93f47acb59
         WEB_SITE=http://search.cpan.org/~sdowd/Mail-POP3Client
+            TYPE=perl
          ENTERED=20150705
          UPDATED=20150705
            SHORT="talk to a POP3 (RFC1939) server"

--- a/perl/Mail-SPF/BUILD
+++ b/perl/Mail-SPF/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/Mail-SPF/DETAILS
+++ b/perl/Mail-SPF/DETAILS
@@ -7,6 +7,7 @@
       SOURCE_VFY=sha1:df53baf018134481591317baf1b5d3a10702d4e7
      SOURCE2_VFY=sha1:e586916f6ee3f2dcd7ac8d1a0ce1e3d370b9e372
         WEB_SITE=http://search.cpan.org/~jmehnle/Mail-SPF
+            TYPE=perl
          ENTERED=20100402
          UPDATED=20100514
            SHORT="an implementation of Sender Policy Framework"

--- a/perl/Mail-Sendmail/BUILD
+++ b/perl/Mail-Sendmail/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/Mail-Sendmail/DETAILS
+++ b/perl/Mail-Sendmail/DETAILS
@@ -4,6 +4,7 @@
    SOURCE_URL[0]=http://search.cpan.org/CPAN/authors/id/M/MI/MIVKOVIC/
       SOURCE_VFY=sha1:606d1dc108fad8ec962062b8dbdee0f7dfa82329
         WEB_SITE=http://search.cpan.org/~mivkovic/Mail-Sendmail-0.79/
+            TYPE=perl
          ENTERED=20011108
          UPDATED=20060210
            SHORT="Mail::Sendmail : A simple module to send mail."

--- a/perl/MailTools/BUILD
+++ b/perl/MailTools/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/MailTools/DETAILS
+++ b/perl/MailTools/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/M/MA/MARKOV
       SOURCE_VFY=sha256:4b7c7ef674b2ef75ea793f053cd067c6a4b33e58e3adf08a89c8ea4c56b3dff8
         WEB_SITE=http://search.cpan.org/search?dist=MailTools
+            TYPE=perl
          ENTERED=20030107
          UPDATED=20150705
            SHORT="perl mail tool functions"

--- a/perl/Math-Round/BUILD
+++ b/perl/Math-Round/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/Math-Round/DETAILS
+++ b/perl/Math-Round/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/G/GR/GROMMEL
       SOURCE_VFY=sha256:73a7329a86e54a5c29a440382e5803095b58f33129e61a1df0093b4824de9327
         WEB_SITE=http://search.cpan.org/~drolsky/Math-Round
+            TYPE=perl
          ENTERED=20111009
          UPDATED=20150705
            SHORT="Perl extension for rounding numbers"

--- a/perl/Module-Implementation/BUILD
+++ b/perl/Module-Implementation/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/Module-Implementation/DETAILS
+++ b/perl/Module-Implementation/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/D/DR/DROLSKY
       SOURCE_VFY=sha256:c15f1a12f0c2130c9efff3c2e1afe5887b08ccd033bd132186d1e7d5087fd66d
         WEB_SITE=http://search.cpan.org/~drolsky/Module-Implementation
+            TYPE=perl
          ENTERED=20150705
          UPDATED=20150705
            SHORT="loads one of several alternate underlying implementations for a module"

--- a/perl/Module-Metadata/BUILD
+++ b/perl/Module-Metadata/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/Module-Metadata/DETAILS
+++ b/perl/Module-Metadata/DETAILS
@@ -4,6 +4,7 @@
    SOURCE_URL[0]=http://search.cpan.org/CPAN/authors/id/D/DA/DAGOLDEN/
       SOURCE_VFY=sha1:d96557b4476fbbe9d6f3d0a78240511810f154d1
         WEB_SITE=http://search.cpan.org/~dagolden/Module-Metadata-$VERSION/
+            TYPE=perl
          ENTERED=20110416
          UPDATED=20111008
            SHORT="Gather package and POD information from perl module files"

--- a/perl/Module-Runtime/BUILD
+++ b/perl/Module-Runtime/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/Module-Runtime/DEPENDS
+++ b/perl/Module-Runtime/DEPENDS
@@ -1,1 +1,1 @@
-depends perl
+depends Module-Build

--- a/perl/Module-Runtime/DETAILS
+++ b/perl/Module-Runtime/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/Z/ZE/ZEFRAM
       SOURCE_VFY=sha256:4c44fe0ea255a9fd00741ee545063f6692d2a28e7ef2fbaad1b24a92803362a4
         WEB_SITE=http://search.cpan.org/~zefram/Module-Runtime
+            TYPE=perl
          ENTERED=20150705
          UPDATED=20150705
            SHORT="runtime module handling"

--- a/perl/Net-DBus/BUILD
+++ b/perl/Net-DBus/BUILD
@@ -1,4 +1,0 @@
-perl  Makefile.PL &&
-
-default_make
-

--- a/perl/Net-DBus/DETAILS
+++ b/perl/Net-DBus/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/D/DA/DANBERR
       SOURCE_VFY=sha256:8391696db9e96c374b72984c0bad9c7d1c9f3b4efe68f9ddf429a77548e0e269
         WEB_SITE=http://search.cpan.org/~danberr/Net-DBus
+            TYPE=perl
          ENTERED=20070916
          UPDATED=20150705
            SHORT="Perl XS API to dbus"

--- a/perl/Net-DNS-Resolver-Programmable/BUILD
+++ b/perl/Net-DNS-Resolver-Programmable/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/Net-DNS-Resolver-Programmable/DETAILS
+++ b/perl/Net-DNS-Resolver-Programmable/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/J/JM/JMEHNLE/net-dns-resolver-programmable
       SOURCE_VFY=sha1:05601b1a3054eaaca03b3ec6e4aeefdb838dc44e
         WEB_SITE=http://search.cpan.org/dist/Net-DNS-Resolver-Programmable
+            TYPE=perl
          ENTERED=20100514
          UPDATED=20100514
            SHORT="programmable DNS resolver class for offline emulation of DNS"

--- a/perl/Net-DNS/DETAILS
+++ b/perl/Net-DNS/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/N/NL/NLNETLABS/
       SOURCE_VFY=sha256:1ad46ba6438b846a94b4f50d53ecfda55f504a17e11b94effb087ff9329e61d0
         WEB_SITE=http://search.cpan.org/search?dist=Net-DNS
+            TYPE=perl
          ENTERED=20020619
          UPDATED=20180210
            SHORT="perl DNS Resolver Module"

--- a/perl/Net-HTTP/BUILD
+++ b/perl/Net-HTTP/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/Net-HTTP/DETAILS
+++ b/perl/Net-HTTP/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://cpan.metacpan.org/authors/id/O/OA/OALDERS/
       SOURCE_VFY=sha256:70c45b6aaf3e9fb1ce30a1fc3cf828cfaee45c5c0bd147b2f617efade1765e78
         WEB_SITE=http://search.cpan.org/~ether/Net-HTTP
+            TYPE=perl
          ENTERED=20111006
          UPDATED=20170606
            SHORT="Low-level HTTP connection (client)"

--- a/perl/Net-Ident/BUILD
+++ b/perl/Net-Ident/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/Net-Ident/DETAILS
+++ b/perl/Net-Ident/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/T/TO/TODDR/
       SOURCE_VFY=sha256:5f5f1142185a67b87406a3fb31f221564f61838a70ef4c07284a66c55e82ad05
         WEB_SITE=http://search.cpan.org/~jpc/Net-Ident
+            TYPE=perl
          ENTERED=20100414
          UPDATED=20150705
            SHORT="lookup the username on the remote end of a TCP/IP connection"

--- a/perl/Net-Netmask/BUILD
+++ b/perl/Net-Netmask/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/Net-Netmask/DETAILS
+++ b/perl/Net-Netmask/DETAILS
@@ -4,6 +4,7 @@
    SOURCE_URL[0]=http://search.cpan.org/CPAN/authors/id/M/MU/MUIR/modules
       SOURCE_VFY=sha256:07099c1ff4de752e6f5420b32de12e4338b05bbb252e53c782b740173ba31533
         WEB_SITE=http://search.cpan.org/search?query=Net-netmask
+            TYPE=perl
          ENTERED=20021228
          UPDATED=20150705
       MAINTAINER=csm@moongroup.com

--- a/perl/Net-RawSock/BUILD
+++ b/perl/Net-RawSock/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/Net-RawSock/DETAILS
+++ b/perl/Net-RawSock/DETAILS
@@ -4,6 +4,7 @@
    SOURCE_URL[0]=http://www.hsc.fr/ressources/outils/rawsock/download/
       SOURCE_VFY=sha1:fd57c3fdee92dd56c9da567b1fa9a0d80e246980
         WEB_SITE=http://www.hsc.fr/ressources/outils/rawsock/index.html
+            TYPE=perl
          ENTERED=20040217
          UPDATED=20040217
            SHORT="Net::RawSock provides a base function to send raw IP datagrams from Perl."

--- a/perl/Net-SNMP/BUILD
+++ b/perl/Net-SNMP/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/Net-SNMP/DETAILS
+++ b/perl/Net-SNMP/DETAILS
@@ -4,6 +4,7 @@
    SOURCE_URL[0]=http://search.cpan.org/CPAN/authors/id/D/DT/DTOWN/
    SOURCE_VFY[0]=sha1:492073bcf5206b56783e07c0603ff3b1f12707fa
         WEB_SITE=http://search.cpan.org/~dtown/Net-SNMP/
+            TYPE=perl
          ENTERED=20011108
          UPDATED=20101219
            SHORT="a perl module for Simple Network Management Protocol"

--- a/perl/Net-Server/BUILD
+++ b/perl/Net-Server/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/Net-Server/DETAILS
+++ b/perl/Net-Server/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/R/RH/RHANDOM
       SOURCE_VFY=sha256:0921056aedc871a59c4b76f58764f0e0a16c1816b58c366a9d80e46367744fa0
         WEB_SITE=http://search.cpan.org/~rhandom/Net-Server/
+            TYPE=perl
          ENTERED=20030309
          UPDATED=20150705
            SHORT="Extensible, general Perl server engine"

--- a/perl/Net-UPnP/BUILD
+++ b/perl/Net-UPnP/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/Net-UPnP/DETAILS
+++ b/perl/Net-UPnP/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/S/SK/SKONNO
       SOURCE_VFY=sha256:cf323b34adb07c4cf79443bbebbafca11e213f1c7a50b5fac5e572909598821b
         WEB_SITE=http://search.cpan.org/~skonno/Net-UPnP
+            TYPE=perl
          ENTERED=20101111
          UPDATED=20150705
            SHORT="Perl extension for UPnP"

--- a/perl/NetAddr-IP/BUILD
+++ b/perl/NetAddr-IP/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/NetAddr-IP/DETAILS
+++ b/perl/NetAddr-IP/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/M/MI/MIKER
       SOURCE_VFY=sha256:ab8275bb8f306f780cd029a6dc48764461f4d1ef3a106b99fe5a90cbf2968839
         WEB_SITE=http://search.cpan.org/search?dist=NetAddr-IP
+            TYPE=perl
          ENTERED=20100401
          UPDATED=20150705
            SHORT="manages IPv4 and IPv6 addresses and subnets in perl"

--- a/perl/OLE-Storage_Lite/BUILD
+++ b/perl/OLE-Storage_Lite/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/OLE-Storage_Lite/DETAILS
+++ b/perl/OLE-Storage_Lite/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/J/JM/JMCNAMARA
       SOURCE_VFY=sha256:e72e055c35bd85ad7c20cf2adb6c89bdbf5725df969484fa6dc981d531ef2c9d
         WEB_SITE=http://search.cpan.org/~jmcnamara/OLE-Storage_Lite
+            TYPE=perl
          ENTERED=20150705
          UPDATED=20150705
            SHORT="Simple Class for OLE document interface"

--- a/perl/Ogg-Vorbis-Header/BUILD
+++ b/perl/Ogg-Vorbis-Header/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/Ogg-Vorbis-Header/DETAILS
+++ b/perl/Ogg-Vorbis-Header/DETAILS
@@ -4,6 +4,7 @@
    SOURCE_URL[0]=http://search.cpan.org/CPAN/authors/id/D/DB/DBP/
       SOURCE_VFY=sha1:82db618b9fb9df4522c480052ba7bd59eb9724e0
         WEB_SITE=http://search.cpan.org/~dbp/Ogg-Vorbis-Header/
+            TYPE=perl
          ENTERED=20090320
          UPDATED=20090320
            SHORT="object-oriented interface to Ogg Vorbis files"

--- a/perl/PAR-Dist/BUILD
+++ b/perl/PAR-Dist/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/PAR-Dist/DETAILS
+++ b/perl/PAR-Dist/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/R/RS/RSCHUPP/
       SOURCE_VFY=sha256:9e47220b594a27bd1750bcfa1d6f60a57ae670c68ce331895a79f08bac671e1d
         WEB_SITE=http://search.cpan.org/dist/PAR-Dist/
+            TYPE=perl
          ENTERED=20150925
          UPDATED=20150925
            SHORT="Perl bindings to create and manipulate PAR distributions"

--- a/perl/Pango-Perl/BUILD
+++ b/perl/Pango-Perl/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/Pango-Perl/DETAILS
+++ b/perl/Pango-Perl/DETAILS
@@ -6,6 +6,7 @@ SOURCE_DIRECTORY=$BUILD_DIRECTORY/Pango-$VERSION
    SOURCE_URL[1]=$SFORGE_URL/gtk2-perl/
       SOURCE_VFY=sha256:9f7039bf79bca027009fdc2b0472ecf2d2e0e30227fb92c5ecd1c867dae99264
         WEB_SITE=http://search.cpan.org/~tsch/Pango/
+            TYPE=perl
          ENTERED=20090318
          UPDATED=20150705
            SHORT="Perl wrappers for the Pango library"

--- a/perl/Parse-CPAN-Meta/BUILD
+++ b/perl/Parse-CPAN-Meta/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/Parse-CPAN-Meta/DETAILS
+++ b/perl/Parse-CPAN-Meta/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/D/DA/DAGOLDEN
       SOURCE_VFY=sha256:dd1df72c80390551563159f18f81a26baabeda8d4b0e94df7f1c223391967121
         WEB_SITE=http://search.cpan.org/~dagolden/Parse-CPAN-Meta-$VERSION/
+            TYPE=perl
          ENTERED=20110416
          UPDATED=20150705
            SHORT="Parse META.yml and META.json CPAN metadata files"

--- a/perl/Parse-Pidl/BUILD
+++ b/perl/Parse-Pidl/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/Parse-Pidl/DETAILS
+++ b/perl/Parse-Pidl/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/C/CT/CTRLSOFT/
       SOURCE_VFY=sha1:6e814c2a7a2f83e8c62d3e3bebd757f03c54b38e
         WEB_SITE=http://search.cpan.org/~ctrlsoft/Parse-Pidl/
+            TYPE=perl
          ENTERED=20071027
          UPDATED=20071027
            SHORT="IDL Compiler written in Perl"

--- a/perl/Parse-RecDescent/BUILD
+++ b/perl/Parse-RecDescent/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/Parse-RecDescent/DETAILS
+++ b/perl/Parse-RecDescent/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/J/JT/JTBRAUN
       SOURCE_VFY=sha256:e1000f0b82256269fb8daa43aab166a7832fc18b4689af7c8d6d1a49fe75c687
         WEB_SITE=http://search.cpan.org/~jtbraun/Parse-RecDescent
+            TYPE=perl
          ENTERED=20090320
          UPDATED=20150705
            SHORT="generate recursive-descent parsers"

--- a/perl/Path-Class/BUILD
+++ b/perl/Path-Class/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/Path-Class/DETAILS
+++ b/perl/Path-Class/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/K/KW/KWILLIAMS
       SOURCE_VFY=sha256:9226b305196127d02529303dbd6c37802baafe736f0245cb089241ed25922aee
         WEB_SITE=http://search.cpan.org/~kwilliams/Path-Class
+            TYPE=perl
          ENTERED=20070310
          UPDATED=20150705
            SHORT="Perl module to provide cross-platform path manipulation"

--- a/perl/PathTools/BUILD
+++ b/perl/PathTools/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/PathTools/DETAILS
+++ b/perl/PathTools/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/S/SM/SMUELLER/
       SOURCE_VFY=sha256:caa8d4b45372b8cb0ef0f6f696efa3a60b0fd394b115cad39a7fbb8f6bd38026
         WEB_SITE=http://search.cpan.org/search?dist=PathTools
+            TYPE=perl
          ENTERED=20040921
          UPDATED=20150218
            SHORT="PathTools Speculates and acts on file names"

--- a/perl/Perl-OSType/BUILD
+++ b/perl/Perl-OSType/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/Perl-OSType/DETAILS
+++ b/perl/Perl-OSType/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/D/DA/DAGOLDEN
       SOURCE_VFY=sha256:a1c2cd995314348e04eadb6675943edac55a351e56316cf965ae902e7be0bef1
         WEB_SITE=http://search.cpan.org/~dagolden/Perl-OSType
+            TYPE=perl
          ENTERED=20110416
          UPDATED=20150705
            SHORT="Map Perl operating system names to generic types"

--- a/perl/Perl-Tidy/BUILD
+++ b/perl/Perl-Tidy/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/Perl-Tidy/DETAILS
+++ b/perl/Perl-Tidy/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/S/SH/SHANCOCK
       SOURCE_VFY=sha256:6dd04ed8c315bcfea8fe713de8f9de68955795b6864f3be6c177e802fd30dca7
         WEB_SITE=http://perltidy.sourceforge.net
+            TYPE=perl
          ENTERED=20080508
          UPDATED=20160621
       MAINTAINER=dagbrown@lart.ca

--- a/perl/PerlIO-eol/BUILD
+++ b/perl/PerlIO-eol/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/PerlIO-eol/DETAILS
+++ b/perl/PerlIO-eol/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/A/AU/AUDREYT/
       SOURCE_VFY=sha1:5c6e19973135caf7a44c37943b1a598058ff1d07
         WEB_SITE=http://www.perl.com/CPAN/modules/by-module/CPAN/
+            TYPE=perl
          ENTERED=20070310
          UPDATED=20070310
            SHORT="PerlIO layer for normalizing line endings"

--- a/perl/PerlIO-gzip/BUILD
+++ b/perl/PerlIO-gzip/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/PerlIO-gzip/DETAILS
+++ b/perl/PerlIO-gzip/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/N/NW/NWCLARK
       SOURCE_VFY=sha256:d2e9351d58b8a93c86811e25a898ee651fc393a157413652bf42f9aada2eb284
         WEB_SITE=http://search.cpan.org/search?query=PerlIO-gzip
+            TYPE=perl
          ENTERED=20101219
          UPDATED=20150705
            SHORT="Perl extension to provide a PerlIO layer to gzip/gunzip"

--- a/perl/PerlIO-via-Bzip2/BUILD
+++ b/perl/PerlIO-via-Bzip2/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/PerlIO-via-Bzip2/DETAILS
+++ b/perl/PerlIO-via-Bzip2/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/A/AR/ARJEN/
       SOURCE_VFY=sha1:646079d0d5cbe93f8004b6fad5bc632cc38e09a7
         WEB_SITE=http://search.cpan.org/~arjen/PerlIO-via-Bzip2-0.02/
+            TYPE=perl
          ENTERED=20101219
          UPDATED=20101219
            SHORT="PerlIO layer for Bzip2 (de)compression"

--- a/perl/PerlIO-via-dynamic/BUILD
+++ b/perl/PerlIO-via-dynamic/BUILD
@@ -1,0 +1,3 @@
+perl -I`pwd` Makefile.PL &&
+
+default_make

--- a/perl/PerlIO-via-dynamic/BUILD
+++ b/perl/PerlIO-via-dynamic/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/PerlIO-via-dynamic/DETAILS
+++ b/perl/PerlIO-via-dynamic/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/A/AL/ALEXMV
       SOURCE_VFY=sha256:8acd7af4d8af21d28b9c15ae137fe76cd064dad7d26eba8a30b97ebc6e1f6b49
         WEB_SITE=http://search.cpan.org/~alexmv/PerlIO-via-dynamic
+            TYPE=perl
          ENTERED=20060310
          UPDATED=20150705
            SHORT="Perl module to provide dynamic PerlIO layers"

--- a/perl/PerlIO-via-symlink/BUILD
+++ b/perl/PerlIO-via-symlink/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/PerlIO-via-symlink/DETAILS
+++ b/perl/PerlIO-via-symlink/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/C/CL/CLKAO/
       SOURCE_VFY=sha1:d8b73cd3318752254636cdfd960c5e448907fb18
         WEB_SITE=http://www.perl.com/CPAN/modules/by-module/CPAN/
+            TYPE=perl
          ENTERED=20070310
          UPDATED=20070310
            SHORT="Perl module to provide PerlIO layers for creating symlinks"

--- a/perl/Pod-Coverage/BUILD
+++ b/perl/Pod-Coverage/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/Pod-Coverage/DETAILS
+++ b/perl/Pod-Coverage/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/R/RC/RCLAMP
       SOURCE_VFY=sha256:30b7a0b0c942f44a7552c0d34e9b1f2e0ba0b67955c61e3b1589ec369074b107
         WEB_SITE=http://search.cpan.org/~rclamp/Pod-Coverage
+            TYPE=perl
          ENTERED=20111009
          UPDATED=20150705
            SHORT="Checks if the documentation of a module is comprehensive"

--- a/perl/Pod-Escapes/BUILD
+++ b/perl/Pod-Escapes/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/Pod-Escapes/DETAILS
+++ b/perl/Pod-Escapes/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/N/NE/NEILB
       SOURCE_VFY=sha256:dbf7c827984951fb248907f940fd8f19f2696bc5545c0a15287e0fbe56a52308
         WEB_SITE=http://search.cpan.org/search?query=pod-escapes
+            TYPE=perl
          ENTERED=20070310
          UPDATED=20150705
            SHORT="Perl module for resolving Pod E<...> sequences"

--- a/perl/Pod-Simple/BUILD
+++ b/perl/Pod-Simple/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/Pod-Simple/DETAILS
+++ b/perl/Pod-Simple/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/D/DW/DWHEELER
       SOURCE_VFY=sha256:7091566d331adf7b4803e7dbb7b1a2d13b616339ac9caa525033344c881a47ee
         WEB_SITE=http://search.cpan.org/~dwheeler/Pod-Simple
+            TYPE=perl
          ENTERED=20070310
          UPDATED=20150705
            SHORT="Perl framework for parsing Pod"

--- a/perl/Proc-Simple/BUILD
+++ b/perl/Proc-Simple/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/Proc-Simple/DETAILS
+++ b/perl/Proc-Simple/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/M/MS/MSCHILLI
       SOURCE_VFY=sha256:5ed596d70693ebc62a75c56775766aa66808ea917e1765815dcc7cbe5299c3c2
         WEB_SITE=http://search.cpan.org/~mschilli/Proc-Simple
+            TYPE=perl
          ENTERED=20060802
          UPDATED=20150705
       MAINTAINER=perldude@lunar-linux.org

--- a/perl/Regexp-Shellish/BUILD
+++ b/perl/Regexp-Shellish/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/Regexp-Shellish/DETAILS
+++ b/perl/Regexp-Shellish/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/R/RB/RBS/
       SOURCE_VFY=sha1:f89f99055da423a5dfd79717483a9be567ed36f3
         WEB_SITE=http://www.perl.com/CPAN/modules/by-module/CPAN/
+            TYPE=perl
          ENTERED=20070310
          UPDATED=20070310
            SHORT="Perl module to provide shell-like regular expressions"

--- a/perl/SVK/BUILD
+++ b/perl/SVK/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/SVK/DETAILS
+++ b/perl/SVK/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/C/CL/CLKAO/
       SOURCE_VFY=sha1:52e3e9bbf9199e7ffc9b11164d3ebadcb471e584
         WEB_SITE=http://search.cpan.org/~clkao/SVK/
+            TYPE=perl
          ENTERED=20070307
          UPDATED=20101219
            SHORT="A distributed version control system"

--- a/perl/SVN-Dump/BUILD
+++ b/perl/SVN-Dump/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/SVN-Dump/DETAILS
+++ b/perl/SVN-Dump/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/B/BO/BOOK
       SOURCE_VFY=sha256:c582803ba317c9b5a38f4597460d9aa76c199324cce4391c47af7c4619be8a77
         WEB_SITE=http://search.cpan.org/~book/SVN-Dump
+            TYPE=perl
          ENTERED=20101219
          UPDATED=20150705
            SHORT="A Perl interface to Subversion dumps"

--- a/perl/SVN-Mirror/BUILD
+++ b/perl/SVN-Mirror/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/SVN-Mirror/DETAILS
+++ b/perl/SVN-Mirror/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/C/CL/CLKAO/
       SOURCE_VFY=sha1:ce78647269f5c984aea444dc503e3f8dec6f4866
         WEB_SITE=http://search.cpan.org/~clkao/SVN-Mirror/
+            TYPE=perl
          ENTERED=20070310
          UPDATED=20100222
            SHORT="Perl module to mirror remote repositories to local Subversion repositories"

--- a/perl/SVN-Simple/BUILD
+++ b/perl/SVN-Simple/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/SVN-Simple/DEPENDS
+++ b/perl/SVN-Simple/DEPENDS
@@ -1,2 +1,3 @@
+depends swig
 depends subversion
 depends perl

--- a/perl/SVN-Simple/DETAILS
+++ b/perl/SVN-Simple/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/C/CL/CLKAO/
       SOURCE_VFY=sha1:3a47dbe7fb95f19eefe24ad29f7d67bc074708fc
         WEB_SITE=http://search.cpan.org/~clkao/SVN-Simple/
+            TYPE=perl
          ENTERED=20070310
          UPDATED=20100222
            SHORT="A simple Perl interface to Subversion's editor facilities"

--- a/perl/Socket6/BUILD
+++ b/perl/Socket6/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/Socket6/DETAILS
+++ b/perl/Socket6/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/U/UM/UMEMOTO
       SOURCE_VFY=sha256:da746f8e7740b4ef66f4ff70dfad4e90f001a47a4803de66b7d7e0bdc924baa9
         WEB_SITE=http://search.cpan.org/dist/Socket6
+            TYPE=perl
          ENTERED=20100414
          UPDATED=20150705
            SHORT="IPv6 related part of the C socket.h defines and structure manipulators"

--- a/perl/Software-License/BUILD
+++ b/perl/Software-License/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/Software-License/DETAILS
+++ b/perl/Software-License/DETAILS
@@ -5,6 +5,7 @@ SOURCE_DIRECTORY=$BUILD_DIRECTORY/$MODULE-$VERSION
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/R/RJ/RJBS/
       SOURCE_VFY=sha1:630c8117eab58f6b52595cfa497c58aea94ae0c2
         WEB_SITE=http://search.cpan.org/dist/Software-License/
+            TYPE=perl
          ENTERED=20100606
          UPDATED=20141021
            SHORT="Perl packages that provide templated software licenses"

--- a/perl/Spiffy/BUILD
+++ b/perl/Spiffy/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/Spiffy/DETAILS
+++ b/perl/Spiffy/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/I/IN/INGY
       SOURCE_VFY=sha256:8f58620a8420255c49b6c43c5ff5802bd25e4f09240c51e5bf2b022833d41da3
         WEB_SITE=http://search.cpan.org/search?dist=Spiffy
+            TYPE=perl
          ENTERED=20050731
          UPDATED=20150705
            SHORT="Spiffy - Spiffy Perl Interface Framework For You"

--- a/perl/Spreadsheet-WriteExcel/BUILD
+++ b/perl/Spreadsheet-WriteExcel/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/Spreadsheet-WriteExcel/DETAILS
+++ b/perl/Spreadsheet-WriteExcel/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/J/JM/JMCNAMARA
       SOURCE_VFY=sha256:e356aad6866cf135731268ee0e979a197443c15a04878e9cf3e80d022ad6c07e
         WEB_SITE=http://homepage.eircom.net/~jmcnamara/perl/WriteExcel.html
+            TYPE=perl
          ENTERED=20011108
          UPDATED=20150705
            SHORT="Cross platform Perl module to write Excel binary files"

--- a/perl/Stat-lsMode/BUILD
+++ b/perl/Stat-lsMode/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/Stat-lsMode/DETAILS
+++ b/perl/Stat-lsMode/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=ftp://ftp.cpan.org/pub/CPAN/modules/by-authors/id/M/MJ/MJD/
 SOURCE_DIRECTORY=$BUILD_DIRECTORY/Stat-lsMode-$VERSION
         WEB_SITE=http://search.cpan.org/search?dist=Stat-lsMode
+            TYPE=perl
          ENTERED=20040728
          UPDATED=20040728
            SHORT="module for displaying file permission modes"

--- a/perl/Sub-Uplevel/BUILD
+++ b/perl/Sub-Uplevel/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/Sub-Uplevel/DETAILS
+++ b/perl/Sub-Uplevel/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/D/DA/DAGOLDEN
       SOURCE_VFY=sha256:2dcca582a7ea5bada576eb27c4be1d1b064fb22175bdbd6d696c45d083560505
         WEB_SITE=http://search.cpan.org/~dagolden/Sub-Uplevel
+            TYPE=perl
          ENTERED=20060310
          UPDATED=20150705
            SHORT="apparently run a function in a higher stack frame"

--- a/perl/Switch/BUILD
+++ b/perl/Switch/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/Switch/DETAILS
+++ b/perl/Switch/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://cpan.metacpan.org/authors/id/C/CH/CHORNY/
       SOURCE_VFY=sha1:410fc346dc96347bdb04dc7594a1ae19e0bda834
         WEB_SITE=https://metacpan.org/pod/Switch
+            TYPE=perl
          ENTERED=20110531
          UPDATED=20140718
            SHORT="A switch statement for Perl"

--- a/perl/Sys-Gamin/BUILD
+++ b/perl/Sys-Gamin/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/Sys-Gamin/DETAILS
+++ b/perl/Sys-Gamin/DETAILS
@@ -5,6 +5,7 @@
       SOURCE_VFY=sha1:cbbd45aa2e50e1e1d0f04b2d7ac8a8d3e6c0fcc9
         WEB_SITE=http://search.cpan.org/~garnacho/Sys-Gamin
       MAINTAINER=perldude@lunar-linux.org
+            TYPE=perl
          ENTERED=20060802
          UPDATED=20060802
            SHORT="Perl interface to Gamin"

--- a/perl/Task-Weaken/BUILD
+++ b/perl/Task-Weaken/BUILD
@@ -1,0 +1,3 @@
+perl -I`pwd` Makefile.PL &&
+
+default_make

--- a/perl/Task-Weaken/BUILD
+++ b/perl/Task-Weaken/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/Task-Weaken/DETAILS
+++ b/perl/Task-Weaken/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/A/AD/ADAMK/
       SOURCE_VFY=sha1:a057c88cd98d1d81cad911f2d8bbd8c717310d43
         WEB_SITE=http://search.cpan.org/~adamk/Task-Weaken/
+            TYPE=perl
          ENTERED=20100222
          UPDATED=20110416
            SHORT="Ensure that a platform has weaken support"

--- a/perl/Term-ProgressBar/BUILD
+++ b/perl/Term-ProgressBar/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/Term-ProgressBar/DETAILS
+++ b/perl/Term-ProgressBar/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/M/MA/MANWAR/
       SOURCE_VFY=sha256:66994f1a6ca94d8d92e3efac406142fb0d05033360c0acce2599862db9c30e44
         WEB_SITE=http://search.cpan.org/~manwar/Term-ProgressBar
+            TYPE=perl
          ENTERED=20090328
          UPDATED=20150705
            SHORT="Perl module to provide a progress meter on a standard terminal"

--- a/perl/Term-ReadLine-Gnu/BUILD
+++ b/perl/Term-ReadLine-Gnu/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/Term-ReadLine-Gnu/DETAILS
+++ b/perl/Term-ReadLine-Gnu/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/H/HA/HAYASHI/
       SOURCE_VFY=sha256:f8f075eef6056e0649cce355af2b8695ea1c793dc15d5834012c800297dc4de8
         WEB_SITE=http://search.cpan.org/~hayashi/Term-ReadLine-Gnu/
+            TYPE=perl
          ENTERED=20150615
          UPDATED=20150615
            SHORT="Perl extension for the GNU Readline/History Library"

--- a/perl/TermReadKey/BUILD
+++ b/perl/TermReadKey/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/TermReadKey/DETAILS
+++ b/perl/TermReadKey/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://www.cpan.org/authors/id/J/JS/JSTOWE
       SOURCE_VFY=sha256:99708f2d157343b79af6d552384fc4cbdf8ab633b727eb547f733fbc1cfdd14d
         WEB_SITE=http://search.cpan.org/search?dist=TermReadKey
+            TYPE=perl
          ENTERED=20060807
          UPDATED=20150705
            SHORT="TermReadKey - A perl module for simple terminal control"

--- a/perl/Test-Deep/BUILD
+++ b/perl/Test-Deep/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/Test-Deep/DETAILS
+++ b/perl/Test-Deep/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/R/RJ/RJBS
       SOURCE_VFY=sha256:8dabe31cef91456bc2348f85520913bd89f5bc8f694dce4cb1b4e498242813f8
         WEB_SITE=http://search.cpan.org/~rjbs/Test-Deep
+            TYPE=perl
          ENTERED=20150705
          UPDATED=20150705
            SHORT="Perl module for extremely flexible deep comparison"

--- a/perl/Test-Exception/BUILD
+++ b/perl/Test-Exception/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/Test-Exception/DETAILS
+++ b/perl/Test-Exception/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/E/EX/EXODIST
       SOURCE_VFY=sha256:156b13f07764f766d8b45a43728f2439af81a3512625438deab783b7883eb533
         WEB_SITE=http://search.cpan.org/~exodist/Test-Exception
+            TYPE=perl
          ENTERED=20060310
          UPDATED=20160528
            SHORT="Perl module to test exception based code"

--- a/perl/Test-Fatal/BUILD
+++ b/perl/Test-Fatal/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/Test-Fatal/DETAILS
+++ b/perl/Test-Fatal/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/R/RJ/RJBS
       SOURCE_VFY=sha256:bcdcef5c7b2790a187ebca810b0a08221a63256062cfab3c3b98685d91d1cbb0
         WEB_SITE=http://search.cpan.org/~rjbs/Test-Fatal
+            TYPE=perl
          ENTERED=20150705
          UPDATED=20150705
            SHORT="incredibly simple helpers for testing code with exceptions"

--- a/perl/Test-File/BUILD
+++ b/perl/Test-File/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/Test-File/DETAILS
+++ b/perl/Test-File/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/B/BD/BDFOY/
       SOURCE_VFY=sha256:61b4a6ab8f617c8c7b5975164cf619468dc304b6baaaea3527829286fa58bcd5
         WEB_SITE=http://search.cpan.org/~bdfoy/Test-File
+            TYPE=perl
          ENTERED=20070607
          UPDATED=20180408
            SHORT="perl module to test file attributes"

--- a/perl/Test-NoWarnings/BUILD
+++ b/perl/Test-NoWarnings/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/Test-NoWarnings/DETAILS
+++ b/perl/Test-NoWarnings/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/A/AD/ADAMK
       SOURCE_VFY=sha256:638a57658cb119af1fe5b15e73d47c2544dcfef84af0c6b1b2e97f08202b686c
         WEB_SITE=http://search.cpan.org/~adamk/Test-NoWarnings
+            TYPE=perl
          ENTERED=20100414
          UPDATED=20150705
            SHORT="Make sure you didn't emit any warnings while testing"

--- a/perl/Test-Pod-Coverage/BUILD
+++ b/perl/Test-Pod-Coverage/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/Test-Pod-Coverage/DETAILS
+++ b/perl/Test-Pod-Coverage/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/N/NE/NEILB
       SOURCE_VFY=sha256:48c9cca9f7d99eee741176445b431adf09c029e1aa57c4703c9f46f7601d40d4
         WEB_SITE=http://search.cpan.org/dist/Test-Pod-Coverage
+            TYPE=perl
          ENTERED=20100606
          UPDATED=20150705
            SHORT="Check for pod coverage in your distribution"

--- a/perl/Test-Pod/BUILD
+++ b/perl/Test-Pod/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/Test-Pod/DETAILS
+++ b/perl/Test-Pod/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/E/ET/ETHER
       SOURCE_VFY=sha256:c1a1d3cedf4a579e3aad89c36f9878a8542b6656dbe71f1581420f49582d7efb
         WEB_SITE=http://search.cpan.org/~ether/Test-Pod
+            TYPE=perl
          ENTERED=20070607
          UPDATED=20150705
            SHORT="check for POD errors in files"

--- a/perl/Test-Requires/BUILD
+++ b/perl/Test-Requires/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/Test-Requires/DETAILS
+++ b/perl/Test-Requires/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/T/TO/TOKUHIROM
       SOURCE_VFY=sha256:e7b1b4b30b90d530aea68205c0e65cf7a784d6a218df5a2b41830cdb404d8221
         WEB_SITE=http://search.cpan.org/~tokuhirom/Test-Requires
+            TYPE=perl
          ENTERED=20150705
          UPDATED=20150705
            SHORT="Checks to see if the module can be loaded"

--- a/perl/Test-Simple/BUILD
+++ b/perl/Test-Simple/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/Test-Simple/DETAILS
+++ b/perl/Test-Simple/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/E/EX/EXODIST
       SOURCE_VFY=sha256:55a414ce89eb7a5e9e84186f286b002054f10ae8ef4f8f2d61bb710e7549f16b
         WEB_SITE=http://search.cpan.org/search?dist=Test-Simple
+            TYPE=perl
          ENTERED=20020619
          UPDATED=20150705
            SHORT="yet another framework for writing test scripts"

--- a/perl/Test-Tester/BUILD
+++ b/perl/Test-Tester/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/Test-Tester/DETAILS
+++ b/perl/Test-Tester/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/F/FD/FDALY
       SOURCE_VFY=sha256:d3c7c85e2fcbd5bb9c9c4d2e76ddaa9b1694ed0ab2795b722904cf043e123655
         WEB_SITE=http://search.cpan.org/~fdaly/Test-Tester
+            TYPE=perl
          ENTERED=20100414
          UPDATED=20180301
            SHORT="Ease testing test modules built with Test::Builder"

--- a/perl/Text-Diff/BUILD
+++ b/perl/Text-Diff/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/Text-Diff/DETAILS
+++ b/perl/Text-Diff/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/O/OV/OVID/
       SOURCE_VFY=sha1:a3fbfc834ea198281ffa7eedb596742e76ba3ba0
         WEB_SITE=http://search.cpan.org/~adamk/Text-Diff/
+            TYPE=perl
          ENTERED=20060310
          UPDATED=20111008
            SHORT="Perform diffs on files and record sets"

--- a/perl/Tie-DBI/BUILD
+++ b/perl/Tie-DBI/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/Tie-DBI/DETAILS
+++ b/perl/Tie-DBI/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/T/TO/TODDR
       SOURCE_VFY=sha256:28e726eef081036ae04cadd068feb2dce34fa3cd3b6397991ebddb1a907ca422
         WEB_SITE=https://github.com/toddr/Tie-DBI
+            TYPE=perl
          ENTERED=20030823
          UPDATED=20150705
            SHORT="Tie hashes to DBI relational databases"

--- a/perl/Time-Progress/BUILD
+++ b/perl/Time-Progress/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/Time-Progress/DETAILS
+++ b/perl/Time-Progress/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/C/CA/CADE
       SOURCE_VFY=sha256:ebd7d0808c192a193d3594c3b15c3e5b082de6d713c5810f26871870c9bf2fae
         WEB_SITE=http://search.cpan.org/~cade/Time-Progress
+            TYPE=perl
          ENTERED=20101219
          UPDATED=20150705
            SHORT="Elapsed and estimated finish time reporting"

--- a/perl/Tk-TableMatrix/BUILD
+++ b/perl/Tk-TableMatrix/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/Tk-TableMatrix/DETAILS
+++ b/perl/Tk-TableMatrix/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/C/CE/CERNEY/
       SOURCE_VFY=sha1:46325baf804461bcc8548124536ac94526a8b1fe
         WEB_SITE=http://search.cpan.org/~cerney/Tk-TableMatrix/
+            TYPE=perl
          ENTERED=20111009
          UPDATED=20111009
            SHORT="Table Display with Spreadsheet-like bindings"

--- a/perl/Try-Tiny/BUILD
+++ b/perl/Try-Tiny/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/Try-Tiny/DETAILS
+++ b/perl/Try-Tiny/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/D/DO/DOY
       SOURCE_VFY=sha256:60fba46f4693d33d54539104f9001df008dabb400b6837e9605c39a6ee6a1b19
         WEB_SITE=http://search.cpan.org/~doy/Try-Tiny
+            TYPE=perl
          ENTERED=20150705
          UPDATED=20150705
            SHORT="minimal try/catch with proper preservation of $@"

--- a/perl/UNIVERSAL-require/BUILD
+++ b/perl/UNIVERSAL-require/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/UNIVERSAL-require/DETAILS
+++ b/perl/UNIVERSAL-require/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/N/NE/NEILB
       SOURCE_VFY=sha256:b2a736a87967a143dab58c8a110501d5235bcdd2c8b2a3bfffcd3c0bd06b38ed
         WEB_SITE=http://search.cpan.org/~mschwern/UNIVERSAL-require
+            TYPE=perl
          ENTERED=20070310
          UPDATED=20150705
            SHORT="Perl module to let you require() modules from a variable"

--- a/perl/Unicode-String/BUILD
+++ b/perl/Unicode-String/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/Unicode-String/DETAILS
+++ b/perl/Unicode-String/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/G/GA/GAAS/
       SOURCE_VFY=sha1:7cc47c5a1c5e38f23886bbc613b27a4a4a3d5459
         WEB_SITE=http://search.cpan.org/search?dist=Unicode-String
+            TYPE=perl
          ENTERED=20040911
          UPDATED=20060210
            SHORT="Perl module for a string of Unicode characters"

--- a/perl/Unix-Mknod/BUILD
+++ b/perl/Unix-Mknod/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/Unix-Mknod/DETAILS
+++ b/perl/Unix-Mknod/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/P/PI/PIRZYK
       SOURCE_VFY=sha256:9fbe98a780c1ba052f976aba4430270b4111e025d55d8f3fecc3df05b3b63e3c
         WEB_SITE=http:/search.cpan.org/search?query=$MODULE
+            TYPE=perl
          ENTERED=20150705
          UPDATED=20150705
            SHORT="Perl extension for mknod, major, minor, and makedev"

--- a/perl/Unix-Syslog/BUILD
+++ b/perl/Unix-Syslog/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/Unix-Syslog/DETAILS
+++ b/perl/Unix-Syslog/DETAILS
@@ -5,6 +5,7 @@ SOURCE_DIRECTORY=$BUILD_DIRECTORY/$MODULE-$VERSION
    SOURCE_URL[0]=http://search.cpan.org/CPAN/authors/id/M/MH/MHARNISCH/
       SOURCE_VFY=sha1:42728e41b4d85e2e2e5f711939e329a0500f56c4
         WEB_SITE=http://search.cpan.org/~mharnisch/Unix-Syslog/
+            TYPE=perl
          ENTERED=20030309
          UPDATED=20100222
            SHORT="Perl interface to the UNIX syslog"

--- a/perl/User/BUILD
+++ b/perl/User/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/User/DETAILS
+++ b/perl/User/DETAILS
@@ -4,6 +4,7 @@
    SOURCE_URL[0]=http://www.cpan.org/authors/id/T/TB/TBONE/
       SOURCE_VFY=sha1:92c4ea8588b7624c6c4506e586aa036d74816d12
         WEB_SITE=http://search.cpan.org/~tbone/User/
+            TYPE=perl
          ENTERED=20040510
          UPDATED=20101109
            SHORT="Perl API for locating user information regardless of OS"

--- a/perl/WWW-Curl/BUILD
+++ b/perl/WWW-Curl/BUILD
@@ -1,0 +1,3 @@
+perl -I`pwd` Makefile.PL &&
+
+default_make

--- a/perl/WWW-Curl/BUILD
+++ b/perl/WWW-Curl/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/WWW-Curl/DETAILS
+++ b/perl/WWW-Curl/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/S/SZ/SZBALINT/
       SOURCE_VFY=sha256:52ffab110e32348d775f241c973eb56f96b08eedbc110d77d257cdb0a24ab7ba
         WEB_SITE=http://search.cpan.org/dist/WWW-Curl/
+            TYPE=perl
          ENTERED=20160215
          UPDATED=20160215
            SHORT="Perl/CPAN Module WWW::Curl"

--- a/perl/WWW-Mechanize/BUILD
+++ b/perl/WWW-Mechanize/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/WWW-Mechanize/DETAILS
+++ b/perl/WWW-Mechanize/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/O/OA/OALDERS/
       SOURCE_VFY=sha256:36d97e778ab911ab5a762d551541686cbf3463c571f474322f7b5da77f50a879
         WEB_SITE=http://search.cpan.org/dist/WWW-Mechanize
+            TYPE=perl
          ENTERED=20090328
          UPDATED=20180408
            SHORT="Handy web browsing in a Perl object"

--- a/perl/WWW-RobotRules/BUILD
+++ b/perl/WWW-RobotRules/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/WWW-RobotRules/DETAILS
+++ b/perl/WWW-RobotRules/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/G/GA/GAAS
       SOURCE_VFY=sha256:46b502e7a288d559429891eeb5d979461dd3ecc6a5c491ead85d165b6e03a51e
         WEB_SITE=http://search.cpan.org/~gaas/WWW-RobotRules
+            TYPE=perl
          ENTERED=20111006
          UPDATED=20150705
            SHORT="database of robots.txt-derived permissions"

--- a/perl/WWW-Search-Ebay/BUILD
+++ b/perl/WWW-Search-Ebay/BUILD
@@ -1,0 +1,3 @@
+perl -I`pwd` Makefile.PL &&
+
+default_make

--- a/perl/WWW-Search-Ebay/BUILD
+++ b/perl/WWW-Search-Ebay/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/WWW-Search-Ebay/DETAILS
+++ b/perl/WWW-Search-Ebay/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/M/MT/MTHURN
       SOURCE_VFY=sha256:568d8bdf45d591b2627e96f6c2a156988b14b1e035bf9edeaa959eae8f44b546
         WEB_SITE=http://search.cpan.org/search?dist=WWW-Search-Ebay
+            TYPE=perl
          ENTERED=20040507
          UPDATED=20150705
            SHORT="Perl module for searching Ebay (US Site)"

--- a/perl/WWW-Search-Ebay/DETAILS
+++ b/perl/WWW-Search-Ebay/DETAILS
@@ -1,8 +1,8 @@
           MODULE=WWW-Search-Ebay
-         VERSION=3.041
+         VERSION=3.051
           SOURCE=$MODULE-$VERSION.tar.gz
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/M/MT/MTHURN
-      SOURCE_VFY=sha256:568d8bdf45d591b2627e96f6c2a156988b14b1e035bf9edeaa959eae8f44b546
+      SOURCE_VFY=sha256:4144bb21948b77ddd9002388e9376cdc5d8b3a421074576e97f5746e6df487f2
         WEB_SITE=http://search.cpan.org/search?dist=WWW-Search-Ebay
             TYPE=perl
          ENTERED=20040507

--- a/perl/WWW-Search/BUILD
+++ b/perl/WWW-Search/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/WWW-Search/DETAILS
+++ b/perl/WWW-Search/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/M/MT/MTHURN
       SOURCE_VFY=sha256:0402353b380898b273629d28fde4d8ce90d20adc7651b786899202c4ba51c412
         WEB_SITE=http://search.cpan.org/~mthurn/WWW-Search/
+            TYPE=perl
          ENTERED=20040510
          UPDATED=20180408
            SHORT="Perl module for querying search engines"

--- a/perl/XML-AutoWriter/BUILD
+++ b/perl/XML-AutoWriter/BUILD
@@ -1,0 +1,3 @@
+perl -I`pwd` Makefile.PL &&
+
+default_make

--- a/perl/XML-AutoWriter/BUILD
+++ b/perl/XML-AutoWriter/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/XML-AutoWriter/DETAILS
+++ b/perl/XML-AutoWriter/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/P/PE/PERIGRIN/
       SOURCE_VFY=sha1:9ee99f5e168cbe39109e19136fd3fbdf0fb4910a
         WEB_SITE=http://search.cpan.org/~perigrin/XML-AutoWriter/
+            TYPE=perl
          ENTERED=20060310
          UPDATED=20100222
            SHORT="DOCTYPE based XML output"

--- a/perl/XML-AutoWriter/patch.d/makefile-pl.patch
+++ b/perl/XML-AutoWriter/patch.d/makefile-pl.patch
@@ -1,0 +1,20 @@
+diff -r -C 3 XML-AutoWriter-0.4.orig/Makefile.PL XML-AutoWriter-0.4/Makefile.PL
+*** XML-AutoWriter-0.4.orig/Makefile.PL 2018-06-28 11:01:51.397797955 +0900
+--- XML-AutoWriter-0.4/Makefile.PL      2018-06-28 11:02:02.577814277 +0900
+***************
+*** 9,15 ****
+  build_requires => 'Test';
+  build_requires => 'IO::File';
+
+! auto_set_repository;
+  auto_manifest;
+  auto_install;
+  WriteAll;
+--- 9,15 ----
+  build_requires => 'Test';
+  build_requires => 'IO::File';
+
+! auto_set_repository();
+  auto_manifest;
+  auto_install;
+  WriteAll;

--- a/perl/XML-DOM/BUILD
+++ b/perl/XML-DOM/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/XML-DOM/DETAILS
+++ b/perl/XML-DOM/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/T/TJ/TJMATHER
       SOURCE_VFY=sha256:8ba24b0b459b01d6c5e5b0408829c7d5dfe47ff79b3548c813759048099b175e
         WEB_SITE=http://search.cpan.org/dist/XML-DOM
+            TYPE=perl
          ENTERED=20150217
          UPDATED=20180408
            SHORT="DOM Level 1 compliant interface"

--- a/perl/XML-LibXML/BUILD
+++ b/perl/XML-LibXML/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/XML-LibXML/DETAILS
+++ b/perl/XML-LibXML/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/S/SH/SHLOMIF
       SOURCE_VFY=sha256:721452e3103ca188f5968ab06d5ba29fe8e00e49f4767790882095050312d476
         WEB_SITE=http://search.cpan.org/~pajas/XML-LibXML
+            TYPE=perl
          ENTERED=20090328
          UPDATED=20180408
            SHORT="Perl binding for libxml2"

--- a/perl/XML-LibXSLT/BUILD
+++ b/perl/XML-LibXSLT/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/XML-LibXSLT/DETAILS
+++ b/perl/XML-LibXSLT/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/S/SH/SHLOMIF
       SOURCE_VFY=sha256:2a5e374edaa2e9f9d26b432265bfea9b4bb7a94c9fbfef9047b298fce844d473
         WEB_SITE=http://search.cpan.org/~pajas/XML-LibXSLT
+            TYPE=perl
          ENTERED=20111008
          UPDATED=20180222
            SHORT="interface to libxslt library"

--- a/perl/XML-NamespaceSupport/BUILD
+++ b/perl/XML-NamespaceSupport/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/XML-NamespaceSupport/DETAILS
+++ b/perl/XML-NamespaceSupport/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/P/PE/PERIGRIN/
       SOURCE_VFY=sha256:47e995859f8dd0413aa3f22d350c4a62da652e854267aa0586ae544ae2bae5ef
         WEB_SITE=http://search.cpan.org/~perigrin/XML-NamespaceSupport/
+            TYPE=perl
          ENTERED=20090328
          UPDATED=20171001
            SHORT="A simple generic namespace support class"

--- a/perl/XML-RAI/BUILD
+++ b/perl/XML-RAI/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/XML-RAI/DETAILS
+++ b/perl/XML-RAI/DETAILS
@@ -5,6 +5,7 @@ SOURCE_DIRECTORY=$BUILD_DIRECTORY/$MODULE-$VERSION
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/T/TI/TIMA/
       SOURCE_VFY=sha1:64258d913a6ef5e9a72f45729922554403fa2f06
         WEB_SITE=http://search.cpan.org/dist/XML-RAI/lib/XML/RAI.pm
+            TYPE=perl
          ENTERED=20050507
          UPDATED=20100222
            SHORT="RSS Abstraction Interface."

--- a/perl/XML-RegExp/BUILD
+++ b/perl/XML-RegExp/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/XML-RegExp/DETAILS
+++ b/perl/XML-RegExp/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/T/TJ/TJMATHER
       SOURCE_VFY=sha1:94da8c1448259d7463525dd8c8203e811fe4f4d1
         WEB_SITE=http://search.cpan.org/dist/XML-RegExp/
+            TYPE=perl
          ENTERED=20150217
          UPDATED=20150217
            SHORT="Regular expressions for XML tokens"

--- a/perl/XML-SAX-Base/BUILD
+++ b/perl/XML-SAX-Base/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/XML-SAX-Base/DETAILS
+++ b/perl/XML-SAX-Base/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/G/GR/GRANTM/
       SOURCE_VFY=sha256:66cb355ba4ef47c10ca738bd35999723644386ac853abbeb5132841f5e8a2ad0
         WEB_SITE=http://search.cpan.org/~grantm/XML-SAX-Base/
+            TYPE=perl
          ENTERED=20111008
          UPDATED=20171001
            SHORT="Base class SAX Drivers and Filters"

--- a/perl/XML-SAX-Expat/BUILD
+++ b/perl/XML-SAX-Expat/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/XML-SAX-Expat/DETAILS
+++ b/perl/XML-SAX-Expat/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/B/BJ/BJOERN
       SOURCE_VFY=sha256:4c016213d0ce7db2c494e30086b59917b302db8c292dcd21f39deebd9780c83f
         WEB_SITE=http://search.cpan.org/~bjoern/XML-SAX-Expat/
+            TYPE=perl
          ENTERED=20130906
          UPDATED=20150705
            SHORT="Perl SAX2 Driver for Expat"

--- a/perl/XML-SAX/DETAILS
+++ b/perl/XML-SAX/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/G/GR/GRANTM/
       SOURCE_VFY=sha256:45ea6564ef8692155d57b2de0862b6442d3c7e29f4a9bc9ede5d7ecdc74c2ae3
         WEB_SITE=http://search.cpan.org/~grantm/XML-SAX/
+            TYPE=perl
          ENTERED=20090328
          UPDATED=20180222
            SHORT="Simple API for XML"

--- a/perl/XML-Simple/BUILD
+++ b/perl/XML-Simple/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/XML-Simple/DETAILS
+++ b/perl/XML-Simple/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/G/GR/GRANTM/
       SOURCE_VFY=sha256:b9450ef22ea9644ae5d6ada086dc4300fa105be050a2030ebd4efd28c198eb49
         WEB_SITE=http://search.cpan.org/dist/XML-Simple/
+            TYPE=perl
          ENTERED=20060421
          UPDATED=20180408
            SHORT="XML::Simple perl module"

--- a/perl/XML-Writer/BUILD
+++ b/perl/XML-Writer/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/XML-Writer/DETAILS
+++ b/perl/XML-Writer/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/J/JO/JOSEPHW/
       SOURCE_VFY=sha1:c87edc8255e98d4e7b3843f3947d8a9df4e94862
         WEB_SITE=http://search.cpan.org/~josephw/XML-Writer/
+            TYPE=perl
          ENTERED=20030529
          UPDATED=20141021
            SHORT="Perl module for writing XML"

--- a/perl/XML-XPath/BUILD
+++ b/perl/XML-XPath/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/XML-XPath/DETAILS
+++ b/perl/XML-XPath/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/M/MA/MANWAR/
       SOURCE_VFY=sha256:9e6ac67c2cead5f918a060b8b9ccdbdcaa6d610be8517bba42a96cd56748b512
         WEB_SITE=http://search.cpan.org/~manwar/XML-XPath
+            TYPE=perl
          ENTERED=20111006
          UPDATED=20180408
            SHORT="for parsing and evaluating XPath statements"

--- a/perl/YAML-Syck/BUILD
+++ b/perl/YAML-Syck/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/YAML-Syck/DETAILS
+++ b/perl/YAML-Syck/DETAILS
@@ -5,6 +5,7 @@ SOURCE_DIRECTORY=$BUILD_DIRECTORY/$MODULE-$VERSION
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/T/TO/TODDR/
       SOURCE_VFY=sha256:62b344216176556a0c497065ad8385157b9f261c6e687218dfa19ec7d7258dc7
         WEB_SITE=http://search.cpan.org/~toddr/YAML-Syck
+            TYPE=perl
          ENTERED=20060801
          UPDATED=20180408
       MAINTAINER=perldude@lunar-linux.org

--- a/perl/YAML-Tiny/BUILD
+++ b/perl/YAML-Tiny/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/YAML-Tiny/DETAILS
+++ b/perl/YAML-Tiny/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/E/ET/ETHER
       SOURCE_VFY=sha256:bc315fa12e8f1e3ee5e2f430d90b708a5dc7e47c867dba8dce3a6b8fbe257744
         WEB_SITE=http://search.cpan.org/dist/YAML-Tiny
+            TYPE=perl
          ENTERED=20100606
          UPDATED=20180408
            SHORT="Read/Write YAML files with as Perl little code as possible"

--- a/perl/ack/BUILD
+++ b/perl/ack/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/ack/DETAILS
+++ b/perl/ack/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/P/PE/PETDANCE/
       SOURCE_VFY=sha256:02c441dbbc86bf69c792ae92dc92419a0448c31f69d9703dd1530425c36e0f6c
         WEB_SITE=http://betterthangrep.com/
+            TYPE=perl
          ENTERED=20170301
          UPDATED=20180218
            SHORT="ack is a tool like grep, optimized for programmers"

--- a/perl/inc-latest/BUILD
+++ b/perl/inc-latest/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/inc-latest/DETAILS
+++ b/perl/inc-latest/DETAILS
@@ -5,6 +5,7 @@ SOURCE_DIRECTORY=$BUILD_DIRECTORY/$MODULE-release-$VERSION
  SOURCE_URL_FULL=http://github.com/Perl-Toolchain-Gang/inc-latest/archive/release-$VERSION.tar.gz
       SOURCE_VFY=sha256:fc4dff5387d8350d4284b0afc5b139fe479aa447a2cc1030a72d877999e19282
         WEB_SITE=http://github.com/Perl-Toolchain-Gang/inc-latest/
+            TYPE=perl
          ENTERED=20150925
          UPDATED=20150925
            SHORT="Build, test, and install Perl modules"

--- a/perl/libintl-perl/BUILD
+++ b/perl/libintl-perl/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/libintl-perl/DETAILS
+++ b/perl/libintl-perl/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/G/GU/GUIDO
       SOURCE_VFY=sha256:d8d5e95f5553e1a624c3f8bf0cd42f4a46d67bcf83291d5bd6c81c9be2f261a2
         WEB_SITE=http://search.cpan.org/~guido/libintl-perl-$VERSION
+            TYPE=perl
          ENTERED=20110327
          UPDATED=20150705
            SHORT="high-level interface to Perl message translation"

--- a/perl/local-lib/BUILD
+++ b/perl/local-lib/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/local-lib/DETAILS
+++ b/perl/local-lib/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/H/HA/HAARG
       SOURCE_VFY=sha256:0cf6f5916fc5ae86ef30c5df87414fd3587eff40642bc85ab17a59047bb82099
         WEB_SITE=http://search.cpan.org/~haarg/local-lib/
+            TYPE=perl
          ENTERED=20170914
          UPDATED=20170914
            SHORT="create and use a local lib/ for perl modules with PERL5LIB"

--- a/perl/perl-tk/BUILD
+++ b/perl/perl-tk/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/perl-tk/DETAILS
+++ b/perl/perl-tk/DETAILS
@@ -5,6 +5,7 @@
 SOURCE_DIRECTORY=$BUILD_DIRECTORY/Tk-$VERSION
       SOURCE_VFY=sha256:84756e9b07a2555c8eecf88e63d5cbbba9b1aa97b1e71a3d4aa524a7995a88ad
         WEB_SITE=http://search.cpan.org/~srezic/Tk
+            TYPE=perl
          ENTERED=20020620
          UPDATED=20150615
            SHORT="tk for perl"

--- a/perl/perlipq/BUILD
+++ b/perl/perlipq/BUILD
@@ -1,3 +1,0 @@
-perl Makefile.PL &&
-
-default_make

--- a/perl/perlipq/DETAILS
+++ b/perl/perlipq/DETAILS
@@ -5,6 +5,7 @@ SOURCE_DIRECTORY=$BUILD_DIRECTORY/perlipq-$VERSION
    SOURCE_URL[0]=http://search.cpan.org/CPAN/authors/id/J/JM/JMORRIS/
       SOURCE_VFY=sha1:b5b3ccb900e999c2071ecbc4fb786a7502aff5e8
         WEB_SITE=http://search.cpan.org/search?dist=perlipq
+            TYPE=perl
          ENTERED=20040227
          UPDATED=20040227
            SHORT="Perl extension to Linux iptables userspace queueing via libipq."


### PR DESCRIPTION
This gets rid of the BUILD file when the default Perl build can be
used instead, now that type support is in the default Lunar tools.