### PR TITLE
intel-tbb: fix broken install for 32bit systems

### DIFF
--- a/libs/intel-tbb/BUILD
+++ b/libs/intel-tbb/BUILD
@@ -13,4 +13,4 @@
 
   install -Dm0644 tbb.pc /usr/lib/pkgconfig/ &&
 
-  install build/linux_intel*release/*.so* /usr/lib/
+  install build/linux_i*release/*.so* /usr/lib/


### PR DESCRIPTION
Small change on the output dir which starts with "linux_intel*" on 64bit systems but is generated as "linux_ia32*" on 32bit systems.