### PR TITLE
darktable version bump

### DIFF
--- a/graphics/darktable/BUILD
+++ b/graphics/darktable/BUILD
@@ -1,6 +1,5 @@
 OPTS+=" -DBUILD_USERMANUAL=OFF \
-        -DDONT_USE_INTERNAL_LUA=OFF \
-        -DBUILD_CURVE_TOOLS=ON \
-        -DBUILD_NOISE_TOOLS=ON" &&
+        -DDONT_USE_INTERNAL_LUA=OFF" &&
 
-CC="clang" CXX="clang++" default_cmake_build
+CC="clang" CXX="clang++"
+default_cmake_build

--- a/graphics/darktable/DEPENDS
+++ b/graphics/darktable/DEPENDS
@@ -13,7 +13,7 @@ depends curl
 depends gphoto2
 depends libsoup
 depends dbus-glib
-depends openexr
+depends isl
 depends openmp
 
 depends python-pyrsistent
@@ -31,6 +31,17 @@ depends GraphicsMagick
 depends colord-gtk
 
 # optional
+
+optional_depends gmic \
+  "-DUSE_GMIC=1" \
+  "-DUSE_GMIC=0" \
+  "for 3D LUT support"
+  
+optional_depends openexr \
+   "-DUSE_OPENEXR=1" \
+   "-DUSE_OPENEXR=0" \
+   "for EXR format support" 
+
 optional_depends flickcurl \
       "-DUSE_FLICKR=1" \
       "-DUSE_FLICKR=0" \

--- a/graphics/darktable/DETAILS
+++ b/graphics/darktable/DETAILS
@@ -1,11 +1,11 @@
           MODULE=darktable
-         VERSION=3.6.0
+         VERSION=3.6.1
           SOURCE=$MODULE-$VERSION.tar.xz
-      SOURCE_URL=https://github.com/darktable-org/darktable/releases/download/release-${VERSION}/
-      SOURCE_VFY=sha256:86bcd0184af38b93c3688dffd3d5c19cc65f268ecf9358d649fa11fe26c70a39
+        SOURCE_URL=https://github.com/darktable-org/darktable/releases/download/release-${VERSION}/
+      SOURCE_VFY=a2bfc7c103b824945457a9bfed9e52f007fa1d030f9dbcb3ff0327851be42d14
         WEB_SITE=https://darktable.org/
          ENTERED=20190818
-         UPDATED=20210813
+         UPDATED=20211001
            SHORT="An image darkroom"
 
 cat << EOF


### PR DESCRIPTION
BUILD: removed a couple of redundant OPTS (both are ON by default)
DEPENDS: moved _openexr_ from a hard dependency to an _optional,_ added _isl_ as a hard dep, and g'mic as an optional
DETAILS: normal version bump changes
