### PR TITLE
engrampa - archive manager

### DIFF
--- a/x11-utils/engrampa/BUILD
+++ b/x11-utils/engrampa/BUILD
@@ -1,0 +1,3 @@
+OPTS+="--disable-caja-actions"
+
+default_build

--- a/x11-utils/engrampa/DEPENDS
+++ b/x11-utils/engrampa/DEPENDS
@@ -1,0 +1,1 @@
+depends gtk+-3

--- a/x11-utils/engrampa/DETAILS
+++ b/x11-utils/engrampa/DETAILS
@@ -1,0 +1,18 @@
+          MODULE=engrampa
+         VERSION=1.24.2
+          SOURCE=$MODULE-$VERSION.tar.xz
+      SOURCE_URL=https://github.com/mate-desktop/engrampa/releases/download/v${VERSION}
+      SOURCE_VFY=sha256:ee280d288c974732ec7bc2d1c3e18fa563b33a30f3e4cb3e976ebc71be6c4674
+        WEB_SITE=http://www.mate-desktop.org
+         ENTERED=20210701
+         UPDATED=20210701
+           SHORT="Archive Manager"
+           TYPE=default
+
+cat << EOF
+Engrampa is a fork of File-Roller.
+
+Engrampa is an archive manager for the MATE environment.  This means that you can create and modify archives; view the content of an archive; view and modify a file contained in the archive; extract files from the archive.
+
+Engrampa is only a front-end (a graphical interface) to archiving programs like tar and zip
+EOF


### PR DESCRIPTION
Part of the Mate Desktop, _engrampa_ is a fork of GNOME 3's _file roller,_ but without the extra GNOME dependencies.