### PR TITLE
deadbeef - version bump

### DIFF
--- a/audio/deadbeef/BUILD
+++ b/audio/deadbeef/BUILD
@@ -1,0 +1,4 @@
+## last.fm and libnotify require swift/libdispatch to work
+OPTS+=" --disable-gtk2 --disable-lfm --disable-notify"
+CC=clang CXX=clang++
+default_build

--- a/audio/deadbeef/DEPENDS
+++ b/audio/deadbeef/DEPENDS
@@ -1,27 +1,23 @@
-depends intltool
 depends XML-Parser
 depends yasm
 depends zip
 depends ffmpeg
 depends jansson
+depends gtk+-3
 
 optional_depends alsa-lib "" "--disable-alsa" "for ALSA output support"
 optional_depends alsa-oss "" "--disable-oss" "for Open Sound System output support"
 optional_depends pulseaudio "" "--disable-pulse" "for Pulseaudio output support"
-optional_depends gtk+-3 "" "--disable-gtk3" "for GTK3 version of gtkui support"
-optional_depends gtk+-2 "" "--disable-gtk2" "for GTK2 version of gtkui support"
 optional_depends libvorbis "" "--disable-vorbis" "for Ogg Vorbis player support"
 optional_depends flac "" "--disable-flac" "for FLAC player support"
 optional_depends libsndfile "" "--disable-sndfile" "for libsndfile plugin for PCM wave files support"
 optional_depends wavpack "" "--disable-wavpack" "for wavpack support"
-optional_depends libnotify "" "--disable-notify" "for notification-daemon support"
 optional_depends libmpcdec "" "--disable-musepack" "for Musepack support"
 optional_depends wildmidi "" "--disable-wildmidi" "for wildmidi support"
 optional_depends libdca "" "--disable-dca" "for dca (DTS audio) support"
-optional_depends faad2 "" "--enable-faad"  "for faad support"
+optional_depends faad2 "" "--disable-faad"  "for faad support"
 optional_depends libmms "" "--disable-mms" "for MMS streaming vfs support"
-optional_depends libsamplerate "" "--enable-src" "for libsamplerate (SRC) support"
-optional_depends imlib2 "" "--enable-artwork-imlib2" "for imlib2 in artwork in support"
-optional_depends dumb "" "--enable-dumb" "for DUMB support"
-
+optional_depends libsamplerate "" "--disable-src" "for libsamplerate (SRC) support"
+optional_depends imlib2 "" "--disable-artwork-imlib2" "for imlib2 in artwork in support"
+optional_depends dumb "" "--disable-dumb" "for DUMB support"
 optional_depends libmad "" ""  "for mpeg(mad) support"

--- a/audio/deadbeef/DETAILS
+++ b/audio/deadbeef/DETAILS
@@ -1,11 +1,11 @@
           MODULE=deadbeef
-         VERSION=0.7.2
+         VERSION=1.8.7
           SOURCE=$MODULE-$VERSION.tar.bz2
-      SOURCE_URL=http://sourceforge.net/projects/$MODULE/files
-      SOURCE_VFY=sha256:8a63abdf00c2f37c33e018ae0b39d391873e037434074b84bb47381bf283c884
+      SOURCE_URL=$SFORGE_URL/$MODULE/
+      SOURCE_VFY=sha256:4409f1623cbaa52140f30d30760b4534c74e638286819f46dc0b4046879ffec5
         WEB_SITE=http://deadbeef.sourceforge.net
          ENTERED=20141229
-         UPDATED=20170301
+         UPDATED=20210409
            SHORT="an audio player for GNU/Linux systems with X11 written in C and C++"
 
 cat << EOF

--- a/audio/deadbeef/PRE_BUILD
+++ b/audio/deadbeef/PRE_BUILD
@@ -1,3 +1,4 @@
-default_pre_build &&
+default_pre_build
 
-sedit 's/zip_file_t/vfs_zip_file_t/g' plugins/vfs_zip/vfs_zip.c
+## may not be necessary?
+##sedit 's/zip_file_t/vfs_zip_file_t/g' plugins/vfs_zip/vfs_zip.c


### PR DESCRIPTION
BUILD:
- gtk2 is now legacy code, and upstream will stop supporting it soon.
- last.fm and notification support require swift/libdispatch, which we don't have on Lunar.

DEPENDS:
- made gtk3 the default
- fixed an error in the faad2 optional_depends

DETAILS:
normal version bump updates

PRE_BUILD:
there's a string replacement that doesn't seem to be necessary anymore (compiled and works fine without it), but I've commented it out and left it here in case I'm wrong and it is needed.