### PR TITLE
Darktable & GraphicsMagick

### DIFF
--- a/graphics/GraphicsMagick/DEPENDS
+++ b/graphics/GraphicsMagick/DEPENDS
@@ -11,12 +11,13 @@ depends xz
 
 optional_depends hp2xx    ""  ""  "to convert HP-GL foramts"
 optional_depends lcms2    ""  ""  "for color management"
-optional_depends transfig ""  ""  "to read fig image format"
 optional_depends gnuplot  ""  ""  "to read plot files"
 optional_depends jbigkit  ""  ""  "bi-level image compression"
 optional_depends jasper   ""  ""  "JPEG-2000 support"
 optional_depends libwmf   ""  ""  "for Windows Metafile support"
 optional_depends libfpx   ""  ""  "for flash pix support"
-optional_depends ufraw    ""  ""  "for RAW image support"
+
+## crashes the build - ufraw needs updating
+## optional_depends ufraw    ""  ""  "for RAW image support"
 
 optional_depends sane-backends "" "" "for scanner support"

--- a/graphics/GraphicsMagick/DETAILS
+++ b/graphics/GraphicsMagick/DETAILS
@@ -1,11 +1,11 @@
           MODULE=GraphicsMagick
-         VERSION=1.3.31
+         VERSION=1.3.33
           SOURCE=$MODULE-$VERSION.tar.xz
-      SOURCE_URL=$SFORGE_URL/graphicsmagick
-      SOURCE_VFY=sha256:096bbb59d6f3abd32b562fc3b34ea90d88741dc5dd888731d61d17e100394278
+      SOURCE_URL=$SFORGE_URL/graphicsmagick/
+      SOURCE_VFY=sha256:130cb330a633580b5124eba5c125bbcbc484298423a97b9bed37ccd50d6dc778
         WEB_SITE=http://www.graphicsmagick.org/
          ENTERED=20061117
-         UPDATED=20181216
+         UPDATED=20191003
            SHORT="A swiss army knife of image processing"
 
 cat << EOF

--- a/graphics/darktable/BUILD
+++ b/graphics/darktable/BUILD
@@ -1,5 +1,2 @@
-# GnomeKeyring is only supported for versions older than 3.12.0, version 3.12.0 found.
-# Please use libsecret instead.
-OPTS+=" -DBUILD_USERMANUAL=0 -DDONT_USE_INTERNAL_LUA=0" &&
-
+OPTS+=" -DBUILD_USERMANUAL=0 -DDONT_USE_INTERNAL_LUA=1 -DRAWSPEED_ENABLE_LTO=ON"      
 default_cmake_build

--- a/graphics/darktable/DEPENDS
+++ b/graphics/darktable/DEPENDS
@@ -1,21 +1,40 @@
-depends SDL
-depends exiv2
+##website says these are required
+depends sqlite
+depends openjpeg-2
+depends libpng
 depends pugixml
-depends json-glib
-depends openexr
-depends ilmbase
-depends gtk+-2
+depends gtk+-3
+depends cairo
 depends lcms2
+depends exiv2
+depends tiff
+depends curl
+depends gphoto2
+depends dbus-glib
+depends openexr
+depends libsoup
+
+# looks for these duing configure,
+# but website doesn't list them as requirements.
+# should probably include them, because they're
+# super useful to functionality
+
+depends libxslt
+depends gettext
 depends lensfun
 depends librsvg
-depends gtk-engines2
+depends libxml2
+depends json-glib
+depends pango
+depends openmp
+depends zlib
+depends libwebp
+depends GraphicsMagick
 
-depends python-jsonschema
 
-optional_depends colord-gtk "-DUSE_COLORD=1"         "-DUSE_COLORD=0"         "For libcolord support"
-optional_depends flickcurl  "-DUSE_FLICKR=1"         "-DUSE_FLICKR=0"         "For Flickr API support"
-optional_depends openjpeg   "-DUSE_OPENJPEG=1"       "-DUSE_OPENJPEG=0"       "For openjpeg graphics support"
-optional_depends libgphoto2 "-DUSE_CAMERA_SUPPORT=1" "-DUSE_CAMERA_SUPPORT=0" "For Camera support"
-optional_depends libsecret  "-DUSE_LIBSECRET=1"      "-DUSE_LIBSECRET=0"      "For storing and retrieving passwords"
+optional_depends colord-gtk "-DUSE_COLORD=1"         "-DUSE_COLORD=0"         "For color management support" y
+optional_depends luajit      "-DUSE_LUA=1"            "-DUSE_LUA=0"            "For lua scripting support" y
+
+optional_depends flickcurl  "-DUSE_FLICKR=1"         "-DUSE_FLICKR=0"         "For Flickr API support" n
+optional_depends libsecret  "-DUSE_LIBSECRET=1"      "-DUSE_LIBSECRET=0"      "For storing and retrieving passwords" n
 optional_depends kwallet    "-DUSE_KWALLET=1"        "-DUSE_KWALLET=0"        "Use kwallet password manager" n
-optional_depends "lua"      "-DUSE_LUA=1"            "-DUSE_LUA=0"            "For lua scripting support"

--- a/graphics/darktable/DETAILS
+++ b/graphics/darktable/DETAILS
@@ -1,11 +1,11 @@
-          MODULE=darktable
-         VERSION=2.6.2
+		  MODULE=darktable
+         VERSION=2.6.3
           SOURCE=$MODULE-$VERSION.tar.xz
-      SOURCE_URL=http://github.com/darktable-org/darktable/releases/download/release-$VERSION
-      SOURCE_VFY=sha256:9cb9efbb09a40375ff05cef89343235a621c58339539e44985470a029a7ffb45
-        WEB_SITE=http://www.darktable.org
-         ENTERED=20111109
-         UPDATED=20190712
+      SOURCE_URL=https://github.com/darktable-org/darktable/releases/download/release-${VERSION}/
+      SOURCE_VFY=a518999c8458472edfc04577026ce5047d74553052af0f52d10ba8ce601b78f0 
+        WEB_SITE=https://darktable.org/
+         ENTERED=20190818
+         UPDATED=20191024
            SHORT="An image darkroom"
 
 cat << EOF

--- a/graphics/darktable/PRE_BUILD
+++ b/graphics/darktable/PRE_BUILD
@@ -1,0 +1,3 @@
+default_pre_build &&
+
+sed -i -e 's\find_llvm("7;\find_llvm("9;8;7;\g' CMakeLists.txt


### PR DESCRIPTION
Update Darktable to 2.6.3 & and GraphicsMagick to 1.3.33 (used by Darktable).

Darktable:
-updated DETAILS to new version
-updated DEPENDS to use GTK3, shifted some mandatory / optional depends.
-added PRE_BUILD sed replace to find LLVM/Clang 9
-updated BUILD to enable LTO support to RAWSPEED (internal to Darktable), as recommend by upstream.

GraphicsMagick:
-update DETAILS to new version
-updated DEPENDS to remove some broken options.