### PR TITLE
node - use Python3

### DIFF
--- a/web/node/DEPENDS
+++ b/web/node/DEPENDS
@@ -1,4 +1,4 @@
-depends python2
+depends python
 depends procps
 depends c-ares
 
@@ -13,5 +13,3 @@ optional_depends icu4c \
 optional_depends http-parser \
                  "--shared-http-parser" "" \
                  "for system installed http-parser"
-
-#depends v8


### PR DESCRIPTION
- Node uses Python v3 by default, updated DEPENDS.
- Also removed unused dependency on 'v8'