### PR TITLE
libpsl + publicsuffix-list fixes

### DIFF
--- a/libs/libpsl/BUILD
+++ b/libs/libpsl/BUILD
@@ -5,8 +5,7 @@ OPTS+=" --disable-static \
         --enable-runtime=libidn2 \
         --with-psl-file=/usr/share/publicsuffix/effective_tld_names.dat \
         --with-psl-testfile=/usr/share/publicsuffix/test_psl.txt"
+        
 
-default_config &&
-LC_CTYPE=en_US.UTF-8 make &&
-prepare_install &&
-make install
+LC_CTYPE=en_US.UTF-8 
+default_build

--- a/libs/libpsl/DEPENDS
+++ b/libs/libpsl/DEPENDS
@@ -6,6 +6,6 @@ depends publicsuffix-list
 
 optional_depends gtk-doc \
                  "--enable-gtk-doc" \
-                 "--disable-docs" \
+                 "--disable-gtk-doc" \
                  "for documentation install" \
                  "n"

--- a/libs/libpsl/POST_INSTALL
+++ b/libs/libpsl/POST_INSTALL
@@ -1,0 +1,1 @@
+lin -p publicsuffix-list

--- a/libs/libpsl/PRE_BUILD
+++ b/libs/libpsl/PRE_BUILD
@@ -1,3 +1,2 @@
 default_pre_build &&
-rm -rf list &&
-autoreconf -fvi
+rm -rf list

--- a/net/publicsuffix-list/DETAILS
+++ b/net/publicsuffix-list/DETAILS
@@ -1,11 +1,11 @@
           MODULE=publicsuffix-list
-         VERSION=20180512.65ddeb3
-     _GIT_COMMIT=65ddeb3eca4cfd9f436f7b2fed49df57624d40f7
+         VERSION=20210406.5cb7ed8
+     _GIT_COMMIT=5cb7ed80c9ee58b8a60f00d42598c9ead406ee29
           SOURCE=$MODULE-$VERSION.tar.bz2
       SOURCE_URL=git+https://github.com/publicsuffix/list:$_GIT_COMMIT
         WEB_SITE=https://github.com/rockdaboot/libpsl
          ENTERED=20180512
-         UPDATED=20180512
+         UPDATED=20210413
            SHORT="Cross-vendor public domain suffix database"
 
 cat << EOF


### PR DESCRIPTION
libpsl:
DEPENDS - fixed an error in the gtk-doc optional_depends that causes a configure failure if you chose to _not_ install (libpsl defaults to enabling docs).
PRE_BUILD - autoreconf doesn't read the OPTS in the DEPENDS file (because PRE_BUILD is finished before DEPENDS is read), which meant the gtk-doc failure still happened. It's not necessary to the build anyway.
BUILD - using default_build works properly, even with the exported LC_CTYPE (why aren't we using the system default?). This makes the autoreconf in PRE_BUILD unnecessary.
POST_INSTALL - since we're deleting the suffix list in PRE_BUILD, I added in this implicit install of _publicsuffix-list,_ which is the whole point to libpsl.

publicsuffix-list:
DETAILS: updated to the most recent commit.
