### PR TITLE
gphoto2: fix depends

### DIFF
--- a/graphics/gphoto2/DEPENDS
+++ b/graphics/gphoto2/DEPENDS
@@ -1,5 +1,6 @@
 depends libgphoto2
 depends popt
+depends libexif
 
 optional_depends libjpeg-turbo \
                  "" "--without-jpeg" \
@@ -8,8 +9,3 @@ optional_depends libjpeg-turbo \
 optional_depends readline "--with-readline" "--without-readline" "for readline support"
 optional_depends aalib    "--with-aalib"    "--without-aalib"    "for preview support"
 optional_depends cdk      "--with-cdk"      "--without-cdk"      "for ncurses type support"
-
-optional_depends libexif \
-                 "--with-libexif=auto" \
-                 "--with-libexif=no"  \
-                 "for EXIF data support"


### PR DESCRIPTION
libexif is no longer optional in gphoto2