### PR TITLE
libopenraw - 0.3.0 updates

### DIFF
--- a/graphics/libopenraw/BUILD
+++ b/graphics/libopenraw/BUILD
@@ -1,6 +1,2 @@
-#If libjpeg-turbo is installed this sedit will cause the make to barf.
-if in_depends $MODULE jpeg; then
-  sedit "s/TRUE/JPEG::TRUE/" lib/jfifcontainer.cpp
-fi &&
-
+OPTS+=" --disable-static" &&
 default_build

--- a/graphics/libopenraw/DEPENDS
+++ b/graphics/libopenraw/DEPENDS
@@ -1,4 +1,7 @@
 depends %JPEG
 depends boost
 depends libxml2
-depends gdk-pixbuf
+depends curl
+
+optional_depends gdk-pixbuf "" "" "for GNOME support" y
+optional_depends rustc "" "" "for Canon CR3 support" n

--- a/graphics/libopenraw/DETAILS
+++ b/graphics/libopenraw/DETAILS
@@ -1,11 +1,11 @@
           MODULE=libopenraw
          VERSION=0.3.0
-          SOURCE=$MODULE-$VERSION.tar.bz2
+          SOURCE=$MODULE-$VERSION.tar.xz
       SOURCE_URL=http://libopenraw.freedesktop.org/download/
-      SOURCE_VFY=sha256:abca954fa9cd457c3cb8fde1baa5aeea07c2d8b5fb1630ed6201ac0beb3a6fa0
+      SOURCE_VFY=sha256:557e5af92e21dd59f380cc112b5bec42c70063c8434286615f8d62c9875afb8d
         WEB_SITE=http://libopenraw.freedesktop.org/
          ENTERED=20080723
-         UPDATED=20201219
+         UPDATED=20201223
            SHORT="An implementation for camera RAW files decoding"
 
 cat << EOF

--- a/graphics/libopenraw/PRE_BUILD
+++ b/graphics/libopenraw/PRE_BUILD
@@ -1,0 +1,3 @@
+default_pre_build &&
+
+sed -i 's/libopenraw-0.1/libopenraw-0.3/g' gnome/libopenraw-gnome-0.3.pc.in


### PR DESCRIPTION
tweaks to the recent 0.3.0 update

- BUILD: the sedit breaks the build if it's used (error: 'JPEG' has not been declared), and has been removed.
- DEPENDS: moved gdk-pixbuf to optional_depends, and added rustc option.
- DETAILS: I'm still using the .xz instead of the .bz2. Let's save upstream a 100K of bandwidth.
- PRE_BUILD: fixes an error with the openraw-gnome pkgconfig file. This has been merged upstream.