### PR TITLE
poppler: Update to 0.68.0 & make openjpeg-2 and `%JPEG` regular deps

### DIFF
--- a/libs/poppler/DEPENDS
+++ b/libs/poppler/DEPENDS
@@ -1,6 +1,9 @@
 depends cmake
 depends fontconfig
 depends icu4c
+depends openjpeg-2
+depends %JPEG
+
 
 optional_depends gtk+-2 "" "" "for GTK wrapper support"
 
@@ -15,16 +18,6 @@ optional_depends zlib \
                  "-DENABLE_ZLIB=ON" \
                  "-DENABLE_ZLIB=OFF" \
                  "for zlib compression support (not totally safe)"
-
-optional_depends openjpeg-2 \
-                 "-DENABLE_LIBOPENJPEG=openjpeg2" \
-                 "-DENABLE_LIBOPENJPEG=none" \
-                 "for JPEG 2000 image support"
-
-optional_depends %JPEG \
-                 "-DENABLE_DCTDECODER=libjpeg" \
-                 "-DENABLE_DCTDECODER=none" \
-                 "for JPEG image support (recommended)"
 
 optional_depends libpng \
                  "-DENABLE_LIBPNG=ON" \

--- a/libs/poppler/DETAILS
+++ b/libs/poppler/DETAILS
@@ -1,11 +1,11 @@
           MODULE=poppler
-         VERSION=0.67.0
+         VERSION=0.68.0
           SOURCE=$MODULE-$VERSION.tar.xz
       SOURCE_URL=http://poppler.freedesktop.org
-      SOURCE_VFY=sha256:a34a4f1a0f5b610c584c65824e92e3ba3e08a89d8ab4622aee11b8ceea5366f9
+      SOURCE_VFY=sha256:f90d04f0fb8df6923ecb0f106ae866cf9f8761bb537ddac64dfb5322763d0e58
         WEB_SITE=http://poppler.freedesktop.org
          ENTERED=20050918
-         UPDATED=20180808
+         UPDATED=20180819
            SHORT="A PDF rendering library"
 
 cat << EOF


### PR DESCRIPTION
openjpeg-2 and `%JPEG` have to be regular dependencies, otherwise the build breaks without them.