### PR TITLE
openttd: version bumped to 1.11.0

### DIFF
--- a/games/openttd/BUILD
+++ b/games/openttd/BUILD
@@ -1,12 +1,1 @@
-CXXFLAGS+=' -DU_USING_ICU_NAMESPACE=1'
-
-./configure --prefix-dir=/usr \
-            --man-dir=/share/man/man6 \
-            $OPTS &&
-
-default_make &&
-
-cd /usr/share/games/openttd/baseset/ &&
-unpack $SOURCE2 &&
-unpack $SOURCE3 &&
-unpack $SOURCE4
+default_cmake_build

--- a/games/openttd/DEPENDS
+++ b/games/openttd/DEPENDS
@@ -1,12 +1,6 @@
-depends SDL
+depends cmake
+depends SDL2
 depends zlib
 depends libpng
 depends freetype2
 depends fontconfig
-
-optional_depends timidity++ "" "" "for ingame music"
-
-optional_depends xz  "--with-liblzma" "--without-liblzma" "for savegame compression"
-optional_depends lzo "--with-liblzo2" "--without-liblzo2" "to open savegames older than 0.3"
-
-optional_depends icu4c "--with-icu" "--without-icu" "to support right-to-left languages" n

--- a/games/openttd/DETAILS
+++ b/games/openttd/DETAILS
@@ -1,8 +1,8 @@
           MODULE=openttd
-         VERSION=1.10.3
-        VERSION2=0.6.0
-        VERSION3=0.2.3
-        VERSION4=0.3.1
+         VERSION=1.11.0
+        VERSION2=0.6.1
+        VERSION3=1.0.1
+        VERSION4=0.4.0
           SOURCE=$MODULE-$VERSION-source.tar.xz
          SOURCE2=opengfx-$VERSION2-all.zip
          SOURCE3=opensfx-$VERSION3-all.zip
@@ -11,13 +11,13 @@
      SOURCE2_URL=https://cdn.openttd.org/opengfx-releases/$VERSION2
      SOURCE3_URL=https://cdn.openttd.org/opensfx-releases/$VERSION3
      SOURCE4_URL=https://cdn.openttd.org/openmsx-releases/$VERSION4
-      SOURCE_VFY=sha256:c11601ef547eb1f6d4f9a035bd19e0a760b47872ce7d9b4117aaa45ac377b53b
-     SOURCE2_VFY=sha256:d419c0f5f22131de15f66ebefde464df3b34eb10e0645fe218c59cbc26c20774
-     SOURCE3_VFY=sha256:6831b651b3dc8b494026f7277989a1d757961b67c17b75d3c2e097451f75af02
-     SOURCE4_VFY=sha256:92e293ae89f13ad679f43185e83fb81fb8cad47fe63f4af3d3d9f955130460f5
+      SOURCE_VFY=sha256:5e65184e07368ba1afa62dbb3e35abaee6c4da6730ff4bc9eb4447d53363c7a8
+     SOURCE2_VFY=sha256:c694a112cd508d9c8fdad1b92bde05e7c48b14d66bad0c3999e443367437e37e
+     SOURCE3_VFY=sha256:37b825426f1d690960313414423342733520d08916f512f30f7aaf30910a36c5
+     SOURCE4_VFY=sha256:7698cadf06c44fb5e847a5773a22a4a1ea4fc0cf45664181254656f9e1b27ee2
         WEB_SITE=http://www.openttd.org/
          ENTERED=20060322
-         UPDATED=20200918
+         UPDATED=20210405
            SHORT="A clone of the Microprose game Transport Tycoon Deluxe"
          GARBAGE=off
 

--- a/games/openttd/INSTALL
+++ b/games/openttd/INSTALL
@@ -1,0 +1,8 @@
+prepare_install &&
+
+{ [ -d /usr/share/games/openttd/baseset ] || 
+    mkdir -p /usr/share/games/openttd/baseset; } &&
+cd /usr/share/games/openttd/baseset/ &&
+unpack $SOURCE2 &&
+unpack $SOURCE3 &&
+unpack $SOURCE4


### PR DESCRIPTION
Lots of fixes into this :)
The build system is now cmake
https://github.com/OpenTTD/OpenTTD/releases