### PR TITLE
pulseaudio: fix missing alsa lib

### DIFF
--- a/audio/pulseaudio/BUILD
+++ b/audio/pulseaudio/BUILD
@@ -1,5 +1,6 @@
 # libsamplerate is depreciated.
 OPTS+=" -D udevrulesdir=/usr/lib/udev/rules.d  \
+        -D alsa=enabled \
         -D samplerate=disabled  \
         -D system_group=pulse \
         -D system_user=pulse "


### PR DESCRIPTION
The error I was getting was:
`E: [pulseaudio] ltdl-bind-now.c: Failed to open module module-alsa-card.so: module-alsa-card.so: cannot open shared object file: No such file or directory
E: [pulseaudio] module.c: Failed to open module "module-alsa-card".`