### PR TITLE
darktable update

### DIFF
--- a/graphics/darktable/BUILD
+++ b/graphics/darktable/BUILD
@@ -1,5 +1,4 @@
-# GnomeKeyring is only supported for versions older than 3.12.0, version 3.12.0 found.
-# Please use libsecret instead.
-OPTS+=" -DBUILD_USERMANUAL=0 -DDONT_USE_INTERNAL_LUA=0" &&
-
+CC="clang" CXX="clang++"
+OPTS+=" -DBUILD_USERMANUAL=OFF \
+        -DDONT_USE_INTERNAL_LUA=OFF"
 default_cmake_build

--- a/graphics/darktable/BUILD
+++ b/graphics/darktable/BUILD
@@ -1,4 +1,4 @@
-CC="clang" CXX="clang++"
 OPTS+=" -DBUILD_USERMANUAL=OFF \
-        -DDONT_USE_INTERNAL_LUA=OFF"
-default_cmake_build
+        -DDONT_USE_INTERNAL_LUA=OFF" &&
+
+CC="clang" CXX="clang++" default_cmake_build

--- a/graphics/darktable/DEPENDS
+++ b/graphics/darktable/DEPENDS
@@ -5,6 +5,7 @@ depends libpng
 depends pugixml
 depends gtk+-3
 depends cairo
+depends librsvg
 depends lcms2
 depends exiv2
 depends tiff

--- a/graphics/darktable/DEPENDS
+++ b/graphics/darktable/DEPENDS
@@ -1,21 +1,43 @@
-depends SDL
-depends exiv2
+# hard requirements
+depends sqlite
+depends %JPEG
+depends libpng
 depends pugixml
-depends json-glib
-depends openexr
-depends gtk+-2
+depends gtk+-3
+depends cairo
 depends lcms2
+depends exiv2
+depends tiff
+depends curl
+depends gphoto2
+depends libsoup
+depends dbus-glib
+depends openexr
+depends isl
+depends openmp
+
+# not hard requirements, but
+# important to functionality
+depends libxslt
+depends gettext
 depends lensfun
-depends librsvg
-depends gtk-engines2
+depends libxml2
+depends json-glib
+depends zlib
+depends libwebp
+depends GraphicsMagick
+depends colord-gtk
 
-depends python-jsonschema
-depends python-pyrsistent
-
-optional_depends colord-gtk "-DUSE_COLORD=1"         "-DUSE_COLORD=0"         "For libcolord support"
-optional_depends flickcurl  "-DUSE_FLICKR=1"         "-DUSE_FLICKR=0"         "For Flickr API support"
-optional_depends openjpeg   "-DUSE_OPENJPEG=1"       "-DUSE_OPENJPEG=0"       "For openjpeg graphics support"
-optional_depends libgphoto2 "-DUSE_CAMERA_SUPPORT=1" "-DUSE_CAMERA_SUPPORT=0" "For Camera support"
-optional_depends libsecret  "-DUSE_LIBSECRET=1"      "-DUSE_LIBSECRET=0"      "For storing and retrieving passwords"
-optional_depends kwallet    "-DUSE_KWALLET=1"        "-DUSE_KWALLET=0"        "Use kwallet password manager" n
-optional_depends "lua"      "-DUSE_LUA=1"            "-DUSE_LUA=0"            "For lua scripting support"
+# optional
+optional_depends flickcurl \
+      "-DUSE_FLICKR=1" \
+      "-DUSE_FLICKR=0" \
+      "For Flickr API support" n
+optional_depends libsecret \
+      "-DUSE_LIBSECRET=1" \
+      "-DUSE_LIBSECRET=0" \
+      "For storing and retrieving passwords" n
+optional_depends kwallet \
+      "-DUSE_KWALLET=1" \
+      "-DUSE_KWALLET=0" \
+      "Use kwallet password manager" n

--- a/graphics/darktable/DETAILS
+++ b/graphics/darktable/DETAILS
@@ -1,11 +1,11 @@
           MODULE=darktable
-         VERSION=2.6.3
+         VERSION=3.4.1
           SOURCE=$MODULE-$VERSION.tar.xz
-      SOURCE_URL=http://github.com/darktable-org/darktable/releases/download/release-$VERSION
-      SOURCE_VFY=sha256:a518999c8458472edfc04577026ce5047d74553052af0f52d10ba8ce601b78f0
-        WEB_SITE=http://www.darktable.org
-         ENTERED=20111109
-         UPDATED=20191126
+        SOURCE_URL=https://github.com/darktable-org/darktable/releases/download/release-${VERSION}/
+      SOURCE_VFY=7fc3f851da9bcd7c5053ecd09f21aa3eb6103be98a6c58f52010b6f22174941e
+        WEB_SITE=https://darktable.org/
+         ENTERED=20190818
+         UPDATED=20210410
            SHORT="An image darkroom"
 
 cat << EOF

--- a/graphics/darktable/PRE_BUILD
+++ b/graphics/darktable/PRE_BUILD
@@ -1,4 +1,4 @@
 default_pre_build &&
 
-#updates the check for LLVM
-sed -i 's/find_llvm("/find_llvm("11.1;/g' CMakeLists.txt
+# we know our llvm is newer than 3.8
+sedit 's/\sfind_llvm(.*$/find_package(LLVM CONFIG)/g' CMakeLists.txt

--- a/graphics/darktable/PRE_BUILD
+++ b/graphics/darktable/PRE_BUILD
@@ -1,0 +1,4 @@
+default_pre_build &&
+
+#updates the check for LLVM
+sed -i 's/find_llvm("/find_llvm("11.1;/g' CMakeLists.txt


### PR DESCRIPTION
Whole bunch of changes - the darktable module hasn't been updated in over a year.

BUILD - darktable either requires gcc to be compiled with isl support, or clang to be used as a compiler instead. Since clang will already be installed as part of the dependency chain (gtk+-3 > mesa-lib > llvm), it's easier & safer to use clang.

DEPENDS - this has been almost entirely rewritten because of changes between v2.6 and v3.4

DETAILS - Normal version bump changes.

PRE_BUILD - darktable only checks up to v11.0 of llvm, I've added a sed line to include v11.1.

