### PR TITLE
libpng:add a download URL

### DIFF
--- a/graphics/libpng/DETAILS
+++ b/graphics/libpng/DETAILS
@@ -3,7 +3,8 @@
           SOURCE=$MODULE-$VERSION.tar.xz
          SOURCE2=$MODULE-$VERSION-apng.patch.gz
    SOURCE_URL[0]=$SFORGE_URL/$MODULE
-   SOURCE_URL[1]=ftp://ftp.simplesystems.org/pub/libpng/png/src/${MODULE}16
+   SOURCE_URL[1]=https://fossies.org/linux/misc/
+   SOURCE_URL[2]=ftp://ftp.simplesystems.org/pub/libpng/png/src/${MODULE}16
      SOURCE2_URL=$MIRROR_URL
       SOURCE_VFY=sha256:505e70834d35383537b6491e7ae8641f1a4bed1876dbfe361201fc80868d88ca
      SOURCE2_VFY=sha256:10d9e0cb60e2b387a79b355eb7527c0bee2ed8cbd12cf04417cabc4d6976683c


### PR DESCRIPTION
SourceForge's CDN is too bad. It's 99.99% unlikely that it can't be connected.