### PR TITLE
lttng-ust: New module, libraries used by the LTTng tracer.

### DIFF
--- a/devel/lttng-ust/BUILD
+++ b/devel/lttng-ust/BUILD
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+ARCH=$(uname -m)
+
+OPTS+=" --build=${ARCH}-pc-linux-gnu --host=${ARCH}-pc-linux-gnu \
+        --target=${ARCH}-pc-linux-gnu "
+
+default_build

--- a/devel/lttng-ust/DEPENDS
+++ b/devel/lttng-ust/DEPENDS
@@ -1,0 +1,1 @@
+depends libxml2 libuidd popt libxml2 userspace-rcu

--- a/devel/lttng-ust/DETAILS
+++ b/devel/lttng-ust/DETAILS
@@ -1,0 +1,13 @@
+          MODULE=lttng-ust
+         VERSION=2.10.3
+          SOURCE=$MODULE-$VERSION.tar.bz2
+      SOURCE_URL=https://lttng.org/files/$MODULE/
+      SOURCE_VFY=sha256:9e8420f90d5f963f7aa32bc6d44adc1e491136f687c69ffb7a3075d33b40852b
+        WEB_SITE=https://lttng.org/
+         ENTERED=20190418
+         UPDATED=20190418
+           SHORT="UST libraries for the LTTng system tracer"
+
+cat << EOF
+This is the library collection for the LTTng system tracer.
+EOF


### PR DESCRIPTION
This is PR 2/3.  Please merge this before merging lttng-tools.