### PR TITLE
firefox-bin: version bump

### DIFF
--- a/web/firefox-bin/BUILD
+++ b/web/firefox-bin/BUILD
@@ -11,4 +11,4 @@ fi &&
 # Now the .desktop file and the icon
 mkdir -p /usr/share/applications /usr/share/pixmaps &&
 install -m644 $SCRIPT_DIRECTORY/firefox-bin.desktop /usr/share/applications/ &&
-ln -snf /usr/lib/firefox/browser/icons/mozicon128.png /usr/share/pixmaps/firefox.png
+cp /usr/lib/firefox/browser/chrome/icons/default/default128.png /usr/share/pixmaps/firefox.png

--- a/web/firefox-bin/DETAILS
+++ b/web/firefox-bin/DETAILS
@@ -1,11 +1,11 @@
           MODULE=firefox-bin
-         VERSION=96.0.3
+         VERSION=97.0
           SOURCE=firefox-$VERSION.tar.bz2
       SOURCE_URL=https://ftp.mozilla.org/pub/firefox/releases/${VERSION}/linux-i686/en-US/
-      SOURCE_VFY=sha256:096169898ad97b2575b0b5e07c012f55f8749b7bc85f373c276d97948c3b7e08
+      SOURCE_VFY=sha256:7df5164de2eea1c32657c6ba813664a15ba5a198ac1a19c32ab494f9fab1d39c
         WEB_SITE=http://www.mozilla.org/projects/firefox
          ENTERED=20091207
-         UPDATED=20220204
+         UPDATED=20220208
          ARCHIVE=off
            SHORT="A speedy, full-featured web browser"
 

--- a/web/firefox-bin/DETAILS.x86_64
+++ b/web/firefox-bin/DETAILS.x86_64
@@ -1,10 +1,10 @@
           MODULE=firefox-bin
-         VERSION=96.0.3
+         VERSION=97.0
           SOURCE=firefox-$VERSION.tar.bz2
       SOURCE_URL=https://ftp.mozilla.org/pub/firefox/releases/${VERSION}/linux-x86_64/en-US/
-      SOURCE_VFY=sha256:2b642cfd2db0c2cb0f67453307a5a7d8c90e372a03274644212b51f60d503965
+      SOURCE_VFY=sha256:3d0f74790fe6ff5e38324222ab0c47e10edb31970ed67c6dd7a1c84e7017d1a5
          ENTERED=20091207
-         UPDATED=20220204
+         UPDATED=20220208
          ARCHIVE=off
            SHORT="A speedy, full-featured web browser"
 


### PR DESCRIPTION
BUILD:
 - the _/usr/lib/firefox/browser/icons/_ folder no longer exists, and neither does the _mozicon128.png_ file. I changed this to something that actually works.

DETAILS:
- normal version bump changes