### PR TITLE
bashtop:version bumped to 0.9.6.

### DIFF
--- a/utils/bashtop/DETAILS
+++ b/utils/bashtop/DETAILS
@@ -1,11 +1,11 @@
           MODULE=bashtop
-         VERSION=0.9.1
+         VERSION=0.9.6
           SOURCE=${MODULE}-${VERSION}.tar.gz
  SOURCE_URL_FULL=https://github.com/aristocratos/bashtop/archive/v$VERSION.tar.gz
-      SOURCE_VFY=sha256:6174289a3a96dfee58bc8703a7af6bedab032165a625ecf166557aa4419c7895
+      SOURCE_VFY=sha256:7df1da6f009850a50c936dc9b93e779a60dd6493d47a7ecaf53d25bb66e73fcc
         WEB_SITE=https://github.com/aristocratos/bashtop/
          ENTERED=20200503
-         UPDATED=20200524
+         UPDATED=20200527
            SHORT="Linux resource monitor in bash"
 
 cat << EOF


### PR DESCRIPTION
bashtop:version bumped to 0.9.6.