### PR TITLE
Polkit - version bump, mozjs, gcc 10

### DIFF
--- a/devel/polkit/DEPENDS
+++ b/devel/polkit/DEPENDS
@@ -1,6 +1,6 @@
 depends autoconf-archive
-depends mozjs60
 depends intltool
+depends mozjs
 
 optional_depends systemd \
                  "--enable-libsystemd-login=yes" \

--- a/devel/polkit/DETAILS
+++ b/devel/polkit/DETAILS
@@ -1,11 +1,11 @@
           MODULE=polkit
-         VERSION=0.116
+         VERSION=0.117
           SOURCE=$MODULE-$VERSION.tar.gz
       SOURCE_URL=https://www.freedesktop.org/software/$MODULE/releases
-      SOURCE_VFY=sha256:88170c9e711e8db305a12fdb8234fac5706c61969b94e084d0f117d8ec5d34b1
+      SOURCE_VFY=sha256:e106fe8206638a0524d251f0f96e15eed6e34a3a6d2fd07cc1b6337fdcef7b7c
         WEB_SITE=https://www.freedesktop.org/software/$MODULE
          ENTERED=20091226
-         UPDATED=20200922
+         UPDATED=20200803
            SHORT="A toolkit for defining and handling authorization"
 
 cat << EOF


### PR DESCRIPTION
Version bump to 117 - fixes GCC 10 compatibility, and updated to use newer mozjs.