### PR TITLE
syslog-ng: version bump and fix typo in BUILD

### DIFF
--- a/utils/syslog-ng/BUILD
+++ b/utils/syslog-ng/BUILD
@@ -15,9 +15,9 @@ OPTS+=" --prefix=/usr \
         --with-pidfile-dir=/run"
 
 if module_installed systemd; then
-   OPTS+="--enable-systemd --with-systemd-journal=system"
+   OPTS+=" --enable-systemd --with-systemd-journal=system"
 else
-   OPTS+="--disable-systemd --with-systemd-journal=no"
+   OPTS+=" --disable-systemd --with-systemd-journal=no"
 fi
 
 default_build &&
@@ -26,4 +26,6 @@ install -dm755 /var/lib/syslog-ng /etc/syslog-ng/patterndb.d &&
 install -Dm644 $SCRIPT_DIRECTORY/syslog-ng.conf /etc/syslog-ng/syslog-ng.conf &&
 
 # See http://lists.balabit.hu/pipermail/syslog-ng/2016-February/022667.html
-rm -r /usr/share/syslog-ng/include/scl/cim
+rm -r /usr/share/syslog-ng/include/scl/cim &&
+
+add_priv_group log

--- a/utils/syslog-ng/DETAILS
+++ b/utils/syslog-ng/DETAILS
@@ -1,11 +1,11 @@
           MODULE=syslog-ng
-         VERSION=3.33.1
+         VERSION=3.33.2
           SOURCE=$MODULE-$VERSION.tar.gz
       SOURCE_URL=https://github.com/balabit/syslog-ng/releases/download/$MODULE-$VERSION/
-      SOURCE_VFY=sha256:35913654582947705a5679c9a2dcd4d25b4c98f3f3734cd55e94c5c780c22877
+      SOURCE_VFY=sha256:0b786a06077b9150191d714f45a1b4b3792952cb58163a3af336f074da9fb14b
         WEB_SITE=https://github.com/balabit/syslog-ng
          ENTERED=20180106
-         UPDATED=20210711
+         UPDATED=20210804
            SHORT="Next-generation log daemon"
 
 cat << EOF


### PR DESCRIPTION
Currently running syslog-ng gives those messages:

> [2021-08-04T12:28:26.094620] Error resolving group; group='log'
syslog-ng: Error changing to directory=/run--enable-systemd, errcode=2
[2021-08-04T12:28:26.805680] Error opening control socket, bind() failed; socket='/run--enable-systemd/syslog-ng.ctl', error='No such file or directory (2)'
syslog-ng: Error creating pid file; file='/run--enable-systemd/syslog-ng.pid', error='No 
such file or directory'