### PR TITLE
Nettle

### DIFF
--- a/crypto/nettle/DETAILS
+++ b/crypto/nettle/DETAILS
@@ -1,8 +1,8 @@
           MODULE=nettle
          VERSION=3.5.1
           SOURCE=$MODULE-$VERSION.tar.gz
-   SOURCE_URL[1]=http://www.lysator.liu.se/~nisse/archive
-   SOURCE_URL[2]=ftp://ftp.lysator.liu.se/pub/security/lsh
+   SOURCE_URL[1]=http://ftp.gnu.org/gnu/$MODULE/
+   SOURCE_URL[2]=ftp://ftp.gnu.org/gnu/$MODULE/
       SOURCE_VFY=sha256:75cca1998761b02e16f2db56da52992aef622bf55a3b45ec538bc2eedadc9419
         WEB_SITE=http://www.lysator.liu.se/~nisse/nettle
          ENTERED=20110404

--- a/crypto/nettle/DETAILS
+++ b/crypto/nettle/DETAILS
@@ -4,9 +4,9 @@
    SOURCE_URL[1]=http://ftp.gnu.org/gnu/$MODULE/
    SOURCE_URL[2]=ftp://ftp.gnu.org/gnu/$MODULE/
       SOURCE_VFY=sha256:75cca1998761b02e16f2db56da52992aef622bf55a3b45ec538bc2eedadc9419
-        WEB_SITE=http://www.lysator.liu.se/~nisse/nettle
+        WEB_SITE=https://www.gnu.org/software/nettle/
          ENTERED=20110404
-         UPDATED=20190707
+         UPDATED=20200427
            SHORT="A low-level cryptographic library"
 
 cat << EOF


### PR DESCRIPTION
www.lysator.liu.se url is down (either temporarily or forever). Replaced with the more reliable gnu.org url and website link.