### PR TITLE
httpd: Fix the systemd service file.

### DIFF
--- a/web/httpd/DETAILS
+++ b/web/httpd/DETAILS
@@ -5,7 +5,7 @@
       SOURCE_VFY=sha256:7dc65857a994c98370dc4334b260101a7a04be60e6e74a5c57a6dee1bc8f394a
         WEB_SITE=http://www.apache.org
          ENTERED=20020710
-         UPDATED=20190123
+         UPDATED=20190206
            SHORT="A popular HTTP server"
 
 cat << EOF

--- a/web/httpd/DETAILS
+++ b/web/httpd/DETAILS
@@ -5,7 +5,7 @@
       SOURCE_VFY=sha256:7dc65857a994c98370dc4334b260101a7a04be60e6e74a5c57a6dee1bc8f394a
         WEB_SITE=http://www.apache.org
          ENTERED=20020710
-         UPDATED=20190206
+         UPDATED=20190213
            SHORT="A popular HTTP server"
 
 cat << EOF

--- a/web/httpd/systemd.d/httpd.service
+++ b/web/httpd/systemd.d/httpd.service
@@ -3,7 +3,7 @@ Description=Apache Web Server
 After=network.target remote-fs.target nss-lookup.target
 
 [Service]
-Type=forking
+Type=simple
 ExecStart=/usr/sbin/httpd -k start -DFOREGROUND
 ExecStop=/usr/sbin/httpd -k graceful-stop
 ExecReload=/usr/sbin/httpd -k graceful


### PR DESCRIPTION
You can either make the service type "simple" and start httpd
with the "-DFOREGROUND" flag, or call it "forking", and start
it without that flag.

You can't have it sort of half way.  That just results in an httpd
service that mysteriously times out because it isn't behaving the way
systemd expects it to behave..