### PR TITLE
nspr: fix build error on 32bit machines

### DIFF
--- a/libs/nspr/BUILD
+++ b/libs/nspr/BUILD
@@ -1,4 +1,4 @@
-[[ "`arch`" == "x86_64" ]] && OPTS+=" --enable-64bit" &&
+[[ "`arch`" == "x86_64" ]] && OPTS+=" --enable-64bit"
 
 OPTS+=" --libdir=/usr/lib --with-mozilla --with-pthreads --enable-strip" &&
 


### PR DESCRIPTION
Fix the condition where on 32 bit the whole process chain fails because the arch program doesn't return "x86_64". In this case simply removing the chaining && at the end of the line fixes this bug.

Here's the output without the fix:  
```
root@PC04 ~ # time lin nspr
+ Editing "/etc/lunar/local/depends/nspr"
+ Spawning download manager
+ download queue:  nspr
+ starting lin "nspr"
+ downloading module "nspr"
+ Skipping download of "nspr-4.29.tar.gz" (in cache)
Building nspr version 4.29
+ running "default_pre_build"
+ validating "/usr/src/nspr-4.29"
+ creating building dir "/usr/src/nspr-4.29"
+ Removing old source directory first!
+ destroying building dir "/usr/src/nspr-4.29"
+ Unpacking "/var/spool/lunar/nspr-4.29.tar.gz" in "/usr/src"
+ building "nspr" version "4.29" in /usr/src/nspr-4.29
+ CC="gcc"
+ CXX="g++"
+ CPP="cpp"
+ CFLAGS=" -O2 -march=i686 -pipe"
+ CXXFLAGS=" -O2 -march=i686 -pipe"
+ CPPFLAGS=""
+ LDFLAGS=" -s -Wl,-z,relro"
+ MAKES="2"
+ Enabled wrapper script usage
Creating /var/log/lunar/compile/nspr-4.29.xz 
! Problem detected during BUILD

real	0m2.419s
user	0m1.120s
sys	0m0.501s
```