### PR TITLE
bind: add required dependency to DEPENDS

### DIFF
--- a/net/bind/DEPENDS
+++ b/net/bind/DEPENDS
@@ -1,3 +1,4 @@
+depends python-chardet
 depends python-ply
 depends libuv
 depends libtool

--- a/net/bind/DEPENDS
+++ b/net/bind/DEPENDS
@@ -1,4 +1,5 @@
 depends python-chardet
+depends python-packaging
 depends python-ply
 depends libuv
 depends libtool


### PR DESCRIPTION
Build fails because of missing python-chardet.