### PR TITLE
bashtop:version bumped to 0.9.9.

### DIFF
--- a/utils/bashtop/DETAILS
+++ b/utils/bashtop/DETAILS
@@ -1,11 +1,11 @@
           MODULE=bashtop
-         VERSION=0.9.6
+         VERSION=0.9.9
           SOURCE=${MODULE}-${VERSION}.tar.gz
  SOURCE_URL_FULL=https://github.com/aristocratos/bashtop/archive/v$VERSION.tar.gz
-      SOURCE_VFY=sha256:7df1da6f009850a50c936dc9b93e779a60dd6493d47a7ecaf53d25bb66e73fcc
+      SOURCE_VFY=sha256:d4a9bb16f8c659371f65f7c6012baac7fdd225d2b4383e151d0150c432b97ebe
         WEB_SITE=https://github.com/aristocratos/bashtop/
          ENTERED=20200503
-         UPDATED=20200527
+         UPDATED=20200608
            SHORT="Linux resource monitor in bash"
 
 cat << EOF


### PR DESCRIPTION
bashtop:version bumped to 0.9.9.