### PR TITLE
docutils: add link for libdrm

### DIFF
--- a/doc-tools/docutils/POST_INSTALL
+++ b/doc-tools/docutils/POST_INSTALL
@@ -1,0 +1,3 @@
+# Required by libdrm
+ln -sf rst2man.py /usr/bin/rst2man
+


### PR DESCRIPTION
libdrm's configuration fails without this link from rst2man.py to rst2man with this message:  
```
[...]
Using 'PKG_CONFIG_PATH' from environment with value: '/usr/lib/qt5/pkgconfig:/usr/lib/pkgconfig:/usr/share/pkgconfig:/usr/lib/pkgconfig:/usr/share/pkgconfig:/opt/share/pkgconfig'
Run-time dependency cairo found: YES 1.16.0
Program rst2man found: NO

meson.build:264:0: ERROR: Program 'rst2man' not found

A full log can be found at /usr/src/libdrm-2.4.104/build/meson-logs/meson-log.txt
Creating /var/log/lunar/compile/libdrm-2.4.104.xz 
! Problem detected during BUILD
```