### PR TITLE
chrono: version bumped to 0.2.29

### DIFF
--- a/utils/chrono/DETAILS
+++ b/utils/chrono/DETAILS
@@ -1,12 +1,12 @@
           MODULE=chrono
-         VERSION=0.2.27
+         VERSION=0.2.29
           SOURCE=$MODULE-$VERSION.tar.gz
 SOURCE_DIRECTORY=$BUILD_DIRECTORY/$MODULE-$MODULE-$VERSION
       SOURCE_URL=https://github.com/cody1632/chrono/archive
-      SOURCE_VFY=sha256:1360b1017c5019ae46912990f1a3c84c2d7c943657bdc717936025eec8bc5333
+      SOURCE_VFY=sha256:22e4cfd1d50937b849ba6635c0a597d08a40be590614ae5dc46d2a9d4b3a6bf7
         WEB_SITE=https://github.com/cody1632
          ENTERED=20190618
-         UPDATED=20190624
+         UPDATED=20190626
            SHORT="A ncurses/X11 based chronometer"
 
 cat << EOF


### PR DESCRIPTION
-Now reset even when paused.
-Count seconds_total according to months of 28/29/30/31 days.
-Handle leap year
-Added tests for years and months parsing