### PR TITLE
Inkscape - GraphicsMagick, refine DEPENDS, canvas rotation

### DIFF
--- a/graphics/inkscape/DEPENDS
+++ b/graphics/inkscape/DEPENDS
@@ -6,16 +6,13 @@ depends gsl
 depends libsoup
 depends double-conversion
 depends gc
-depends cairo
 depends %JPEG
 depends zlib
 depends libpng
 depends potrace
 depends gtk+-3
 depends gtkmm3
-depends gdk-pixbuf
 depends gdl
-depends boost
 depends aspell
 depends libxslt
 depends libxml2
@@ -25,6 +22,11 @@ depends gzip
 depends python-numpy
 depends python-lxml
 
+optional_depends GraphicsMagick \
+      "-DWITH_GRAPHICS_MAGICK=ON" \
+      "" \
+      "for raster graphic extensions and filters?"
+
 optional_depends poppler \
         "-DENABLE_POPPLER=ON" \
         "-DENABLE_POPPLER=OFF" \
@@ -33,7 +35,7 @@ optional_depends poppler \
 optional_depends openmp \
         "-DWITH_OPENMP=ON" \
         "-DWITH_OPENMP=OFF" \
-        "for multithread processing support (highly recommended)"
+        "for multithread processing with filters support (highly recommended)"
 
 optional_depends lcms2 \
         "-DENABLE_LCMS=ON" \

--- a/graphics/inkscape/DEPENDS
+++ b/graphics/inkscape/DEPENDS
@@ -21,7 +21,7 @@ optional_depends GraphicsMagick \
 optional_depends openmp \
         "-DWITH_OPENMP=ON" \
         "-DWITH_OPENMP=OFF" \
-        "for multithread processing filter processing support (highly recommended)"
+        "for multithread filter processing support (highly recommended)"
 
 optional_depends poppler \
         "-DENABLE_POPPLER=ON" \

--- a/graphics/inkscape/DEPENDS
+++ b/graphics/inkscape/DEPENDS
@@ -1,41 +1,32 @@
-depends harfbuzz
-depends pango
-depends fontconfig
-depends freetype2
 depends gsl
 depends libsoup
 depends double-conversion
 depends gc
 depends %JPEG
-depends zlib
 depends libpng
 depends potrace
-depends gtk+-3
 depends gtkmm3
 depends gdl
 depends aspell
-depends libxslt
-depends libxml2
-depends gettext
 depends libsigc++2
-depends gzip
+depends boost
 depends python-numpy
 depends python-lxml
 
 optional_depends GraphicsMagick \
       "-DWITH_GRAPHICS_MAGICK=ON" \
       "" \
-      "for raster graphic extensions and filters?"
+      "for extra raster graphic extensions and filters?"
+
+optional_depends openmp \
+        "-DWITH_OPENMP=ON" \
+        "-DWITH_OPENMP=OFF" \
+        "for multithread processing filter processing support (highly recommended)"
 
 optional_depends poppler \
         "-DENABLE_POPPLER=ON" \
         "-DENABLE_POPPLER=OFF" \
         "for PDF support (highly recommended)"
-
-optional_depends openmp \
-        "-DWITH_OPENMP=ON" \
-        "-DWITH_OPENMP=OFF" \
-        "for multithread processing with filters support (highly recommended)"
 
 optional_depends lcms2 \
         "-DENABLE_LCMS=ON" \

--- a/graphics/inkscape/patch.d/0001-add-canavs-rotation-lock-verb-and-desktop-toggle.patch
+++ b/graphics/inkscape/patch.d/0001-add-canavs-rotation-lock-verb-and-desktop-toggle.patch
@@ -1,0 +1,138 @@
+From 9c35798ba0ab653495b20cf3cb849e6e74de7aa8 Mon Sep 17 00:00:00 2001
+From: "byte[]" <byteslice@airmail.cc>
+Date: Fri, 8 May 2020 05:04:21 -0400
+Subject: [PATCH] add canavs rotation lock verb and desktop toggle
+
+---
+ share/ui/menus.xml         | 1 +
+ src/desktop.cpp            | 1 +
+ src/desktop.h              | 4 ++++
+ src/ui/desktop/menubar.cpp | 6 +++++-
+ src/ui/tools/tool-base.cpp | 4 ++--
+ src/verbs.cpp              | 5 +++++
+ src/verbs.h                | 1 +
+ 7 files changed, 19 insertions(+), 3 deletions(-)
+
+diff --git a/share/ui/menus.xml b/share/ui/menus.xml
+index 4e19948e55..b113b54f0e 100644
+--- a/share/ui/menus.xml
++++ b/share/ui/menus.xml
+@@ -131,6 +131,7 @@
+        <verb verb-id="ViewXRayToggle" check="yes" />
+        <verb verb-id="ToggleGrid" check="yes" />
+        <verb verb-id="ToggleGuides" check="yes" />
++       <verb verb-id="ToggleRotation" check="yes" />
+        <verb verb-id="ViewCmsToggle" check="yes" />
+        <separator/>
+        <submenu name="Sh_ow/Hide">
+diff --git a/src/desktop.cpp b/src/desktop.cpp
+index 5cedbbc815..14b0c997eb 100644
+--- a/src/desktop.cpp
++++ b/src/desktop.cpp
+@@ -135,6 +135,7 @@ SPDesktop::SPDesktop()
+     , interaction_disabled_counter(0)
+     , waiting_cursor(false)
+     , showing_dialogs(false)
++    , rotation_locked(false)
+     , guides_active(false)
+     , gr_item(nullptr)
+     , gr_point_type(POINT_LG_BEGIN)
+diff --git a/src/desktop.h b/src/desktop.h
+index 74245d71d8..fd45541b0f 100644
+--- a/src/desktop.h
++++ b/src/desktop.h
+@@ -194,6 +194,7 @@ public:
+     unsigned int interaction_disabled_counter;
+     bool waiting_cursor;
+     bool showing_dialogs;
++    bool rotation_locked;
+     /// \todo fixme: This has to be implemented in different way */
+     guint guides_active : 1;
+ 
+@@ -366,6 +367,9 @@ public:
+     /** \brief  Returns whether the desktop is in quick zoom mode or not */
+     bool quick_zoomed() { return _quick_zoom_enabled; }
+ 
++    void toggle_rotation_lock() { rotation_locked = !rotation_locked; }
++    bool get_rotation_lock() const { return rotation_locked; }
++
+     void zoom_grab_focus();
+ 
+     void rotate_absolute_keep_point   (Geom::Point const &c, double const rotate);
+diff --git a/src/ui/desktop/menubar.cpp b/src/ui/desktop/menubar.cpp
+index 00c51fd490..1f64b1a92a 100644
+--- a/src/ui/desktop/menubar.cpp
++++ b/src/ui/desktop/menubar.cpp
+@@ -266,7 +266,11 @@ checkitem_update(Gtk::CheckMenuItem* menuitem, SPAction* action)
+         } else if (id == "ToggleGuides") {
+             active = dt->namedview->getGuides();
+ 
+-        } else if (id == "ViewCmsToggle") {
++        } else if (id == "ToggleRotation") {
++            active = dt->get_rotation_lock();
++
++        }
++        else if (id == "ViewCmsToggle") {
+             active = dt->colorProfAdjustEnabled();
+         }
+         else if (id == "ViewSplitModeToggle") {
+diff --git a/src/ui/tools/tool-base.cpp b/src/ui/tools/tool-base.cpp
+index d095be4d91..bf98ebd713 100644
+--- a/src/ui/tools/tool-base.cpp
++++ b/src/ui/tools/tool-base.cpp
+@@ -397,7 +397,7 @@ bool ToolBase::root_handler(GdkEvent* event) {
+             break;
+ 
+         case 2:
+-            if (event->button.state & GDK_CONTROL_MASK) {
++            if (event->button.state & GDK_CONTROL_MASK && !desktop->get_rotation_lock()) {
+                 // On screen canvas rotation preview
+ 
+                 // Grab background before doing anything else
+@@ -790,7 +790,7 @@ bool ToolBase::root_handler(GdkEvent* event) {
+         gdouble delta_x = 0;
+         gdouble delta_y = 0;
+ 
+-        if (ctrl & shift) {
++        if ((ctrl & shift) && !desktop->get_rotation_lock()) {
+             /* ctrl + shift, rotate */
+ 
+             double rotate_inc = prefs->getDoubleLimited(
+diff --git a/src/verbs.cpp b/src/verbs.cpp
+index d202d776ee..399af73bb8 100644
+--- a/src/verbs.cpp
++++ b/src/verbs.cpp
+@@ -1964,6 +1964,9 @@ void ZoomVerb::perform(SPAction *action, void *data)
+         case SP_VERB_ZOOM_CENTER_PAGE:
+             dt->zoom_center_page();
+             break;
++        case SP_VERB_TOGGLE_ROTATION:
++            dt->toggle_rotation_lock();
++            break;
+         case SP_VERB_ROTATE_CW:
+         {
+             gint mul = 1 + Inkscape::UI::Tools::gobble_key_events( GDK_KEY_parenleft, 0);
+@@ -3041,6 +3044,8 @@ Verb *Verb::_base_verbs[] = {
+                  INKSCAPE_ICON("show-grid")),
+     new ZoomVerb(SP_VERB_TOGGLE_GUIDES, "ToggleGuides", N_("G_uides"),
+                  N_("Show or hide guides (drag from a ruler to create a guide)"), INKSCAPE_ICON("show-guides")),
++    new ZoomVerb(SP_VERB_TOGGLE_ROTATION, "ToggleRotation", N_("Lock Rotation"),
++                 N_("Lock canvas rotation"), nullptr),
+     new ZoomVerb(SP_VERB_TOGGLE_SNAPPING, "ToggleSnapGlobal", N_("Snap"), N_("Enable snapping"), INKSCAPE_ICON("snap")),
+     new ZoomVerb(SP_VERB_TOGGLE_COMMANDS_TOOLBAR, "ToggleCommandsToolbar", N_("_Commands Bar"),
+                  N_("Show or hide the Commands bar (under the menu)"), nullptr),
+diff --git a/src/verbs.h b/src/verbs.h
+index 81b1a667fa..f317155b68 100644
+--- a/src/verbs.h
++++ b/src/verbs.h
+@@ -270,6 +270,7 @@ enum {
+     SP_VERB_TOGGLE_SCROLLBARS,
+     SP_VERB_TOGGLE_GRID,
+     SP_VERB_TOGGLE_GUIDES,
++    SP_VERB_TOGGLE_ROTATION,
+     SP_VERB_TOGGLE_SNAPPING,
+     SP_VERB_TOGGLE_COMMANDS_TOOLBAR,
+     SP_VERB_TOGGLE_SNAP_TOOLBAR,
+-- 
+2.30.0
+

--- a/graphics/inkscape/patch.d/0002-precedence.patch
+++ b/graphics/inkscape/patch.d/0002-precedence.patch
@@ -1,0 +1,25 @@
+From 2f0db4d6dd4d514bd32e4ccbce3a08c6b6746e65 Mon Sep 17 00:00:00 2001
+From: "byte[]" <byteslice@airmail.cc>
+Date: Fri, 8 May 2020 05:12:08 -0400
+Subject: [PATCH] precedence
+
+---
+ src/ui/tools/tool-base.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/ui/tools/tool-base.cpp b/src/ui/tools/tool-base.cpp
+index bf98ebd713..cf65b5223a 100644
+--- a/src/ui/tools/tool-base.cpp
++++ b/src/ui/tools/tool-base.cpp
+@@ -397,7 +397,7 @@ bool ToolBase::root_handler(GdkEvent* event) {
+             break;
+ 
+         case 2:
+-            if (event->button.state & GDK_CONTROL_MASK && !desktop->get_rotation_lock()) {
++            if ((event->button.state & GDK_CONTROL_MASK) && !desktop->get_rotation_lock()) {
+                 // On screen canvas rotation preview
+ 
+                 // Grab background before doing anything else
+-- 
+2.30.0
+

--- a/graphics/inkscape/patch.d/0003-disable-pan-on-ctrl-shift.patch
+++ b/graphics/inkscape/patch.d/0003-disable-pan-on-ctrl-shift.patch
@@ -1,0 +1,25 @@
+From 8b70165de7025a609cb494c7e3e3ea86faa3c0b8 Mon Sep 17 00:00:00 2001
+From: "byte[]" <byteslice@airmail.cc>
+Date: Fri, 8 May 2020 05:20:49 -0400
+Subject: [PATCH] disable pan on ctrl+shift
+
+---
+ src/ui/tools/tool-base.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/ui/tools/tool-base.cpp b/src/ui/tools/tool-base.cpp
+index cf65b5223a..4a12a7b829 100644
+--- a/src/ui/tools/tool-base.cpp
++++ b/src/ui/tools/tool-base.cpp
+@@ -827,7 +827,7 @@ bool ToolBase::root_handler(GdkEvent* event) {
+                 desktop->rotate_relative_keep_point(scroll_dt, rotate_inc);
+             }
+ 
+-        } else if (event->scroll.state & GDK_SHIFT_MASK) {
++        } else if (shift && !ctrl) {
+            /* shift + wheel, pan left--right */
+ 
+             switch (event->scroll.direction) {
+-- 
+2.30.0
+

--- a/graphics/inkscape/patch.d/0004-change-verb-name.patch
+++ b/graphics/inkscape/patch.d/0004-change-verb-name.patch
@@ -1,0 +1,76 @@
+From 25b6d3a76fa72b6f3ac6245fa017c8e64caaf22d Mon Sep 17 00:00:00 2001
+From: "byte[]" <byteslice@airmail.cc>
+Date: Fri, 8 May 2020 05:58:14 -0400
+Subject: [PATCH] change verb name
+
+---
+ share/ui/menus.xml         | 2 +-
+ src/ui/desktop/menubar.cpp | 2 +-
+ src/verbs.cpp              | 4 ++--
+ src/verbs.h                | 2 +-
+ 4 files changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/share/ui/menus.xml b/share/ui/menus.xml
+index b113b54f0e..3dae11038a 100644
+--- a/share/ui/menus.xml
++++ b/share/ui/menus.xml
+@@ -131,7 +131,7 @@
+        <verb verb-id="ViewXRayToggle" check="yes" />
+        <verb verb-id="ToggleGrid" check="yes" />
+        <verb verb-id="ToggleGuides" check="yes" />
+-       <verb verb-id="ToggleRotation" check="yes" />
++       <verb verb-id="ToggleRotationLock" check="yes" />
+        <verb verb-id="ViewCmsToggle" check="yes" />
+        <separator/>
+        <submenu name="Sh_ow/Hide">
+diff --git a/src/ui/desktop/menubar.cpp b/src/ui/desktop/menubar.cpp
+index 1f64b1a92a..e8f2261e8a 100644
+--- a/src/ui/desktop/menubar.cpp
++++ b/src/ui/desktop/menubar.cpp
+@@ -266,7 +266,7 @@ checkitem_update(Gtk::CheckMenuItem* menuitem, SPAction* action)
+         } else if (id == "ToggleGuides") {
+             active = dt->namedview->getGuides();
+ 
+-        } else if (id == "ToggleRotation") {
++        } else if (id == "ToggleRotationLock") {
+             active = dt->get_rotation_lock();
+ 
+         }
+diff --git a/src/verbs.cpp b/src/verbs.cpp
+index 399af73bb8..15b99e5fa1 100644
+--- a/src/verbs.cpp
++++ b/src/verbs.cpp
+@@ -1964,7 +1964,7 @@ void ZoomVerb::perform(SPAction *action, void *data)
+         case SP_VERB_ZOOM_CENTER_PAGE:
+             dt->zoom_center_page();
+             break;
+-        case SP_VERB_TOGGLE_ROTATION:
++        case SP_VERB_TOGGLE_ROTATION_LOCK:
+             dt->toggle_rotation_lock();
+             break;
+         case SP_VERB_ROTATE_CW:
+@@ -3044,7 +3044,7 @@ Verb *Verb::_base_verbs[] = {
+                  INKSCAPE_ICON("show-grid")),
+     new ZoomVerb(SP_VERB_TOGGLE_GUIDES, "ToggleGuides", N_("G_uides"),
+                  N_("Show or hide guides (drag from a ruler to create a guide)"), INKSCAPE_ICON("show-guides")),
+-    new ZoomVerb(SP_VERB_TOGGLE_ROTATION, "ToggleRotation", N_("Lock Rotation"),
++    new ZoomVerb(SP_VERB_TOGGLE_ROTATION_LOCK, "ToggleRotationLock", N_("Lock rotation"),
+                  N_("Lock canvas rotation"), nullptr),
+     new ZoomVerb(SP_VERB_TOGGLE_SNAPPING, "ToggleSnapGlobal", N_("Snap"), N_("Enable snapping"), INKSCAPE_ICON("snap")),
+     new ZoomVerb(SP_VERB_TOGGLE_COMMANDS_TOOLBAR, "ToggleCommandsToolbar", N_("_Commands Bar"),
+diff --git a/src/verbs.h b/src/verbs.h
+index f317155b68..c8f4b7ae9b 100644
+--- a/src/verbs.h
++++ b/src/verbs.h
+@@ -270,7 +270,7 @@ enum {
+     SP_VERB_TOGGLE_SCROLLBARS,
+     SP_VERB_TOGGLE_GRID,
+     SP_VERB_TOGGLE_GUIDES,
+-    SP_VERB_TOGGLE_ROTATION,
++    SP_VERB_TOGGLE_ROTATION_LOCK,
+     SP_VERB_TOGGLE_SNAPPING,
+     SP_VERB_TOGGLE_COMMANDS_TOOLBAR,
+     SP_VERB_TOGGLE_SNAP_TOOLBAR,
+-- 
+2.30.0
+

--- a/graphics/inkscape/patch.d/0005-put-lock-item-inside-the-canvas-orientation-submenu.patch
+++ b/graphics/inkscape/patch.d/0005-put-lock-item-inside-the-canvas-orientation-submenu.patch
@@ -1,0 +1,32 @@
+From 4acf76c2b505bff2cfd41a26cd7ffbb8d1438373 Mon Sep 17 00:00:00 2001
+From: "byte[]" <byteslice@airmail.cc>
+Date: Fri, 8 May 2020 08:11:25 -0400
+Subject: [PATCH] put lock item inside the canvas orientation submenu
+
+---
+ share/ui/menus.xml | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/share/ui/menus.xml b/share/ui/menus.xml
+index 3dae11038a..6976a13e73 100644
+--- a/share/ui/menus.xml
++++ b/share/ui/menus.xml
+@@ -124,6 +124,7 @@
+          <verb verb-id="FlipHorizontal" check="yes"/>
+          <verb verb-id="FlipVertical" check="yes"/>
+          <separator/>
++         <verb verb-id="ToggleRotationLock" check="yes" />
+          <verb verb-id="RotateZero"/>
+        </submenu>
+        <separator/>
+@@ -131,7 +132,6 @@
+        <verb verb-id="ViewXRayToggle" check="yes" />
+        <verb verb-id="ToggleGrid" check="yes" />
+        <verb verb-id="ToggleGuides" check="yes" />
+-       <verb verb-id="ToggleRotationLock" check="yes" />
+        <verb verb-id="ViewCmsToggle" check="yes" />
+        <separator/>
+        <submenu name="Sh_ow/Hide">
+-- 
+2.30.0
+

--- a/graphics/inkscape/patch.d/0006-add-config-option-to-lock-rotation-by-default.patch
+++ b/graphics/inkscape/patch.d/0006-add-config-option-to-lock-rotation-by-default.patch
@@ -1,0 +1,55 @@
+From 30358fef182c512f850530ccf4c4285b8996d549 Mon Sep 17 00:00:00 2001
+From: "byte[]" <byteslice@airmail.cc>
+Date: Fri, 8 May 2020 09:45:08 -0400
+Subject: [PATCH] add config option to lock rotation by default
+
+---
+ src/desktop.cpp                        | 3 +++
+ src/ui/dialog/inkscape-preferences.cpp | 4 ++++
+ src/ui/dialog/inkscape-preferences.h   | 1 +
+ 3 files changed, 8 insertions(+)
+
+diff --git a/src/desktop.cpp b/src/desktop.cpp
+index 14b0c997eb..5743b989f6 100644
+--- a/src/desktop.cpp
++++ b/src/desktop.cpp
+@@ -251,6 +251,9 @@ SPDesktop::init (SPNamedView *nv, SPCanvas *aCanvas, Inkscape::UI::View::EditWid
+         setDisplayModeNormal();
+     }
+ 
++    // Get default locked status
++    rotation_locked = prefs->getBool("/options/rotationlock");
++
+     // The order in which these canvas items are added determines the z-order. It's therefore
+     // important to add the tempgroup (which will contain the snapindicator) before adding the
+     // controls. Only this way one will be able to quickly (before the snap indicator has
+diff --git a/src/ui/dialog/inkscape-preferences.cpp b/src/ui/dialog/inkscape-preferences.cpp
+index 69aa7c4889..169d8d1b39 100644
+--- a/src/ui/dialog/inkscape-preferences.cpp
++++ b/src/ui/dialog/inkscape-preferences.cpp
+@@ -1098,6 +1098,10 @@ void InkscapePreferences::initPageUI()
+     _page_ui.add_line( false, "", _ui_yaxisdown, "",
+                        _("When off, origin is at lower left corner and y-axis points up"), true);
+ 
++    _ui_rotationlock.init(_("Lock documentation rotation by default"), "/options/rotationlock", false);
++    _page_ui.add_line(false, "", _ui_rotationlock, "",
++                       _("When enabled, common actions which normally rotate the document no longer do so by default"), true);
++
+     
+     _mouse_grabsize.init("/options/grabsize/value", 1, 7, 1, 2, 3, 0);
+     _page_ui.add_line(false, _("_Handle size:"), _mouse_grabsize, "",
+diff --git a/src/ui/dialog/inkscape-preferences.h b/src/ui/dialog/inkscape-preferences.h
+index 4a7cb31ef4..24a4f5e0d5 100644
+--- a/src/ui/dialog/inkscape-preferences.h
++++ b/src/ui/dialog/inkscape-preferences.h
+@@ -388,6 +388,7 @@ protected:
+     UI::Widget::PrefCheckButton _ui_partialdynamic;
+     UI::Widget::ZoomCorrRulerSlider _ui_zoom_correction;
+     UI::Widget::PrefCheckButton _ui_yaxisdown;
++    UI::Widget::PrefCheckButton _ui_rotationlock;
+ 
+     //Spellcheck
+     UI::Widget::PrefCombo       _spell_language;
+-- 
+2.30.0
+

--- a/graphics/inkscape/patch.d/0007-fix-word-salad.patch
+++ b/graphics/inkscape/patch.d/0007-fix-word-salad.patch
@@ -1,0 +1,28 @@
+From 5049329da8d3d3d3a6ad3b938c121ed0a6b1971b Mon Sep 17 00:00:00 2001
+From: "byte[]" <byteslice@airmail.cc>
+Date: Fri, 8 May 2020 17:15:30 -0400
+Subject: [PATCH] fix word salad
+
+---
+ src/ui/dialog/inkscape-preferences.cpp | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/ui/dialog/inkscape-preferences.cpp b/src/ui/dialog/inkscape-preferences.cpp
+index 169d8d1b39..6fe1bbd6e6 100644
+--- a/src/ui/dialog/inkscape-preferences.cpp
++++ b/src/ui/dialog/inkscape-preferences.cpp
+@@ -1098,9 +1098,9 @@ void InkscapePreferences::initPageUI()
+     _page_ui.add_line( false, "", _ui_yaxisdown, "",
+                        _("When off, origin is at lower left corner and y-axis points up"), true);
+ 
+-    _ui_rotationlock.init(_("Lock documentation rotation by default"), "/options/rotationlock", false);
++    _ui_rotationlock.init(_("Lock canvas rotation by default"), "/options/rotationlock", false);
+     _page_ui.add_line(false, "", _ui_rotationlock, "",
+-                       _("When enabled, common actions which normally rotate the document no longer do so by default"), true);
++                       _("When enabled, common actions which normally rotate the canvas no longer do so by default"), true);
+ 
+     
+     _mouse_grabsize.init("/options/grabsize/value", 1, 7, 1, 2, 3, 0);
+-- 
+2.30.0
+


### PR DESCRIPTION
- added GraphicsMagick to optional_depends (for additional filters & extensions)
- removed several _depends_ that are installed by other _depends_ (or are installed by default).

- added several patches that fix the much-hated canvas rotation feature.