### PR TITLE
php: version bumped to 7.4.29

### DIFF
--- a/compilers/php/DEPENDS
+++ b/compilers/php/DEPENDS
@@ -41,7 +41,8 @@ optional_depends db \
                  "for Berkeley DB4 support"
 
 optional_depends sqlite \
-                 "--with-sqlite3=shared,/usr --with-pdo-sqlite=shared,/usr" "" \
+                 "--with-sqlite3=shared,/usr --with-pdo-sqlite=shared,/usr" \
+				 "--without-sqlite3 --without-pdo-sqlite" \
                  "for PDO SQLite support"
 
 optional_depends %MYSQL \
@@ -49,7 +50,8 @@ optional_depends %MYSQL \
                  "for native MySQL support"
 
 optional_depends postgresql \
-                 "--with-pgsql=shared --with-pdo-pgsql=shared" "" \
+                 "--with-pgsql=shared --with-pdo-pgsql=shared" \
+				 "--without-pgsql --without-pdo-pgsql" \
                  "for PostgreSQL support"
 
 optional_depends unixODBC \

--- a/compilers/php/DETAILS
+++ b/compilers/php/DETAILS
@@ -1,11 +1,11 @@
           MODULE=php
-         VERSION=7.4.28
+         VERSION=7.4.29
           SOURCE=php-$VERSION.tar.xz
       SOURCE_URL=http://php.net/distributions/
-      SOURCE_VFY=sha256:9cc3b6f6217b60582f78566b3814532c4b71d517876c25013ae51811e65d8fce
+      SOURCE_VFY=sha256:7d0f07869f33311ff3fe1138dc0d6c0d673c37fcb737eaed2c6c10a949f1aed6
         WEB_SITE=http://www.php.net
          ENTERED=20040919
-         UPDATED=20220218
+         UPDATED=20220516
            SHORT="PHP: Hypertext Processor scripting language"
 
 cat << EOF

--- a/compilers/php/POST_INSTALL
+++ b/compilers/php/POST_INSTALL
@@ -1,4 +1,5 @@
 if [ ! -e /etc/php/php.ini ]; then
+  [ -d /etc/php ] || mkdir /etc/php
   cp $SOURCE_DIRECTORY/php.ini-production /etc/php/php.ini
 fi
 


### PR DESCRIPTION
POST_INSTALL was missing a 'mkdir /etc/php' on initial installation.