### PR TITLE
pinentry: added warning about circular dependency

### DIFF
--- a/x11-utils/pinentry/DEPENDS
+++ b/x11-utils/pinentry/DEPENDS
@@ -16,7 +16,7 @@ optional_depends libsecret \
 optional_depends gcr \
                  "--enable-pinentry-gnome3" \
                  "--disable-pinentry-gnome3" \
-                 "for gnome graphical UI support"
+                 "for gnome graphical UI support - ${PROBLEM_COLOR}Circular dependency - say no, install gcr separately first${DEFAULT_COLOR}"
 
 optional_depends qt5 \
                  "--enable-pinentry-qt" \

--- a/x11-utils/pinentry/DEPENDS
+++ b/x11-utils/pinentry/DEPENDS
@@ -16,7 +16,8 @@ optional_depends libsecret \
 optional_depends gcr \
                  "--enable-pinentry-gnome3" \
                  "--disable-pinentry-gnome3" \
-                 "for gnome graphical UI support - ${PROBLEM_COLOR}Circular dependency - say no, install gcr separately first${DEFAULT_COLOR}"
+                 "for gnome graphical UI support - ${PROBLEM_COLOR}Circular dependency - say no, install gcr separately first${DEFAULT_COLOR}" \
+                 "n"
 
 optional_depends qt5 \
                  "--enable-pinentry-qt" \


### PR DESCRIPTION
pinentry has an optional_depends on gcr.
gcr requires gnupg.
gnupg requires pinentry.

pinentry -> gcr -> gnupg -> pinentry -> gcr -> etc

This PR adds a warning to the optional_depends, and defaults to choosing no.