### PR TITLE
freetype2: Version bumped to 2.10.0

### DIFF
--- a/graphics/freetype2/DETAILS
+++ b/graphics/freetype2/DETAILS
@@ -1,22 +1,13 @@
           MODULE=freetype2
-         VERSION=2.9.1
+         VERSION=2.10.0
           SOURCE=freetype-$VERSION.tar.bz2
-         SOURCE2=freetype-2.7-enable_valid.patch
-         SOURCE3=freetype-2.7-enable_spr.patch
-         SOURCE4=freetype-2.7-subpixel_hinting.patch
 SOURCE_DIRECTORY=$BUILD_DIRECTORY/freetype-$VERSION
    SOURCE_URL[0]=$SFORGE_URL/freetype
    SOURCE_URL[1]=http://savannah.nongnu.org/download/freetype
-     SOURCE2_URL=$PATCH_URL
-     SOURCE3_URL=$PATCH_URL
-     SOURCE4_URL=$PATCH_URL
-      SOURCE_VFY=sha256:db8d87ea720ea9d5edc5388fc7a0497bb11ba9fe972245e0f7f4c7e8b1e1e84d
-     SOURCE2_VFY=sha256:976de1669d1bce01444f7188c6f6b71826b3564366fdab15777994370b3819b4
-     SOURCE3_VFY=sha256:ca89caf8f4da93a568275733b5e4e8540a59d16d6984a9b862cd1f049c021eb6
-     SOURCE4_VFY=sha256:82e1cc4814d08e68a6e57435600a6d2a068684a0193e72a009acf11eea0a61ba
+      SOURCE_VFY=sha256:fccc62928c65192fff6c98847233b28eb7ce05f12d2fea3f6cc90e8b4e5fbe06
         WEB_SITE=http://www.freetype.org/
          ENTERED=20010922
-         UPDATED=20180502
+         UPDATED=20190326
            SHORT="A free, quality, portable font engine"
 
 cat << EOF

--- a/graphics/freetype2/PRE_BUILD
+++ b/graphics/freetype2/PRE_BUILD
@@ -1,9 +1,5 @@
 default_pre_build &&
 
-patch_it $SOURCE2 1 &&
-patch_it $SOURCE3 1 &&
-patch_it $SOURCE4 1 &&
-
 sed -i -r 's:.*(#.*SYSTEM_ZLIB.*) .*:\1:' include/freetype/config/ftoption.h &&
 sed -i -r 's:.*(#.*USE_BZIP2.*) .*:\1:'   include/freetype/config/ftoption.h &&
 


### PR DESCRIPTION
The patches completely failed to apply, so I'm going to just to assume
that the problems that the patches sorted out were fixed within
freetype2 itself.