### PR TITLE
mozjs78 - new version

### DIFF
--- a/compilers/mozjs78/BUILD
+++ b/compilers/mozjs78/BUILD
@@ -1,0 +1,18 @@
+OPTS+=" --with-system-nspr \
+         --with-system-icu \
+         --with-system-zlib \
+         --with-intl-api \
+         --enable-optimize \
+         --enable-readline \
+         --enable-smoosh \
+         --enable-strip \
+         --disable-jemalloc"
+
+cd $BUILD_DIRECTORY/$SOURCE_DIRECTORY/js/src &&
+mkdir -p lunar_build &&
+cd lunar_build &&
+
+../configure --prefix=/usr \
+${OPTS} &&
+
+default_make

--- a/compilers/mozjs78/CONFIGURE
+++ b/compilers/mozjs78/CONFIGURE
@@ -1,0 +1,2 @@
+mquery CCACHE "Enable use of ccache?" y "--with-ccache" ""
+mquery POINTERS "Enable frame-pointers? Make sure your CPU supports this!" y "--with-frame-pointers" ""

--- a/compilers/mozjs78/DEPENDS
+++ b/compilers/mozjs78/DEPENDS
@@ -1,0 +1,6 @@
+depends autoconf-mozilla
+depends icu4c
+depends nspr
+depends cbindgen
+
+optional_depends llvm "" ""  "compile with clang instead of gcc" "n"

--- a/compilers/mozjs78/DETAILS
+++ b/compilers/mozjs78/DETAILS
@@ -1,0 +1,17 @@
+          MODULE=mozjs78
+         VERSION=78.0.1gnome
+          SOURCE=mozjs-${VERSION}.tar.xz
+SOURCE_DIRECTORY=mozjs-${VERSION}
+      SOURCE_URL=$GNOME_URL/teams/releng/tarballs-needing-help/mozjs
+      SOURCE_VFY=sha256:78d762012be9eb460b5805da4f919d1a12b15f4040f126c98a42c4dddac7339e
+        WEB_SITE=http://developer.mozilla.org/en-US/docs/Mozilla/Projects/SpiderMonkey/Releases/24/
+         ENTERED=20140418
+         UPDATED=20201015
+           SHORT="JavaScript interpreter and libraries"
+
+cat << EOF
+This is SpiderMonkey, Mozilla's C implementation of JavaScript.
+SpiderMonkey is written in C and contains a compiler, interpreter, decompiler,
+garbage collector, and standard classes. It is intended to be embedded in other
+applications that provide host environments for JavaScript.
+EOF

--- a/compilers/mozjs78/PRE_BUILD
+++ b/compilers/mozjs78/PRE_BUILD
@@ -1,0 +1,7 @@
+tar xf $SOURCE_CACHE/$SOURCE -C $BUILD_DIRECTORY &&
+# This export is for their hardcoding of autoconf-2.13
+export AUTOCONF=autoconf-mozilla
+
+# looks for rustc, but doesn't actually use it.
+# Remove the requirement, avoid an unnecessary dependency.
+#sed '21,+4d' -i $SOURCE_DIRECTORY/js/moz.configure


### PR DESCRIPTION
Gnome is already using mozjs 78 - gjs fails without it.

This is almost unchanged from the mozjs already found in the moonbase.