### PR TITLE
fuse:Change download URL to https

### DIFF
--- a/filesys/fuse/DETAILS
+++ b/filesys/fuse/DETAILS
@@ -2,11 +2,11 @@
          VERSION=2.9.8
           SOURCE=$MODULE-$VERSION.tar.gz
 SOURCE_DIRECTORY=$BUILD_DIRECTORY/libfuse-$MODULE-$VERSION
-      SOURCE_URL=http://github.com/libfuse/libfuse/archive/
+      SOURCE_URL=https://github.com/libfuse/libfuse/archive/
       SOURCE_VFY=sha256:ceadc28f033b29d7aa1d7c3a5a267d51c2b572ed4e7346e0f9e24f4f5889debb
-        WEB_SITE=http://fuse.sourceforge.net
+        WEB_SITE=https://github.com/libfuse/libfuse
          ENTERED=20040422
-         UPDATED=20180730
+         UPDATED=20180903
            SHORT="File system in userspace"
 
 cat << EOF


### PR DESCRIPTION
fuse:Change download URL to https
And the releases is 3.2.6 now.
https://github.com/libfuse/libfuse/releases