### PR TITLE
Wlroots - fix depends

### DIFF
--- a/wayland/wlroots/BUILD
+++ b/wayland/wlroots/BUILD
@@ -1,7 +1,6 @@
 OPTS+=" -D xcb-errors=enabled \
-        -D xcb-icccm=enabled \
-        -D xcb-xkb=enabled \
         -D xwayland=enabled \
-        -D x11-backend=enabled"
+        -D x11-backend=enabled \
+        -D examples=false"
 
 default_meson_build

--- a/wayland/wlroots/BUILD
+++ b/wayland/wlroots/BUILD
@@ -1,6 +1,5 @@
 OPTS+=" -D xcb-errors=enabled \
         -D xwayland=enabled \
-        -D x11-backend=enabled \
-        -D examples=false"
-
+        -D x11-backend=enabled"
+        
 default_meson_build

--- a/wayland/wlroots/CONFIGURE
+++ b/wayland/wlroots/CONFIGURE
@@ -1,0 +1,3 @@
+mquery "build example applications (for developers)?" \
+	"-D examples=true" \
+	"-D examples=false"


### PR DESCRIPTION
DEPENDS: the _xcb_icccm_ and _xcb-xkb_ compile options no longer exist, and they make the build fail.

CONFIGURE: building the example applications for development is now an optional setting, previously defaulted to 'true'