### PR TITLE
geeqie - patch to fix clutter render

### DIFF
--- a/graphics/geeqie/BUILD
+++ b/graphics/geeqie/BUILD
@@ -1,6 +1,2 @@
-# clutter breaks geeqie 1.6, see here:
-# https://github.com/BestImageViewer/geeqie/issues/829
-# https://gitlab.freedesktop.org/xorg/lib/libx11/-/issues/125
-OPTS=" --disable-gpu-accel"
 
 default_build

--- a/graphics/geeqie/DEPENDS
+++ b/graphics/geeqie/DEPENDS
@@ -17,11 +17,10 @@ optional_depends lirc \
     "--disable-lirc" \
     "for lirc support"
 
-#broken for now? https://github.com/BestImageViewer/geeqie/issues/829
-#optional_depends clutter-gtk \
-#   "" \
-#   "--disable-gpu-accel" \
-#   "for GPU accelerated display"
+optional_depends clutter-gtk \
+   "" \
+   "--disable-gpu-accel" \
+   "for GPU accelerated display"
 
 optional_depends luajit \
     "" \

--- a/graphics/geeqie/patch.d/f34ea0700048c27319a2256408171adda32a7580.patch
+++ b/graphics/geeqie/patch.d/f34ea0700048c27319a2256408171adda32a7580.patch
@@ -1,0 +1,32 @@
+From f34ea0700048c27319a2256408171adda32a7580 Mon Sep 17 00:00:00 2001
+From: Colin Clark <colin.clark@cclark.uk>
+Date: Sat, 9 Jan 2021 11:35:41 +0000
+Subject: [PATCH] Fix #829: segfault with clutter-gtk
+
+https://github.com/BestImageViewer/geeqie/issues/829
+
+This fix might cause other problems which might be cured by calling:
+LIBGL_ALWAYS_INDIRECT=1 geeqie
+
+or, worst case:
+geeqie --disable-clutter
+---
+ src/main.c | 5 -----
+ 1 file changed, 5 deletions(-)
+
+diff --git a/src/main.c b/src/main.c
+index f497240d..4af654fe 100644
+--- a/src/main.c
++++ b/src/main.c
+@@ -904,11 +904,6 @@ gint main(gint argc, gchar *argv[])
+ #ifdef HAVE_GTHREAD
+ #if !GLIB_CHECK_VERSION(2,32,0)
+ 	g_thread_init(NULL);
+-#endif
+-#ifdef HAVE_CLUTTER
+-/* FIXME: see below */
+-	putenv("LIBGL_ALWAYS_INDIRECT=1");
+-	XInitThreads();
+ #endif
+ 	gdk_threads_init();
+ 	gdk_threads_enter();


### PR DESCRIPTION
The 1.6 update had a known bug where gpu acceleration (using clutter) was causing segfaults. This PR includes a patch that fixes the problem, and restores clutter as a DEPENDS option.