### PR TITLE
Graphics magick

### DIFF
--- a/graphics/GraphicsMagick/DEPENDS
+++ b/graphics/GraphicsMagick/DEPENDS
@@ -4,6 +4,7 @@ depends libxml2
 depends tiff
 depends libwebp
 depends freetype2
+depends libXext
 depends libSM
 
 optional_depends gperf "" "" "for improved memory allocator"

--- a/graphics/GraphicsMagick/DEPENDS
+++ b/graphics/GraphicsMagick/DEPENDS
@@ -4,10 +4,7 @@ depends libxml2
 depends tiff
 depends libwebp
 depends freetype2
-depends libXext
 depends libSM
-depends bzip2
-depends xz
 
 optional_depends gperf "" "" "for improved memory allocator"
 optional_depends lcms2    ""  ""  "for color management"

--- a/graphics/GraphicsMagick/DETAILS
+++ b/graphics/GraphicsMagick/DETAILS
@@ -1,11 +1,12 @@
           MODULE=GraphicsMagick
-         VERSION=1.3.35
+         VERSION=1.3.36
           SOURCE=$MODULE-$VERSION.tar.xz
       SOURCE_URL=$SFORGE_URL/graphicsmagick
-      SOURCE_VFY=sha256:188a8d6108fea87a0208723e8d206ec1d4d7299022be8ce5d0a9720509250250
+      SOURCE_VFY=sha256:5d5b3fde759cdfc307aaf21df9ebd8c752e3f088bb051dd5df8aac7ba7338f46
+
         WEB_SITE=http://www.graphicsmagick.org/
          ENTERED=20061117
-         UPDATED=20200229
+         UPDATED=20210109
            SHORT="A swiss army knife of image processing"
 
 cat << EOF


### PR DESCRIPTION
- version bump to 1.3.36
- removed some un-necessary depends (bzip and xz are already installed by default)