### PR TITLE
chrono: version bumped to 0.2.27

### DIFF
--- a/utils/chrono/DETAILS
+++ b/utils/chrono/DETAILS
@@ -1,15 +1,15 @@
           MODULE=chrono
-         VERSION=0.2.23
+         VERSION=0.2.27
           SOURCE=$MODULE-$VERSION.tar.gz
 SOURCE_DIRECTORY=$BUILD_DIRECTORY/$MODULE-$MODULE-$VERSION
       SOURCE_URL=https://github.com/cody1632/chrono/archive
-      SOURCE_VFY=sha256:2b26da480a759c9f2080ddb90dfdce27ba5c014b2b07b4b013404233bb04be7a
+      SOURCE_VFY=sha256:1360b1017c5019ae46912990f1a3c84c2d7c943657bdc717936025eec8bc5333
         WEB_SITE=https://github.com/cody1632
          ENTERED=20190618
-         UPDATED=20190621
+         UPDATED=20190624
            SHORT="A ncurses/X11 based chronometer"
 
 cat << EOF
 chrono is a ncurses-based and or X11-based chronometer with millisecond
-precision, pause, reset and countdown functions.
+precision, days, months, years, pause, reset and countdown functions.
 EOF


### PR DESCRIPTION
Now process months and years. 
Also fixed a bug in the countdown parsing code.
Rewrote time string display function.