### PR TITLE
graphite - update DEPENDS

### DIFF
--- a/graphics/graphite/DEPENDS
+++ b/graphics/graphite/DEPENDS
@@ -1,3 +1,3 @@
-depends python2
+depends python
 depends cmake
 depends freetype2


### PR DESCRIPTION
Graphite no longer needs python2, and probably has not for a while. This was probably an old DEPENDS that was never updated because it never actually failed to build.