### PR TITLE
qhull: Adjusting BUILD to silence this warning during an octave compile;

### DIFF
--- a/science/qhull/BUILD
+++ b/science/qhull/BUILD
@@ -1,3 +1,9 @@
 OPTS+=" -DCMAKE_C_FLAGS=-fPIC -DCMAKE_CXX_FLAGS=-fPIC -DCMAKE_BUILD_TYPE=Release -DLINK_APPS_SHARED=ON" &&
 
-default_cmake_build
+default_cmake_build &&
+
+#Builds libqhull.so needed by octave. Note; not the same as libqhull_r.so.
+cmake --build . --target libqhull &&
+
+cp -P libqhull.so* /usr/lib/
+

--- a/science/qhull/DETAILS
+++ b/science/qhull/DETAILS
@@ -6,7 +6,7 @@ SOURCE_DIRECTORY=$BUILD_DIRECTORY/qhull-2020.2
       SOURCE_VFY=sha256:59356b229b768e6e2b09a701448bfa222c37b797a84f87f864f97462d8dbc7c5
         WEB_SITE=http://www.qhull.org/
          ENTERED=20100125
-         UPDATED=20210421
+         UPDATED=20220327
            SHORT="computing convex hulls"
 
 cat << EOF


### PR DESCRIPTION
 WARNING: Qhull library not found.  This will result in loss of functionality for some geometry functions