### PR TITLE
lttng-modules: New module, the kernel modules for the LTTng system tracer.

### DIFF
--- a/kernel/lttng-modules/BUILD
+++ b/kernel/lttng-modules/BUILD
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+default_config &&
+
+make ${MAKES:+-j${MAKES}} &&
+
+prepare_install &&
+
+make modules_install &&
+
+/sbin/depmod -a

--- a/kernel/lttng-modules/DEPENDS
+++ b/kernel/lttng-modules/DEPENDS
@@ -1,0 +1,1 @@
+depends libxml2 libuidd popt libxml2 userspace-rcu

--- a/kernel/lttng-modules/DETAILS
+++ b/kernel/lttng-modules/DETAILS
@@ -1,0 +1,13 @@
+          MODULE=lttng-modules
+         VERSION=2.10.9
+          SOURCE=$MODULE-$VERSION.tar.bz2
+      SOURCE_URL=https://lttng.org/files/lttng-modules/
+      SOURCE_VFY=sha256:a1855bbd02d0f71ebd180e9872309862036624f012442ab9cc5852eb60340145
+        WEB_SITE=https://lttng.org/
+         ENTERED=20190418
+         UPDATED=20190418
+           SHORT="Modules for the LTTng system tracer"
+
+cat << EOF
+This is the kernel module collection for the LTTng system tracer.
+EOF


### PR DESCRIPTION
This is PR 1/3.  Please merge this first before testing the next.