### PR TITLE
qrencode - update DEPENDS

### DIFF
--- a/libs/qrencode/DEPENDS
+++ b/libs/qrencode/DEPENDS
@@ -1,2 +1,2 @@
 depends libpng
-depends SDL
+depends SDL2


### PR DESCRIPTION
_qrencode_ installs using SDL2 without problems. I think we should use the newer library when possible.