### PR TITLE
inkscape version bump

### DIFF
--- a/graphics/inkscape/BUILD
+++ b/graphics/inkscape/BUILD
@@ -1,5 +1,4 @@
-OPTS+=" -DWITH_NLS=ON \
-        -DWITH_CDR=OFF \
-        -DWITH_GRAPHICS_MAGICK=OFF"
+## CDR = Corel Draw. This file doesn't exist in Lunar
+OPTS+=" -DWITH_CDR=OFF"
 
 default_cmake_build

--- a/graphics/inkscape/DEPENDS
+++ b/graphics/inkscape/DEPENDS
@@ -1,68 +1,67 @@
-depends harfbuzz
-depends pango
-depends fontconfig
-depends freetype2
-depends gsl
-depends libsoup
 depends double-conversion
-depends gc
-depends cairo
-depends %JPEG
-depends zlib
-depends libpng
-depends potrace
 depends gtk+-3
-depends gtkmm3
-depends gdk-pixbuf
-depends gdl
-depends boost
-depends aspell
-depends libxslt
-depends libxml2
-depends gettext
+depends gsl
 depends libsigc++2
-depends gzip
+depends libsoup
+depends gc
+depends potrace
+depends libxml2
+depends libxslt
+depends lcms2
+depends poppler
+depends libpng
+depends gtkmm3
+depends boost
 depends python-numpy
 depends python-lxml
-
-optional_depends poppler \
-        "-DENABLE_POPPLER=ON" \
-        "-DENABLE_POPPLER=OFF" \
-        "for PDF support (highly recommended)"
-
-optional_depends openmp \
-        "-DWITH_OPENMP=ON" \
-        "-DWITH_OPENMP=OFF" \
-        "for multithread processing support (highly recommended)"
-
-optional_depends lcms2 \
-        "-DENABLE_LCMS=ON" \
-        "-DENABLE_LCMS=OFF" \
-        "for Colour Management support"
-
-optional_depends dbus \
-        "-DWITH_DBUS=ON" \
-        "-DWITH_DBUS=OFF" \
-        "for dbus support"
-
-optional_depends gtkspell3 \
-        "-DWITH_GTKSPELL=ON" \
-        "-DWITH_GTKSPELL=OFF" \
-        "for spelling support"
-
-optional_depends libvisio \
-        "-DWITH_LIBVISIO=ON" \
-        "-DWITH_LIBVISIO=OFF" \
-        "for visio diagram support"
-
-optional_depends libwpg \
-        "-DWITH_LIBWPG=ON" \
-        "-DWITH_LIBWPG=OFF" \
-        "for WordPerfect Graphics support"
+depends %JPEG
+depends libpng
+depends tiff
 
 optional_depends jemalloc \
-        "-DWITH_JEMALLOC=ON" \
-        "-DWITH_JEMALLOC=OFF" \
-        "for memory allocation support"
+    "-DWITH_JEMALLOC=ON" \
+    "-DWITH_JEMALLOC=OFF" \
+    "for memory allocation support"
+    
+optional_depends scour \
+    "-DWITH_SCOUR=ON" \
+    "-DWITH_SCOUR=OFF" \
+    "for optimizing SVG save files"  
+      
+optional_depends dbus-glib \
+    "-DWITH_DBUS=ON" \
+    "-DWITH_DBUS=OFF" \
+    "for dbus support"
+
+optional_depends gspell \
+    "-DWITH_GSPELL=ON" \
+    "-DWITH_GSPELL=OFF" \
+    "for spelling support"
+
+optional_depends libvisio \
+    "-DWITH_LIBVISIO=ON" \
+    "-DWITH_LIBVISIO=OFF" \
+    "for visio diagram support"
+
+optional_depends libwpg \
+    "-DWITH_LIBWPG=ON" \
+    "-DWITH_LIBWPG=OFF" \
+    "for WordPerfect Graphics support"
+
+optional_depends openmp \
+    "-DWITH_OPENMP=ON" \
+    "-DWITH_OPENMP=OFF" \
+    "for multithread filter rendering (highly recommended)"
+      
+optional_depends GraphicsMagick \
+    "-DWITH_GRAPHICS_MAGICK=ON" \
+    "-DWITH_GRAPHICS_MAGICK=OFF" \
+    "for extra graphic filters ${PROBLEM_COLOR}choose this or ImageMagick (next)${PROBLEM_COLOR}" 
+
+optional_depends ImageMagick \
+    "-DWITH_IMAGE_MAGICK=ON" \
+    "-DWITH_IMAGE_MAGICK=OFF" \
+    "for extra graphic filters"
+        
 
 

--- a/graphics/inkscape/DETAILS
+++ b/graphics/inkscape/DETAILS
@@ -1,12 +1,12 @@
           MODULE=inkscape
-         VERSION=1.0.2
+         VERSION=1.1
           SOURCE=inkscape-${VERSION}.tar.xz
-      SOURCE_URL=https://inkscape.org/gallery/item/23820/
-SOURCE_DIRECTORY=$BUILD_DIRECTORY/$MODULE-${VERSION}_2021-01-15_e86c870879
-      SOURCE_VFY=sha256:da3e230511a08cbf21e86710d161458594fea87867e9157b67ed01a04ea2798a
+      SOURCE_URL=https://inkscape.org/gallery/item/26932/
+SOURCE_DIRECTORY=$BUILD_DIRECTORY/inkscape-1.1_2021-05-24_c4e8f9ed74
+      SOURCE_VFY=sha256:71e6e8ce3fdf702f59dbc4a276665eb982eb7822b029bbdbeced2df4301795e6
         WEB_SITE=https://inkscape.org/
          ENTERED=20190826
-         UPDATED=20210118
+         UPDATED=20210524
            SHORT="Full featured vector graphics editor"
 
 cat << EOF


### PR DESCRIPTION
BUILD: Removed two unnecessary OPTS - NLS is turned on by default, and GraphicsMagick is now an _optional_depends._
DEPENDS: I removed some unnecessary depends that are implicitly installed by other depends, and shuffled the _optional_ into a more sensible grouping.
DETAILS: normal version bump stuff.