### PR TITLE
Mozjs: Changes to dependencies

### DIFF
--- a/compilers/mozjs/DEPENDS
+++ b/compilers/mozjs/DEPENDS
@@ -6,3 +6,4 @@ depends libffi
 depends nspr
 depends zip
 depends zlib
+depends llvm

--- a/compilers/mozjs/DEPENDS
+++ b/compilers/mozjs/DEPENDS
@@ -6,4 +6,9 @@ depends libffi
 depends nspr
 depends zip
 depends zlib
-depends llvm
+
+optional_depends llvm \
+    "" \
+    "" \
+    "compile with clang instead of gcc"
+    "n"

--- a/compilers/mozjs/PRE_BUILD
+++ b/compilers/mozjs/PRE_BUILD
@@ -1,4 +1,8 @@
 tar xf $SOURCE_CACHE/$SOURCE -C $BUILD_DIRECTORY &&
 
 # This export is for their hardcoding of autoconf-2.13
-export AUTOCONF=autoconf-mozilla
+export AUTOCONF=autoconf-mozilla &&
+
+# looks for rustc, but doesn't actually use it.
+# Remove the requirement, avoid an unnecessary dependency.
+sed '21,+4d' -i $SOURCE_DIRECTORY/js/moz.configure


### PR DESCRIPTION
Mozjs checks for rustc, and fails if it's not found. However, it does not use rustc at all. It defaults to using clang if it's installed, and falls back to gcc.

- PRE_BUILD has been modified with a sed line ( lifted from http://linuxfromscratch.org/blfs/view/systemd/general/js68.html ) that removes the rustc check.
- DEPENDS adds an optional_depends for llvm.