### PR TITLE
efitools: No longer needs the OpenSSL 1.1.x patch

### DIFF
--- a/system/efitools/DETAILS
+++ b/system/efitools/DETAILS
@@ -2,13 +2,10 @@
          VERSION=1.8.1
           COMMIT=28687de80b18b3b35271de1d70769eac3c0b1ab4
           SOURCE=${MODULE}-${VERSION}.tar.gz
-         SOURCE2=efitools-openssl11.patch
       SOURCE_URL=git+https://git.kernel.org/pub/scm/linux/kernel/git/jejb/efitools.git:$COMMIT
-     SOURCE2_URL=$PATCH_URL
-     SOURCE2_VFY=sha256:4c49b7ebaf1906bf41321e21e066d3321ae510f7d5df017bd2cdc81c45d53c52
         WEB_SITE=http://git.kernel.org/cgit/linux/kernel/git/jejb/efitools.git
          ENTERED=20171022
-         UPDATED=20181215
+         UPDATED=20190130
          SHORT="Tools for manipulating UEFI secure boot platforms"
 cat << EOF
 Tools for manipulating UEFI secure boot platforms.

--- a/system/efitools/PRE_BUILD
+++ b/system/efitools/PRE_BUILD
@@ -1,5 +1,0 @@
-default_pre_build
-
-if in_depends $MODULE openssl && [[ "$(module_version openssl)" =~ ^1\.1 ]]; then
-  patch_it $SOURCE2 1
-fi


### PR DESCRIPTION
The source code now has an #ifdef in it to check what version of OpenSSL
you're using.