### PR TITLE
Libvirt 4.6.0

### DIFF
--- a/virtual/libvirt/BUILD
+++ b/virtual/libvirt/BUILD
@@ -17,4 +17,6 @@ if module_installed systemd; then
   OPTS+=" --with-init-script=systemd"
 fi &&
 
+autoreconf &&
+
 default_build

--- a/virtual/libvirt/DETAILS
+++ b/virtual/libvirt/DETAILS
@@ -1,12 +1,12 @@
           MODULE=libvirt
-         VERSION=4.4.0
+         VERSION=4.6.0
           SOURCE=$MODULE-$VERSION.tar.xz
       SOURCE_URL=http://libvirt.org/sources
 SOURCE_DIRECTORY=$BUILD_DIRECTORY/$MODULE-$VERSION
-      SOURCE_VFY=sha256:46631d63cb61af8042593a93fa046dddfff204d29858f20df77a125bd6f84ab6
+      SOURCE_VFY=sha256:b4ac6cd1825d89b9bbafff53f6308f1ac292a44d78eee67bebe01973e2574066
         WEB_SITE=http://libvirt.org/
          ENTERED=20130202
-         UPDATED=20180606
+         UPDATED=20180822
            SHORT="API for controlling virtualization engines"
 
 cat <<EOF

--- a/virtual/libvirt/patch.d/001-xattr.patch
+++ b/virtual/libvirt/patch.d/001-xattr.patch
@@ -1,0 +1,39 @@
+diff --git a/m4/virt-attr.m4 b/m4/virt-attr.m4
+index c55bd7dbd8..478549c17f 100644
+--- a/m4/virt-attr.m4
++++ b/m4/virt-attr.m4
+@@ -5,7 +5,7 @@ AC_DEFUN([LIBVIRT_ARG_ATTR],[
+ ])
+ 
+ AC_DEFUN([LIBVIRT_CHECK_ATTR],[
+-  LIBVIRT_CHECK_LIB([ATTR], [attr], [getxattr], [attr/xattr.h])
++  LIBVIRT_CHECK_LIB([ATTR], [attr], [getxattr], [sys/xattr.h])
+ ])
+ 
+ AC_DEFUN([LIBVIRT_RESULT_ATTR],[
+diff --git a/tests/securityselinuxhelper.c b/tests/securityselinuxhelper.c
+index 22b6709554..fe6f2b5fd9 100644
+--- a/tests/securityselinuxhelper.c
++++ b/tests/securityselinuxhelper.c
+@@ -34,7 +34,7 @@
+ #include <string.h>
+ #include <sys/vfs.h>
+ #include <unistd.h>
+-#include <attr/xattr.h>
++#include <sys/xattr.h>
+ 
+ #ifndef NFS_SUPER_MAGIC
+ # define NFS_SUPER_MAGIC 0x6969
+diff --git a/tests/securityselinuxlabeltest.c b/tests/securityselinuxlabeltest.c
+index c684989fd2..48fee7cd28 100644
+--- a/tests/securityselinuxlabeltest.c
++++ b/tests/securityselinuxlabeltest.c
+@@ -28,7 +28,7 @@
+ 
+ #include <selinux/selinux.h>
+ #include <selinux/context.h>
+-#include <attr/xattr.h>
++#include <sys/xattr.h>
+ 
+ #include "internal.h"
+ #include "testutils.h"


### PR DESCRIPTION
This includes a patch that tells it where to find the xattr.h header file.