### PR TITLE
httpd: version bumped to 2.4.50

### DIFF
--- a/web/httpd/DETAILS
+++ b/web/httpd/DETAILS
@@ -1,11 +1,11 @@
           MODULE=httpd
-         VERSION=2.4.49
+         VERSION=2.4.50
           SOURCE=$MODULE-$VERSION.tar.bz2
       SOURCE_URL=http://www.apache.org/dist/httpd/
-      SOURCE_VFY=sha256:65b965d6890ea90d9706595e4b7b9365b5060bec8ea723449480b4769974133b
+      SOURCE_VFY=sha256:6a2817c070c606682eb53ed963511407d3c3d7a379cdf855971467b00fb3890f
         WEB_SITE=http://www.apache.org
          ENTERED=20020710
-         UPDATED=20210921
+         UPDATED=20211006
            SHORT="A popular HTTP server"
 
 cat << EOF


### PR DESCRIPTION
There was a vulnerability allowing arbitrary path traversal introduced in 2.4.49.
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-41773