### PR TITLE
gdb: Add source-highlight as an optional dependency

### DIFF
--- a/devel/gdb/DEPENDS
+++ b/devel/gdb/DEPENDS
@@ -5,6 +5,12 @@ depends texinfo
 depends zlib
 depends xz
 
+optional_depends source-highlight \
+                 "--enable-source-highlight" \
+                 "--disable-source-highlight" \
+                 "enable Source Highlighting while debuging (will trigger boost compilation)" \
+                 "n"
+
 # guile breaks the build
 #optional_depends guile \
 #                 "--with-guile=guile-2.0" \


### PR DESCRIPTION
Gdb supports source highlighting of the debugged program throught source-highlight module.
This behavior can be controlled at runtime by set style sources ‘on|off’ in the gdb console or the .gdbinit file