### PR TITLE
librsvg: fix depends

### DIFF
--- a/graphics/librsvg/CONFIGURE
+++ b/graphics/librsvg/CONFIGURE
@@ -2,8 +2,4 @@ mquery GDKPIXBUF_LOADER "Enable GdkPixbuf loader?" y \
                         "--enable-pixbuf-loader" \
                         "--disable-pixbuf-loader"
 
-mquery MISC_TOOLS       "Enable miscellaenous tools?" y \
-                        "--enable-tools" \
-                        "--disable-tools"
-
 mquery REBUILD_CAIRO    "Rebuild cairo upon completion to enable SVG testing?" y

--- a/graphics/librsvg/DEPENDS
+++ b/graphics/librsvg/DEPENDS
@@ -9,7 +9,6 @@ optional_depends vala \
                  "--enable-vala=no" \
                  "for vala support"
                  
-                 
 optional_depends gobject-introspection \
                  "--enable-introspection" \
                  "--enable-introspection=no" \

--- a/graphics/librsvg/DEPENDS
+++ b/graphics/librsvg/DEPENDS
@@ -1,16 +1,17 @@
 depends gdk-pixbuf
-depends pango      # needs pango with cairo enabled
+depends pango
 depends rustc
 depends intltool
 depends gtk-doc
 
 optional_depends vala \
                  "--enable-vala" \
-                 "--disable-vala" \
+                 "--enable-vala=no" \
                  "for vala support"
-
+                 
+                 
 optional_depends gobject-introspection \
                  "--enable-introspection" \
-                 "--enable-introspection" \
+                 "--enable-introspection=no" \
                  "for introspection support" \
                  "y"


### PR DESCRIPTION
CONFIGURE: the _miscellaneous tools_ option doesn't exist anymore

DEPENDS:
 - pango requires cairo on Lunar by default
 - gtk-doc is optional
 - gobject-introspection had a typo (both _yes_ and _no_ were set to _enable_)
 - made the disable options for both _vala_ and _introspection_ match what's in the ./configure file.