### PR TITLE
firefox: version bump and lots of other fixes

### DIFF
--- a/web/firefox/BUILD
+++ b/web/firefox/BUILD
@@ -1,14 +1,10 @@
-# this breaks a symbol check in the build scripts
-LDFLAGS=$(echo $LDFLAGS | sed "s/-s//") &&
-
-SHELL="${SHELL:-/bin/bash}" &&
-
-CFLAGS="${CFLAGS/-fno-plt/}" &&
-CXXFLAGS="${CXXFLAGS/-fno-plt/}" &&
+CFLAGS="${CFLAGS/-fno-plt/}"
+CXXFLAGS="${CXXFLAGS/-fno-plt/}"
+CC="clang"
+CXX="clang++"
 
 # LTO needs more open files
-ulimit -n 4096
-
+  ulimit -n 4096
 ./mach configure &&
 ./mach build &&
 ./mach buildsymbols &&
@@ -17,13 +13,8 @@ prepare_install &&
 
 ./mach install &&
 
-install -Dm 644 {"$SCRIPT_DIRECTORY",/usr/share/applications}/firefox.desktop &&
-
+install -Dm 644 $SCRIPT_DIRECTORY/firefox.desktop /usr/share/applications/ &&
 for s in 16 22 24 32 48 256; do
   install -Dm 644 $SOURCE_DIRECTORY/browser/branding/official/default${s}.png \
     /usr/share/icons/hicolor/${s}x${s}/apps/firefox.png
-done &&
-
-# symlink plugins folder
-mkdir -p /usr/lib/lunar/plugins &&
-ln -sfn /usr/lib/firefox/browser /usr/lib/lunar/plugins
+done

--- a/web/firefox/DEPENDS
+++ b/web/firefox/DEPENDS
@@ -1,68 +1,31 @@
 depends autoconf-mozilla
-depends python
-depends llvm
+depends python-cffi
+depends python-pycparser
+depends python-psutil
 depends cbindgen
 depends lld
-depends freetype2
-depends gtk+-2
 depends gtk+-3
 depends nss
-depends curl
 depends alsa-lib
 depends libvpx
-depends cbindgen
-depends pixman
-depends libffi
 depends nasm
 depends node
-depends unzip
-depends mesa-lib
-depends zip
-
-optional_depends libpng \
-                 "--with-system-png" \
-                 "--without-system-libpng" \
-                 "Build with system libpng"
-
-optional_depends libevent \
-                 "--with-system-libevent" \
-                 "--without-system-libevent" \
-                 "Use system event library"
-
-optional_depends dbus-glib \
-                 "--enable-dbus" \
-                 "--disable-dbus" \
-                 "For dbus support"
-
-optional_depends icu4c \
-                 "--with-system-icu" \
-                 "--without-system-icu" \
-                 "Use system icu4c library"
-
-#optional_depends pipewire \
-#                 "--enable-pipewire" \
-#                 "--disable-pipewire"  \
-#                 "Build pipewire sound backend"
+depends dbus-glib
+depends libjpeg-turbo
+depends libevent
+depends icu4c
 
 optional_depends pulseaudio \
-                 "--enable-pulseaudio" \
+                 "" \
                  "--disable-pulseaudio"  \
                  "Build pulseAudio sound backend"
 
-# firefox requires jpeg-turbo extensions, so NO, libjpeg is not enough
-optional_depends libjpeg-turbo \
-                 "--with-system-jpeg" \
-                 "--without-system-jpeg" \
-                 "Use system jpeg library"
-
 optional_depends webrtc-audio-processing  \
-                 "--enable-webrtc"        \
+                 ""        \
                  "--disable-webrtc"       \
                  "For real time communication support"
 
 optional_depends cups \
-                 "--enable-printing" \
+                 "" \
                  "--disable-printing" \
                  "For printing support"
-
-optional_depends flash-plugin "" "" "To enable Flash plugin"

--- a/web/firefox/DETAILS
+++ b/web/firefox/DETAILS
@@ -1,11 +1,11 @@
            MODULE=firefox
-          VERSION=94.0.2
+          VERSION=97.0
            SOURCE=$MODULE-$VERSION.source.tar.xz
        SOURCE_URL=https://archive.mozilla.org/pub/firefox/releases/$VERSION/source
-       SOURCE_VFY=sha256:899ba1c806549034793d7e8ca53f4c845d783c810338f314f3d653d39649e575
+       SOURCE_VFY=sha256:6c8a7dcb47122d033383fd62a1bcaefff0290a6c23d057898e8ff9c72749df28
          WEB_SITE=https://www.mozilla.org/en-US/firefox/
           ENTERED=20110814
-          UPDATED=20211124
+          UPDATED=20220208
             SHORT="A speedy, full-featured web browser"
 cat << EOF
 Mozilla Firefox is the successor of Mozilla Firebird.
@@ -26,10 +26,4 @@ Firefox includes:
     configurable
   * a large variety of free downloadable extensions and themes that
     add specific functionality and visual changes to the browser
-
-------- NOTE -------
-The Lunar version of Firefox has crypto enabled and uses only gtk+-2.
-NOTHING ELSE IS CONFIGURED IN! No mail, irc, composer, gpg, calendar,
-MathML, Javascript debugger, html code inspector, LDAP, help support.
-If you want any of that use the regular seamonkey module.
 EOF

--- a/web/firefox/PRE_BUILD
+++ b/web/firefox/PRE_BUILD
@@ -1,10 +1,10 @@
-default_pre_build &&
-
 if [ ! -e /usr/include/cairo/cairo-tee.h ]; then
   message "${PROBLEM_COLOR}Run: ${MODULE_COLOR}lin -rc cairo" &&
   message "${MESSAGE_COLOR}To recompile cairo with tee(libX11) support, which is required by firefox.${DEFAULT_COLOR}" &&
   false
 fi &&
+
+default_pre_build &&
 
 # This export is for their hardcoding of autoconf-2.13
 export AUTOCONF=autoconf-mozilla &&

--- a/web/firefox/PRE_BUILD
+++ b/web/firefox/PRE_BUILD
@@ -1,57 +1,25 @@
-if [ ! -e /usr/include/cairo/cairo-tee.h ]; then
-  message "${PROBLEM_COLOR}Run: ${MODULE_COLOR}lin -rc cairo" &&
-  message "${MESSAGE_COLOR}To recompile cairo with tee(libX11) support, which is required by firefox.${DEFAULT_COLOR}" &&
-  false
-fi &&
-
 default_pre_build &&
-
-# Google API keys (see http://www.chromium.org/developers/how-tos/api-keys)
-# The keys below are for Lunar Linux use ONLY. If you are maintaining chromium
-# for another distribution, please get your own set of keys.
-google_api_key=AIzaSyDhObDIVsBGV5fleLgLq6ZpfKldIVMvrG4 &&
-
-echo -n "$google_api_key" > google_api_key &&
-
-export MOZ_CO_PROJECT=browser &&
-export MOZILLA_HOME=/usr/lib/$MODULE-$VERSION &&
-export MOZILLA_OFFICIAL=1 &&
-export BUILD_OFFICIAL=1 &&
-export MOZ_MAKE_FILES=$MAKES &&
-export MOZ_OPTIMIZE_FLAGS="$CFLAGS" &&
-export MOZ_DEBUG_FLAGS="$CFLAGS" &&
-export MOZ_JEMALLOC=1 &&
-export MOZ_ADDON_SIGNING=1 &&
-#export MOZ_REQUIRE_SIGNING=0 &&
-export MACH_USE_SYSTEM_PYTHON=1 &&
-export CC=clang &&
-export CXX=clang++ &&
-export AR=llvm-ar &&
-export NM=llvm-nm &&
-export RANLIB=llvm-ranlib &&
 
 # This export is for their hardcoding of autoconf-2.13
 export AUTOCONF=autoconf-mozilla &&
 
 cp $SCRIPT_DIRECTORY/mozconfig . &&
-export MOZ_OBJDIR="${SOURCE_DIRECTORY}/build-mozilla" &&
-mkdir -p ${MOZ_OBJDIR} &&
+export MOZBUILD_STATE_PATH="${SOURCE_DIRECTORY}/build-mozilla" &&
+mkdir -p ${MOZBUILD_STATE_PATH} &&
 
+# Google API keys: 
+# This api key is for Lunar Linux use ONLY.
+# See http://www.chromium.org/developers/how-tos/api-keys
+# to get your own set of keys.
+
+cp $SCRIPT_DIRECTORY/google_api_key . &&
+echo "ac_add_options --with-google-location-service-api-keyfile=$SOURCE_DIRECTORY/google_api_key" >> mozconfig &&
+echo "ac_add_options --with-google-safebrowsing-api-keyfile=$SOURCE_DIRECTORY/google_api_key" >> mozconfig &&
+
+# add optionals from DEPENDS to mozconfig
 for flag in $OPTS; do
   echo "ac_add_options $flag" >> mozconfig
 done &&
 
-echo "ac_add_options --with-google-location-service-api-keyfile=$SOURCE_DIRECTORY/google_api_key" >> mozconfig &&
-echo "ac_add_options --with-google-safebrowsing-api-keyfile=$SOURCE_DIRECTORY/google_api_key" >> mozconfig &&
-
 # turn off this #$ bell during build
-setterm -bfreq -blength &> /dev/null &&
-
-if [ -n "${MAKES}" ]; then
-  echo "mk_add_options MOZ_MAKE_FLAGS='-j${MAKES}'" >> mozconfig
-fi &&
-
-sedit '/deny.*missing_docs/ d' $(grep -rl "deny.*missing_docs" servo) &&
-
-#error: options `-C embed-bitcode=no` and `-C lto` are incompatible
-sed -i "s|-Clto$||" config/makefiles/rust.mk
+setterm -bfreq -blength &> /dev/null

--- a/web/firefox/PRE_BUILD
+++ b/web/firefox/PRE_BUILD
@@ -27,5 +27,10 @@ for flag in $OPTS; do
   echo "ac_add_options $flag" >> mozconfig
 done &&
 
+# use our chosen number of jobs
+if [ -n "${MAKES}" ]; then
+  echo "mk_add_options MOZ_MAKE_FLAGS='-j${MAKES}'" >> mozconfig
+fi &&
+
 # turn off this #$ bell during build
 setterm -bfreq -blength &> /dev/null

--- a/web/firefox/PRE_BUILD
+++ b/web/firefox/PRE_BUILD
@@ -1,5 +1,11 @@
 default_pre_build &&
 
+if [ ! -e /usr/include/cairo/cairo-tee.h ]; then
+  message "${PROBLEM_COLOR}Run: ${MODULE_COLOR}lin -rc cairo" &&
+  message "${MESSAGE_COLOR}To recompile cairo with tee(libX11) support, which is required by firefox.${DEFAULT_COLOR}" &&
+  false
+fi &&
+
 # This export is for their hardcoding of autoconf-2.13
 export AUTOCONF=autoconf-mozilla &&
 

--- a/web/firefox/google_api_key
+++ b/web/firefox/google_api_key
@@ -1,0 +1,1 @@
+AIzaSyDhObDIVsBGV5fleLgLq6ZpfKldIVMvrG4

--- a/web/firefox/mozconfig
+++ b/web/firefox/mozconfig
@@ -1,44 +1,41 @@
-ac_add_options --prefix=/usr
-ac_add_options --with-user-appdir=".firefox"
-ac_add_options --with-system-zlib
-ac_add_options --with-ccache
-ac_add_options --with-unsigned-addon-scopes=app,system
-ac_add_options --enable-application=browser
-ac_add_options --enable-default-toolkit=cairo-gtk3
-ac_add_options --enable-linker=gold
 ac_add_options --enable-release
-ac_add_options --enable-hardening
-ac_add_options --enable-rust-simd
-ac_add_options --enable-optimize="$CFLAGS"
-ac_add_options --enable-strip
-ac_add_options --enable-install-strip
 ac_add_options --enable-official-branding
-ac_add_options --enable-jemalloc
+ac_add_options --enable-optimize="$CFLAGS"
+ac_add_options --enable-default-toolkit=cairo-gtk3
+ac_add_options --enable-application=browser
+ac_add_options --with-unsigned-addon-scopes=app,system
+ac_add_options --with-user-appdir=".firefox"
+
 ac_add_options --enable-system-pixman
 ac_add_options --enable-system-ffi
+ac_add_options --with-system-jpeg
+ac_add_options --with-system-png
+ac_add_options --with-system-zlib
+ac_add_options --with-system-libevent
+ac_add_options --with-system-icu
+ac_add_options --enable-alsa
+
+ac_add_options --prefix=/usr
+ac_add_options --with-ccache
+ac_add_options --enable-linker=lld
+ac_add_options --enable-hardening
+ac_add_options --enable-rust-simd
+ac_add_options --enable-strip
+ac_add_options --enable-install-strip
+ac_add_options --enable-jemalloc
 ac_add_options --enable-raw
 ac_add_options --enable-dbus
 ac_add_options --enable-replace-malloc
+ac_add_options --disable-elf-hack
+ac_add_options --disable-bootstrap
+
 ac_add_options --disable-debug
 ac_add_options --disable-debug-symbols
-ac_add_options --disable-updater
 ac_add_options --disable-crashreporter
+ac_add_options --disable-updater
 ac_add_options --disable-necko-wifi
-
-# startupcache deterministically segfaults on *some* systems. Just leave it disabled.
-#ac_add_options --disable-startupcache
-
-# Disabling tests breaks PGO so having CONFIGURE set it
 ac_add_options --disable-tests
+ac_add_options --without-wasm-sandboxed-libraries
 
-#DEBUG: configure: error: --enable-system-cairo is not supported
-#ac_add_options --disable-system-cairo
-
-# The following is taken from the Linux From Scratch folks;
-# The following option unsets Telemetry Reporting. With the Addons Fiasco,
-# Mozilla was found to be collecting user's data, including saved passwords and
-# web form data, without users consent. Mozilla was also found shipping updates
-# to systems without the user's knowledge or permission.
-# As a result of this, use the following command to permanently disable
-# telemetry reporting in Firefox.
 unset MOZ_TELEMETRY_REPORTING
+export MOZILLA_OFFICIAL=1


### PR DESCRIPTION
Lots of changes!

BUILD:
 - the change to LDFLAGS and specifying SHELL aren't necessary any more, and the build works fine without them
 - got rid of the /usr/lib/lunar/plugins symlink. We don't actually do anything with this.

DEPENDS:
 - removed some dependencies that are implicitly installed by other deps. Also, good by to gtk2 and Flash!
 - since our preference is to use system-installed programs, I removed the optional_depends, made them regular depends, and added their OPTS directly into mozconfig

DETAILS:
 - normal version bump stuff
 - removed note that says our version of FF uses gtk2 and recommends to use seamonkey for full features - it hasn't used gtk2 in years, and our seamonkey module is 8 years old.
  
PRE_BUILD:
 - almost all the _export_ options work by default , or are covered by mozconfig options, and aren't necessary to the build. a couple got moved into _BUILD_ and _mozconfig._
 - MOZ_OBJDIR (build directory) is now handled by MOZBUILD_STATE_PATH.
 - rather than post a notice about using the google_api_key, then echoing the key into a file, I put a more concise notice and put the key directly into a file.
 - the problems fixed by the _sedit_ lines don't exist any more, so they've been removed.

google_api_key:
 - new file containing the Lunar api key.
 
mozconfig:
 - rearranged the options into logical groups.
 - removed the options that we had commented out for years (startup cache and cairo).
 - added in an option about webassembly sandboxing (which needs to be fixed with another module).
 - removed the explanation about disabling telemetry: no one is looking at this file, and the telemetry feature doesn't gather this info any more (according to Mozilla).