### PR TITLE
libmspub - GCC 10 fix

### DIFF
--- a/libs/libmspub/patch.d/libmspub-0.1.4-gcc10.patch
+++ b/libs/libmspub/patch.d/libmspub-0.1.4-gcc10.patch
@@ -1,0 +1,26 @@
+From 698bed839c9129fa7a90ca1b5a33bf777bc028d1 Mon Sep 17 00:00:00 2001
+From: Stephan Bergmann <sbergman@redhat.com>
+Date: Tue, 11 Jun 2019 12:15:28 +0200
+Subject: missing include
+
+Change-Id: I3c5c085f55223688cdc7b972f7c7981411881263
+Reviewed-on: https://gerrit.libreoffice.org/73814
+Reviewed-by: Michael Stahl <Michael.Stahl@cib.de>
+Tested-by: Michael Stahl <Michael.Stahl@cib.de>
+--
+src/lib/MSPUBMetaData.h | 1 +
+1 file changed, 1 insertion(+)
+
+diff --git a/src/lib/MSPUBMetaData.h b/src/lib/MSPUBMetaData.h
+index 9167f4f..27bdd4f 100644
+--- a/src/lib/MSPUBMetaData.h
++++ b/src/lib/MSPUBMetaData.h
+@@ -13,7 +13,8 @@
+ #include <map>
+ #include <utility>
+ #include <vector>
++#include <stdint.h>
+ 
+ #include <librevenge/librevenge.h>
+ 
+ #include <librevenge-stream/librevenge-stream.h>


### PR DESCRIPTION
patch to work with GCC 10. Libreoffice-bin needs this by default.