### PR TITLE
Firefox bin

### DIFF
--- a/web/firefox-bin/DETAILS
+++ b/web/firefox-bin/DETAILS
@@ -1,11 +1,11 @@
           MODULE=firefox-bin
-         VERSION=76.0
+         VERSION=76.0.1
           SOURCE=firefox-$VERSION.tar.bz2
       SOURCE_URL=http://download-installer.cdn.mozilla.net/pub/firefox/releases/$VERSION/linux-i686/en-US
-      SOURCE_VFY=sha256:c0fa1a7b44f6d88015961b7d0fd9ac14fd5f87f4b603d37655da46d41b8fe13f
+      SOURCE_VFY=f355704f2ccd0bfca2b6de07613262272f37a03b90948e9d6bd5024079819004
         WEB_SITE=http://www.mozilla.org/projects/firefox
          ENTERED=20091207
-         UPDATED=20200505
+         UPDATED=20200512
          ARCHIVE=off
            SHORT="A speedy, full-featured web browser"
 

--- a/web/firefox-bin/DETAILS.x86_64
+++ b/web/firefox-bin/DETAILS.x86_64
@@ -1,5 +1,5 @@
           MODULE=firefox-bin
-         VERSION=76.0
+         VERSION=76.0.1
           SOURCE=firefox-$VERSION.tar.bz2
       SOURCE_URL=http://download-installer.cdn.mozilla.net/pub/firefox/releases/$VERSION/linux-x86_64/en-US
       SOURCE_VFY=315faf03a9a06ff561c3d911100739eedeb9f02a7861cbc4613177a072df45ca

--- a/web/firefox-bin/DETAILS.x86_64
+++ b/web/firefox-bin/DETAILS.x86_64
@@ -2,10 +2,10 @@
          VERSION=76.0
           SOURCE=firefox-$VERSION.tar.bz2
       SOURCE_URL=http://download-installer.cdn.mozilla.net/pub/firefox/releases/$VERSION/linux-x86_64/en-US
-      SOURCE_VFY=sha256:57c69fca69afde25d72057e3162ac985ab1729b152ce432252777087877e4697
+      SOURCE_VFY=315faf03a9a06ff561c3d911100739eedeb9f02a7861cbc4613177a072df45ca
         WEB_SITE=http://www.mozilla.org/projects/firefox
          ENTERED=20091207
-         UPDATED=20200505
+         UPDATED=20200512
          ARCHIVE=off
            SHORT="A speedy, full-featured web browser"
 


### PR DESCRIPTION
Bump to 76.0.1 (bug-fix point release: https://www.mozilla.org/en-US/firefox/76.0.1/releasenotes/  )