### PR TITLE
new module - python-appdirs

### DIFF
--- a/python/python-appdirs/DEPENDS
+++ b/python/python-appdirs/DEPENDS
@@ -1,0 +1,1 @@
+depends python-setuptools

--- a/python/python-appdirs/DETAILS
+++ b/python/python-appdirs/DETAILS
@@ -1,0 +1,16 @@
+            MODULE=python-appdirs
+           VERSION=1.4.4
+            SOURCE=$MODULE-$VERSION.tar.gz
+  SOURCE_DIRECTORY=$BUILD_DIRECTORY/appdirs-$VERSION
+        SOURCE_URL_FULL=https://files.pythonhosted.org/packages/d7/d8/05696357e0311f5b5c316d7b95f46c669dd9c15aaeecbb48c7d0aeb88c40/appdirs-1.4.4.tar.gz
+        SOURCE_VFY=sha256:7d5d0167b2b1ba821647616af46a749d1c653740dd0d2415100fe26e27afdf41
+          WEB_SITE=http://pypi.python.org/pypi/appdirs/
+              TYPE=python3
+           ENTERED=20210530
+           UPDATED=20210530
+             SHORT="A small Python module for determining appropriate platform-specific dirs"
+              TYPE=python3
+
+cat << EOF
+A small Python module for determining appropriate platform-specific dirs, e.g. a "user data dir". 
+EOF

--- a/python/python-appdirs/DETAILS
+++ b/python/python-appdirs/DETAILS
@@ -5,7 +5,6 @@
         SOURCE_URL_FULL=https://files.pythonhosted.org/packages/d7/d8/05696357e0311f5b5c316d7b95f46c669dd9c15aaeecbb48c7d0aeb88c40/appdirs-1.4.4.tar.gz
         SOURCE_VFY=sha256:7d5d0167b2b1ba821647616af46a749d1c653740dd0d2415100fe26e27afdf41
           WEB_SITE=http://pypi.python.org/pypi/appdirs/
-              TYPE=python3
            ENTERED=20210530
            UPDATED=20210530
              SHORT="A small Python module for determining appropriate platform-specific dirs"


### PR DESCRIPTION
A small Python module for determining appropriate platform-specific dirs, e.g. a "user data dir"

This module is for multi-platform apps to figure out the correct directory structure to use when storing user data.
From the homepage:

> What directory should your app use for storing user data? If running on Mac OS X, you should use:
> 
> ~/Library/Application Support/<AppName>
> 
> If on Windows (at least English Win XP) that should be:
> 
> C:\Documents and Settings\<User>\Application Data\Local Settings\<AppAuthor>\<AppName>
> 
> or possibly:
> 
> C:\Documents and Settings\<User>\Application Data\<AppAuthor>\<AppName>
> 
> for roaming profiles but that is another story.
> 
> On Linux (and other Unices) the dir, according to the XDG spec, is:
> 
> ~/.local/share/<AppName>

This module is needed for the new extensions manager in Inkscape (updated PR for that pending approval of this).