### PR TITLE
mozjs version bump to mozjs60

### DIFF
--- a/compilers/mozjs/BUILD
+++ b/compilers/mozjs/BUILD
@@ -1,10 +1,42 @@
-cd $SOURCE_DIRECTORY/js/src &&
+mkdir -p $SOURCE_DIRECTORY/lunar_build &&
+cd $SOURCE_DIRECTORY/lunar_build
 
-if [[ $STATIC_LIBRARY == "n" ]]; then
-  sedit 's/FORCE_STATIC_LIB = True/FORCE_STATIC_LIB = False/'
-fi && 
+if [[ $STATIC_LIB == "n" ]]; then
+#  sedit 's/FORCE_STATIC_LIB = True/FORCE_STATIC_LIB = False/' ../js/src/build/moz.build
+#  sedit 's/NO_EXPAND_LIBS = True/NO_EXPAND_LIBS = False/' ../js/src/build/moz.build
+#  sedit "s/STATIC_LIBRARY_NAME = 'js_static'/#STATIC_LIBRARY_NAME =/" ../js/src/build/moz.build
+#  sedit "s/'static:js'/'js'/" ../js/src/shell/moz.build
+#  sedit "s/'static:js'/'js'/" ../js/src/jsapi-tests/moz.build
+#  sedit "s/'static:js'/'js'/" ../js/src/gdb/moz.build
+sedit 's/ifneq (,$(REAL_LIBRARY))/ifneq (libjs_static.a,$(REAL_LIBRARY))/' ../js/src/build/Makefile.in
+fi &&
 
-./configure --prefix=/usr &&
+if [[ $ENABLE_SHELL == "n" ]]; then
+  sedit 's|$(MAKE) -C shell install|#$(MAKE) -C shell install|' ../js/src/Makefile.in
+  LOCAL_CONFIG=" --disable-js-shell"
+else
+  LOCAL_CONFIG=" --enable-js-shell"
+fi &&
+
+#do not build a debug version
+#DEBUG_CONFIG="--disable-strip --enable-debug --enable-debug-symbols"
+DEBUG_CONFIG="--enable-strip --disable-debug-symbols"
+
+LOCAL_PACKAGES_CONFIG="--with-intl-api --with-system-zlib --with-system-icu --with-system-nspr --disable-jemalloc"
+
+if module_installed ccache; then
+  if [[ $ENABLE_CCACHE == "y" ]]; then
+    message "Build mozjs with ccache support"
+    LOCAL_PACKAGES_CONFIG+=" --with-ccache"
+  fi
+fi  &&
+
+../js/src/configure --prefix=/usr \
+${LOCAL_PACKAGES_CONFIG} \
+${DEBUG_CONFIG} \
+${LOCAL_CONFIG} \
+${OPTS} &&
+
 make &&
 prepare_install &&
 make install

--- a/compilers/mozjs/CONFIGURE
+++ b/compilers/mozjs/CONFIGURE
@@ -1,1 +1,3 @@
-mquery STATIC_LIB "Build static library of mozjs (~ 500MB), not needed for gjs?" n
+mquery STATIC_LIB "Install static library of mozjs(not needed for gnome3)?" n
+mquery ENABLE_SHELL "Install JS shell cli(not needed for gnome3)?" n
+mquery ENABLE_CCACHE "Build JS with ccache support?" y

--- a/compilers/mozjs/DETAILS
+++ b/compilers/mozjs/DETAILS
@@ -1,14 +1,12 @@
           MODULE=mozjs
-         VERSION=52.6.0
-          SOURCE=$MODULE-${VERSION}gnome1.tar.xz
+         VERSION=60.1.0
+          SOURCE=$MODULE-${VERSION}.tar.bz2
       SOURCE_URL=$GNOME_URL/teams/releng/tarballs-needing-help/mozjs
-SOURCE_DIRECTORY=$BUILD_DIRECTORY/$MODULE
-      SOURCE_VFY=sha256:786647e0ee743ab8ebd67d307ab406f93d50363ead7d7d05e29eeb113ebbf525
+      SOURCE_VFY=sha256:834ffe877fdbbd81315ae3c101221fa404096c354483a86c1a02ece19fca68fd
         WEB_SITE=http://developer.mozilla.org/en-US/docs/Mozilla/Projects/SpiderMonkey/Releases/24/
          ENTERED=20140418
-         UPDATED=20180912
+         UPDATED=20181228
            SHORT="JavaScript interpreter and libraries"
-           PSAFE=no
 
 cat << EOF
 This is SpiderMonkey, Mozilla's C implementation of JavaScript.

--- a/compilers/mozjs/PRE_BUILD
+++ b/compilers/mozjs/PRE_BUILD
@@ -1,7 +1,4 @@
-validate_source_dir $SOURCE_DIRECTORY &&
-mk_source_dir $SOURCE_DIRECTORY &&
-cd $SOURCE_DIRECTORY &&
-tar xf $SOURCE_CACHE/$SOURCE -C $SOURCE_DIRECTORY &&
+tar xf $SOURCE_CACHE/$SOURCE -C $BUILD_DIRECTORY &&
 
 # This export is for their hardcoding of autoconf-2.13
 export AUTOCONF=autoconf-mozilla

--- a/devel/polkit/BUILD
+++ b/devel/polkit/BUILD
@@ -11,7 +11,7 @@ rm -rf /usr/bin/pkexec &&
 autoconf &&
 
 OPTS+=" --disable-static \
-        --disable-gtk-doc-html"
+        --disable-gtk-doc-html" &&
 
 default_build &&
 

--- a/devel/polkit/patch.d/mozjs-60.patch
+++ b/devel/polkit/patch.d/mozjs-60.patch
@@ -1,0 +1,148 @@
+diff --git a/configure.ac b/configure.ac
+index bfa87ddcb2e52388cd68378e81fcb4763a056cbe..1939aba2d5f62978a3b2e7ff5d1a258af69fa025 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -79,7 +79,7 @@ PKG_CHECK_MODULES(GLIB, [gmodule-2.0 gio-unix-2.0 >= 2.30.0])
+ AC_SUBST(GLIB_CFLAGS)
+ AC_SUBST(GLIB_LIBS)
+ 
+-PKG_CHECK_MODULES(LIBJS, [mozjs-52])
++PKG_CHECK_MODULES(LIBJS, [mozjs-60])
+ 
+ AC_SUBST(LIBJS_CFLAGS)
+ AC_SUBST(LIBJS_CXXFLAGS)
+diff --git a/src/polkitbackend/polkitbackendjsauthority.cpp b/src/polkitbackend/polkitbackendjsauthority.cpp
+index 76027149d4dfdc54064be48a3aeafeec8326a67b..984a0f0e579d51c09117f4e495b0c3fdc46fe61b 100644
+--- a/src/polkitbackend/polkitbackendjsauthority.cpp
++++ b/src/polkitbackend/polkitbackendjsauthority.cpp
+@@ -150,18 +150,17 @@ G_DEFINE_TYPE (PolkitBackendJsAuthority, polkit_backend_js_authority, POLKIT_BAC
+ /* ---------------------------------------------------------------------------------------------------- */
+ 
+ static const struct JSClassOps js_global_class_ops = {
+-  NULL,
+-  NULL,
+-  NULL,
+-  NULL,
+-  NULL,
+-  NULL,
+-  NULL,
+-  NULL,
+-  NULL,
+-  NULL,
+-  NULL,
+-  NULL
++  nullptr,  // addProperty
++  nullptr,  // deleteProperty
++  nullptr,  // enumerate
++  nullptr,  // newEnumerate
++  nullptr,  // resolve
++  nullptr,  // mayResolve
++  nullptr,  // finalize
++  nullptr,  // call
++  nullptr,  // hasInstance
++  nullptr,  // construct
++  JS_GlobalObjectTraceHook
+ };
+ 
+ static JSClass js_global_class = {
+@@ -172,18 +171,17 @@ static JSClass js_global_class = {
+ 
+ /* ---------------------------------------------------------------------------------------------------- */
+ static const struct JSClassOps js_polkit_class_ops = {
+-  NULL,
+-  NULL,
+-  NULL,
+-  NULL,
+-  NULL,
+-  NULL,
+-  NULL,
+-  NULL,
+-  NULL,
+-  NULL,
+-  NULL,
+-  NULL
++  nullptr,  // addProperty
++  nullptr,  // deleteProperty
++  nullptr,  // enumerate
++  nullptr,  // newEnumerate
++  nullptr,  // resolve
++  nullptr,  // mayResolve
++  nullptr,  // finalize
++  nullptr,  // call
++  nullptr,  // hasInstance
++  nullptr,  // construct
++  nullptr   // trace
+ };
+ 
+ static JSClass js_polkit_class = {
+@@ -469,19 +467,18 @@ polkit_backend_js_authority_constructed (GObject *object)
+ 
+   {
+     JS::CompartmentOptions compart_opts;
+-    compart_opts.behaviors().setVersion(JSVERSION_LATEST);
++
+     JS::RootedObject global(authority->priv->cx);
+ 
+     authority->priv->js_global = new JS::Heap<JSObject*> (JS_NewGlobalObject (authority->priv->cx, &js_global_class, NULL, JS::FireOnNewGlobalHook, compart_opts));
+ 
+     global = authority->priv->js_global->get ();
+-
+-    if (global == NULL)
++    if (!global)
+       goto fail;
+ 
+     authority->priv->ac = new JSAutoCompartment(authority->priv->cx,  global);
+ 
+-    if (authority->priv->ac == NULL)
++    if (!authority->priv->ac)
+       goto fail;
+ 
+     if (!JS_InitStandardClasses (authority->priv->cx, global))
+@@ -493,7 +490,7 @@ polkit_backend_js_authority_constructed (GObject *object)
+ 
+     polkit = authority->priv->js_polkit->get ();
+ 
+-    if (polkit == NULL)
++    if (!polkit)
+       goto fail;
+ 
+     if (!JS_DefineProperty(authority->priv->cx, global, "polkit", polkit, JSPROP_ENUMERATE))
+@@ -504,7 +501,7 @@ polkit_backend_js_authority_constructed (GObject *object)
+                              js_polkit_functions))
+       goto fail;
+ 
+-    JS::CompileOptions options(authority->priv->cx, JSVERSION_UNKNOWN);
++    JS::CompileOptions options(authority->priv->cx);
+     JS::RootedValue rval(authority->priv->cx);
+     if (!JS::Evaluate (authority->priv->cx,
+                        options,
+@@ -684,7 +681,9 @@ set_property_strv (PolkitBackendJsAuthority  *authority,
+   JS::AutoValueVector elems(authority->priv->cx);
+   guint n;
+ 
+-  elems.resize(value->len);
++  if (!elems.resize(value->len))
++    g_error ("Unable to resize vector");
++
+   for (n = 0; n < value->len; n++)
+     {
+       const char *c_string = (const char *) g_ptr_array_index(value, n);
+@@ -741,7 +740,7 @@ subject_to_jsval (PolkitBackendJsAuthority  *authority,
+                   GError                   **error)
+ {
+   gboolean ret = FALSE;
+-  JS::CompileOptions options(authority->priv->cx, JSVERSION_UNKNOWN);
++  JS::CompileOptions options(authority->priv->cx);
+   const char *src;
+   JS::RootedObject obj(authority->priv->cx);
+   pid_t pid;
+@@ -868,7 +867,7 @@ action_and_details_to_jsval (PolkitBackendJsAuthority  *authority,
+                              GError                   **error)
+ {
+   gboolean ret = FALSE;
+-  JS::CompileOptions options(authority->priv->cx, JSVERSION_UNKNOWN);
++  JS::CompileOptions options(authority->priv->cx);
+   const char *src;
+   JS::RootedObject obj(authority->priv->cx);
+   gchar **keys;
+


### PR DESCRIPTION
polkit needs a patch for compiling successfully against mozjs60.
this patch is already applied as PR in polkit's gitlab, see url bellow
https://gitlab.freedesktop.org/polkit/polkit/merge_requests/4