### PR TITLE
GraphicsMagick - update DEPENDS

### DIFF
--- a/graphics/GraphicsMagick/DEPENDS
+++ b/graphics/GraphicsMagick/DEPENDS
@@ -9,12 +9,14 @@ depends libSM
 depends bzip2
 depends xz
 
+optional_depends gperf "" "" "for improved memory allocator"
 optional_depends lcms2    ""  ""  "for color management"
 optional_depends gnuplot  ""  ""  "to read plot files"
 optional_depends jbigkit  ""  ""  "bi-level image compression"
 optional_depends jasper   ""  ""  "JPEG-2000 support"
 optional_depends libwmf   ""  ""  "for Windows Metafile support"
 optional_depends libfpx   ""  ""  "for flash pix support"
-optional_depends ufraw    ""  ""  "for RAW image support"
-
+optional_depends libopenraw    ""  ""  "for RAW image support"
 optional_depends sane-backends "" "" "for scanner support"
+optional_depends graphviz "" "" "for graph drawing support. Requires ghostscript (next)"
+optional_depends ghostscript "" "" "for PDF support"


### PR DESCRIPTION
- added some optional_depends available in the configuration
- specifically removed ufraw in favour of libopenraw (openraw is better as a backend processor, and ufraw hasn't been updated in 5 years).