### PR TITLE
apr-util: fix configure error

### DIFF
--- a/libs/apr-util/BUILD
+++ b/libs/apr-util/BUILD
@@ -1,5 +1,5 @@
 mv configure.{in,ac} &&
-autoreconf &&
+autoreconf -i &&
 libtoolize &&
 
 OPTS+=" --with-apr=`which apr-$(installed_version apr | cut -d. -f1)-config` \


### PR DESCRIPTION
Got this output:
```
[...]
checking host system type... x86_64-pc-linux-gnu
checking target system type... x86_64-pc-linux-gnu
checking for a BSD-compatible install... /usr/bin/install -c
checking for working mkdir -p... yes
APR-util Version: 1.6.1
checking for chosen layout... apr-util
checking for gcc... gcc
checking whether the C compiler works... yes
checking for C compiler default output file name... a.out
checking for suffix of executables... 
checking whether we are cross compiling... no
checking for suffix of object files... o
checking whether the compiler supports GNU C... yes
checking whether gcc accepts -g... yes
checking for gcc option to enable C11 features... none needed
Applying apr-util hints file rules for x86_64-pc-linux-gnu
checking for APR... no
configure: error: APR could not be located. Please use the --with-apr option.
Creating /var/log/lunar/compile/apr-util-1.6.1.xz 
! Problem detected during BUILD
```