### PR TITLE
updated depends & build

### DIFF
--- a/graphics/GraphicsMagick/BUILD
+++ b/graphics/GraphicsMagick/BUILD
@@ -1,8 +1,9 @@
 OPTS+=" --enable-shared \
-        --enable-symbol-prefix \
+        --disable-static \
         --with-perl \
         --with-threads \
         --with-modules \
-        --with-quantum-depth=16"
+        --with-quantum-depth=16 \
+        --with-x "
 
 default_build

--- a/graphics/GraphicsMagick/DEPENDS
+++ b/graphics/GraphicsMagick/DEPENDS
@@ -6,6 +6,9 @@ depends libwebp
 depends freetype2
 depends libXext
 depends libSM
+depends %JPEG
+depends ghostscript
+depends openmp
 
 optional_depends gperf "" "" "for improved memory allocator"
 optional_depends lcms2    ""  ""  "for color management"
@@ -16,5 +19,4 @@ optional_depends libwmf   ""  ""  "for Windows Metafile support"
 optional_depends libfpx   ""  ""  "for flash pix support"
 optional_depends libopenraw    ""  ""  "for RAW image support"
 optional_depends sane-backends "" "" "for scanner support"
-optional_depends graphviz "" "" "for graph drawing support. Requires ghostscript (next)"
-optional_depends ghostscript "" "" "for PDF support"
+optional_depends graphviz "" "" "for graph drawing support."

--- a/graphics/GraphicsMagick/DETAILS
+++ b/graphics/GraphicsMagick/DETAILS
@@ -3,6 +3,7 @@
           SOURCE=$MODULE-$VERSION.tar.xz
       SOURCE_URL=$SFORGE_URL/graphicsmagick
       SOURCE_VFY=sha256:5d5b3fde759cdfc307aaf21df9ebd8c752e3f088bb051dd5df8aac7ba7338f46
+
         WEB_SITE=http://www.graphicsmagick.org/
          ENTERED=20061117
          UPDATED=20210109


### PR DESCRIPTION
BUILD: _--enable-symbol-prefix_ causes several of the programs to fail if ImageMagick is also installed. Static files were disabled, and X support is implicitly included.
DEPENDS: added some missing deps, and GM requires ghostscript now.
