### PR TITLE
bind: Fixing module name.

### DIFF
--- a/net/bind/DETAILS
+++ b/net/bind/DETAILS
@@ -1,4 +1,4 @@
-          MODULE=bind-utils
+          MODULE=bind
          VERSION=9.13.7
           SOURCE=bind-$VERSION.tar.gz
 SOURCE_DIRECTORY=$BUILD_DIRECTORY/bind-$VERSION


### PR DESCRIPTION
We seriously need to set moonbase-other to be PR-only.  The number of
terrible, broken commits here lately is just unacceptable.