### PR TITLE
conmon: add missing meson code

### DIFF
--- a/virtual/conmon/DEPENDS
+++ b/virtual/conmon/DEPENDS
@@ -1,3 +1,4 @@
 depends git
 depends systemd
 depends meson
+depends libseccomp

--- a/virtual/conmon/PRE_BUILD
+++ b/virtual/conmon/PRE_BUILD
@@ -1,3 +1,4 @@
 default_pre_build &&
 
-sedit "s:/usr/local:/usr:" Makefile
+sedit "s:/usr/local:/usr:" Makefile &&
+sedit "37i cc = meson.get_compiler('c')" meson.build


### PR DESCRIPTION
The error message I had was:
`meson.build:37:0: ERROR: Unknown variable "cc".`