### PR TITLE
php: fix wrong config path

### DIFF
--- a/compilers/php/POST_INSTALL
+++ b/compilers/php/POST_INSTALL
@@ -1,10 +1,10 @@
-if [ ! -e /etc/php.ini ]; then
-  cp $SOURCE_DIRECTORY/php.ini-production /etc/php.ini
+if [ ! -e /etc/php/php.ini ]; then
+  cp $SOURCE_DIRECTORY/php.ini-production /etc/php/php.ini
 fi
 
 case $REGGLOBALS in
   y|Y)
-    sedit "s/register_globals = Off/register_globals = On/" /etc/php.ini
+    sedit "s/register_globals = Off/register_globals = On/" /etc/php/php.ini
     ;;
     *) true
     ;;


### PR DESCRIPTION
HTML files starting with <?xml fail to display, giving this error message:  
"Parse error: syntax error, unexpected 'version' (T_STRING) in /srv/files/docs/tmp/index.html on line 1"  

The short_open_tag is set to Off in /etc/php.ini but phpinfo() reveals that it's set to On.

Moving php.ini in /etc/php fixes this issue and the page displays correctly.