### PR TITLE
Atril - document viewer

### DIFF
--- a/doc-tools/atril/BUILD
+++ b/doc-tools/atril/BUILD
@@ -1,3 +1,5 @@
-OPTS+=" --disable-caja --enable-pixbuf --enable-epub --disable-synctex --disable-tests"
-
+OPTS+=" --disable-caja \
+       --disable-synctex \
+       --disable-static \
+       --enable-epub"
 default_build

--- a/doc-tools/atril/BUILD
+++ b/doc-tools/atril/BUILD
@@ -1,0 +1,3 @@
+OPTS+=" --disable-caja --enable-pixbuf --enable-epub --disable-synctex --disable-tests"
+
+default_build

--- a/doc-tools/atril/DEPENDS
+++ b/doc-tools/atril/DEPENDS
@@ -40,6 +40,11 @@ optional_depends unrar \
    "--enable-comics" \
    "" \
    "for CBR comic support"
+
+optional_depends gtk-doc \
+   "--enable-gtk-doc" \
+   "" \
+   "for documentation"
    
 optional_depends gobject-introspection \
    "--enable-introspection" \

--- a/doc-tools/atril/DEPENDS
+++ b/doc-tools/atril/DEPENDS
@@ -1,4 +1,5 @@
 depends gtk+-3
+depends libsecret
 
 optional_depends dbus \
    "" \

--- a/doc-tools/atril/DEPENDS
+++ b/doc-tools/atril/DEPENDS
@@ -1,0 +1,34 @@
+depends gtk+-3
+depends libspectre
+depends poppler
+
+
+optional_depends ghostscript \
+   "" \
+   "--disable-ps" \
+   "for postscript file support"
+
+optional_depends djvulibre \
+   "" \
+   "--disable-djvu" \
+   "for Djvu file support"
+   
+optional_depends texlive \
+  "" \
+  "--disable-dvi" \
+ "for dvi file support"
+
+optional_depends unrar \
+   "--enable-comics" \
+   "" \
+   "for CBR comic file support"
+
+optional_depends gobject-introspection \
+   "--enable-introspection" \
+   "" \
+   "support gobject-introspection?"
+   
+optional_depends gtk-doc \
+   "--enable-gtk-doc" \
+   "" \
+   "include documentation?"

--- a/doc-tools/atril/DEPENDS
+++ b/doc-tools/atril/DEPENDS
@@ -1,34 +1,46 @@
 depends gtk+-3
-depends libspectre
-depends poppler
 
-
-optional_depends ghostscript \
+optional_depends dbus \
+   "" \
+   "--disable-dbus" \
+   "for dbus support"
+   
+optional_depends poppler \
+   "" \
+   "--disable-pdf" \
+   "for pdf support"
+   
+optional_depends libspectre\
    "" \
    "--disable-ps" \
-   "for postscript file support"
-
+   "for postscript document support"
+   
+optional_depends tiff \
+   "" \
+   "--disable-tiff" \
+   "for multipage tiff support"
+   
 optional_depends djvulibre \
    "" \
    "--disable-djvu" \
-   "for Djvu file support"
+   "for djvu document support"
    
 optional_depends texlive \
-  "" \
-  "--disable-dvi" \
- "for dvi file support"
+   "" \
+   "--disable-dvi" \
+   "for dvi support"
+
+optional_depends gdk-pixbuf \
+   "--enable-pixbuf" \
+   "" \
+   "for pixbuf support"
 
 optional_depends unrar \
    "--enable-comics" \
    "" \
-   "for CBR comic file support"
-
+   "for CBR comic support"
+   
 optional_depends gobject-introspection \
    "--enable-introspection" \
    "" \
-   "support gobject-introspection?"
-   
-optional_depends gtk-doc \
-   "--enable-gtk-doc" \
-   "" \
-   "include documentation?"
+   "for introspection support"

--- a/doc-tools/atril/DETAILS
+++ b/doc-tools/atril/DETAILS
@@ -5,8 +5,8 @@
       SOURCE_VFY=aabf1c00f7ce975b0cfe45decb2c459e75f00fb7002cca3a3800d3136195e060
         WEB_SITE=http://www.mate-desktop.org
          ENTERED=20081030
-         UPDATED=20210103
-           SHORT="document viewer"
+         UPDATED=20210117
+           SHORT="PDF viewer"
 
 cat << EOF
 Atril is a simple multi-page document viewer. It can display and print PostScript (PS), Encapsulated PostScript (EPS), DJVU, DVI, XPS and Portable Document Format (PDF) files. When supported by the document, it also allows searching for text, copying text to the clipboard, hypertext navigation, and table-of-contents bookmarks. Atril is a fork of Evince.

--- a/doc-tools/atril/DETAILS
+++ b/doc-tools/atril/DETAILS
@@ -1,0 +1,13 @@
+          MODULE=atril
+         VERSION=1.25.0
+          SOURCE=$MODULE-$VERSION.tar.xz
+      SOURCE_URL=https://github.com/mate-desktop/$MODULE/releases/download/v${VERSION}/
+      SOURCE_VFY=aabf1c00f7ce975b0cfe45decb2c459e75f00fb7002cca3a3800d3136195e060
+        WEB_SITE=http://www.mate-desktop.org
+         ENTERED=20081030
+         UPDATED=20210103
+           SHORT="document viewer"
+
+cat << EOF
+Atril is a simple multi-page document viewer. It can display and print PostScript (PS), Encapsulated PostScript (EPS), DJVU, DVI, XPS and Portable Document Format (PDF) files. When supported by the document, it also allows searching for text, copying text to the clipboard, hypertext navigation, and table-of-contents bookmarks. Atril is a fork of Evince.
+EOF


### PR DESCRIPTION
Part of the MATE desktop, Atril is functionally identical to Evince, but without the GNOME dependencies.

_Note:_ Version 1.25 is a testing version (but very stable, incremental changes from 1.24). It includes the option to disable synctex, which we don't have in the Moonbase.