### PR TITLE
 bashtop: version bumped to 0.8.30.

### DIFF
--- a/utils/bashtop/DETAILS
+++ b/utils/bashtop/DETAILS
@@ -1,11 +1,11 @@
           MODULE=bashtop
-         VERSION=0.8.28
+         VERSION=0.8.30
           SOURCE=${MODULE}-${VERSION}.tar.gz
  SOURCE_URL_FULL=https://github.com/aristocratos/bashtop/archive/v$VERSION.tar.gz
-      SOURCE_VFY=sha256:f38bf0f36cb766e246ae432a3cf6023880e8279d2d7f3e8aa0ce5ba9e9f58542
+      SOURCE_VFY=sha256:047685776e222a15093fe06d44a511748c245113a64559fa931ce4459412f3a5
         WEB_SITE=https://github.com/aristocratos/bashtop/
          ENTERED=20200503
-         UPDATED=20200510
+         UPDATED=20200514
            SHORT="Linux resource monitor in bash"
 
 cat << EOF


### PR DESCRIPTION
 bashtop: version bumped to 0.8.30.