### PR TITLE
mate-calc - desktop calculator

### DIFF
--- a/x11-apps/mate-calc/DEPENDS
+++ b/x11-apps/mate-calc/DEPENDS
@@ -1,0 +1,1 @@
+depends gtk+-3

--- a/x11-apps/mate-calc/DETAILS
+++ b/x11-apps/mate-calc/DETAILS
@@ -1,0 +1,13 @@
+          MODULE=mate-calc
+         VERSION=1.24.2
+          SOURCE=$MODULE-$VERSION.tar.xz
+      SOURCE_URL=https://github.com/mate-desktop/${MODULE}/releases/download/v${VERSION}/
+      SOURCE_VFY=sha256:d4a4c8ff51c4611b32a129b7cad33c3bb8a1ec6b9d5f209aa4ee0c8f1b90e8f9
+        WEB_SITE=http://mate-desktop.org
+         ENTERED=20210415
+         UPDATED=20210415
+           SHORT="GTK based calulator"
+
+cat << EOF
+MATE Calculator (mate-calc) started as a fork of gnome-calc, the calculator application that was previously in the OpenWindows Deskset of the Solaris 8 operating system.
+EOF


### PR DESCRIPTION
Part of the Mate Desktop, _mate-calc_ is a fork of _gnome calculator, _ but without the GNOME dependencies.