### PR TITLE
geeqie - version bump

### DIFF
--- a/graphics/geeqie/BUILD
+++ b/graphics/geeqie/BUILD
@@ -1,1 +1,6 @@
+# clutter breaks geeqie 1.6, see here:
+# https://github.com/BestImageViewer/geeqie/issues/829
+# https://gitlab.freedesktop.org/xorg/lib/libx11/-/issues/125
+OPTS=" --disable-gpu-accel"
+
 default_build

--- a/graphics/geeqie/DEPENDS
+++ b/graphics/geeqie/DEPENDS
@@ -2,58 +2,73 @@ depends %JPEG
 depends tiff
 depends gtk+-3
 
+optional_depends lcms2 \
+    "" \
+    "--disable-lcms" \
+    "color management support"
+
 optional_depends exiv2 \
-    ""  "--disable-exiv2" \
+    "" \
+    "--disable-exiv2" \
     "enhanced exif support"
 
 optional_depends lirc \
-    "" "--disable-lirc" \
+    "" \
+    "--disable-lirc" \
     "for lirc support"
 
+#broken for now? https://github.com/BestImageViewer/geeqie/issues/829
+#optional_depends clutter-gtk \
+#   "" \
+#   "--disable-gpu-accel" \
+#   "for GPU accelerated display"
+
 optional_depends luajit \
-    "" "--disable-lua" \
+    "" \
+    "--disable-lua" \
     "for lua scripting support"
-
-optional_depends clutter \
-    "" "--disable-gpu-accel" \
-    "for GPU accelerated display"
-
-optional_depends lcms2 \
-    "" "--disable-lcms" \
-    "color management support"
-
-optional_depends poppler \
-    "" "--disable-pdf" \
-    "for pdf support"
-
-optional_depends doxygen \
-    "" "--disable-doxygen-doc" \
-    "for documentation support"
-
-optional_depends ffmpegthumbnailer \
-    "" "" \
-    "to display thumbnails of video files"
-
+    
 optional_depends librsvg \
-    "" "" \
+    "" \
+    "" \
     "for SVG image support"
 
 optional_depends libwmf \
-    "" "" \
+    "" \
+    "" \
     "for wmf image support"
 
-optional_depends Image-ExifTool \
-    "" "" \
-    "for the jpeg info extraction plugin"
+optional_depends ffmpegthumbnailer \
+    "" \
+    "" \
+    "to display thumbnails of video files"
+    
+optional_depends poppler \
+    "" \
+    "--disable-pdf" \
+    "for pdf support"
+
+optional_depends Image-ExifTool  \
+    "" \
+    "" \
+    "For the jpeg info extraction plugin"
 
 optional_depends libheif \
-    "" "" \
+    "" \
+    "" \
     "for HEIF file display"
 
 optional_depends libwebp \
-    "" "" \
+    "" \
+    "" \
     "for WEBP image display"
 
-optional_depends djvulibre \
-    "" "" \
+optional_depends djvulibre  \
+    "" \
+    "" \
     "for DjVu image display"
+
+optional_depends doxygen \
+    "" \
+    "--disable-doxygen-doc" \
+    "for documentation support"

--- a/graphics/geeqie/DETAILS
+++ b/graphics/geeqie/DETAILS
@@ -2,10 +2,10 @@
          VERSION=1.6
           SOURCE=$MODULE-$VERSION.tar.xz
       SOURCE_URL=http://www.geeqie.org
-      SOURCE_VFY=sha256:48f8a4474454d182353100e43878754b76227f3b8f30cfc258afc9d90a4e1920
-        WEB_SITE=http://www.geeqie.org/
+      SOURCE_VFY=48f8a4474454d182353100e43878754b76227f3b8f30cfc258afc9d90a4e1920
+        WEB_SITE=http://www.geeqie.org
          ENTERED=20081030
-         UPDATED=20201203
+         UPDATED=20201209
            SHORT="lightweight Gtk+ based image viewer"
 
 cat << EOF
@@ -16,4 +16,5 @@ contact gqview author and the only maintainer.
     * geeqie works on files and directories, there is no need to import images
     * fast preview for many raw image formats
     * tools for image comparison, sorting and managing photo collection
+
 EOF

--- a/graphics/geeqie/PRE_BUILD
+++ b/graphics/geeqie/PRE_BUILD
@@ -1,3 +1,0 @@
-default_pre_build &&
-
-NOCONFIGURE=1 ./autogen.sh


### PR DESCRIPTION
- Version bump to 1.6
- There's a problem with gpu acceleration (clutter-gtk -> libX11). It's a known issue, and will hopefully be patched soon.
See: https://github.com/BestImageViewer/geeqie/issues/829, which leads to
https://gitlab.freedesktop.org/xorg/lib/libx11/-/issues/125