### PR TITLE
containerd: fix wrong installation path

### DIFF
--- a/virtual/containerd/BUILD
+++ b/virtual/containerd/BUILD
@@ -3,7 +3,7 @@ export GOFLAGS="-trimpath -mod=readonly -modcacherw"
 make VERSION=v$VERSION REVISION=
 make VERSION=v$VERSION man
 prepare_install &&
-make install DESTDIR=/usr &&
+make install PREFIX=/usr &&
 
 install -Dm644 man/*.8 -t /usr/share/man/man8/ &&
 install -Dm644 man/*.5 -t /usr/share/man/man5/ &&

--- a/virtual/containerd/BUILD
+++ b/virtual/containerd/BUILD
@@ -3,7 +3,7 @@ export GOFLAGS="-trimpath -mod=readonly -modcacherw"
 make VERSION=v$VERSION REVISION=
 make VERSION=v$VERSION man
 prepare_install &&
-make install PREFIX=/usr &&
+make PREFIX=/usr install &&
 
 install -Dm644 man/*.8 -t /usr/share/man/man8/ &&
 install -Dm644 man/*.5 -t /usr/share/man/man5/ &&


### PR DESCRIPTION
The containerd binary was being installed in /usr/usr/local/bin/containerd