### PR TITLE
speech-dispatcher: fix build error

### DIFF
--- a/audio/speech-dispatcher/PRE_BUILD
+++ b/audio/speech-dispatcher/PRE_BUILD
@@ -1,0 +1,3 @@
+default_pre_build &&
+
+sedit 's/\(help2man\)/\1 --no-discard-stderr/' src/api/python/speechd_config/Makefile.am


### PR DESCRIPTION
I had this error on my laptop and server:  
```
[...]
make[5]: Leaving directory '/usr/src/speech-dispatcher-0.10.2/src/api/python/speechd'
Making all in speechd_config
make[5]: Entering directory '/usr/src/speech-dispatcher-0.10.2/src/api/python/speechd_config'
rm -f config.py
rm -f paths.py
srcdir=; \
test -f ./config.py.in || srcdir=./; \
sed -e "s:[@]GETTEXT_PACKAGE[@]:speech-dispatcher:" -e "s:[@]VERSION[@]:0.10.2:" -e "s:[@]localedir[@]:/usr/share/locale:" ${srcdir}config.py.in > config.py
srcdir=; \
test -f ./paths.py.in || srcdir=./; \
sed -e "s:[@]spdconforigdir[@]:/usr/share/speech-dispatcher/conf:" -e "s:[@]spdconfdir[@]:/etc/speech-dispatcher:" -e "s:[@]snddatadir[@]:/usr/share/sounds/speech-dispatcher:" -e "s:[@]spddesktopconforigdir[@]:/usr/share/speech-dispatcher/conf/desktop:" ${srcdir}paths.py.in > paths.py
LC_ALL=C PYTHONPATH=./.. PYTHONDONTWRITEBYTECODE=1 help2man -N -n "configure Speech Dispatcher and diagnose problems" --output=spd-conf.1 ./spd-conf
  GEN      speechd.desktop
help2man: can't get `--help' info from ./spd-conf
Try `--no-discard-stderr' if option outputs to stderr
make[5]: *** [Makefile:854: spd-conf.1] Error 1
make[5]: Leaving directory '/usr/src/speech-dispatcher-0.10.2/src/api/python/speechd_config'
make[4]: *** [Makefile:453: all-recursive] Error 1
make[4]: Leaving directory '/usr/src/speech-dispatcher-0.10.2/src/api/python'
make[3]: *** [Makefile:455: all-recursive] Error 1
make[3]: Leaving directory '/usr/src/speech-dispatcher-0.10.2/src/api'
make[2]: *** [Makefile:453: all-recursive] Error 1
make[2]: Leaving directory '/usr/src/speech-dispatcher-0.10.2/src'
make[1]: *** [Makefile:587: all-recursive] Error 1
make[1]: Leaving directory '/usr/src/speech-dispatcher-0.10.2'
make: *** [Makefile:475: all] Error 2

Creating /var/log/lunar/compile/speech-dispatcher-0.10.2.xz 
! Problem detected during BUILD
```