### PR TITLE
rsyslog: version bumped to 8.2204.1

### DIFF
--- a/utils/rsyslog/DETAILS
+++ b/utils/rsyslog/DETAILS
@@ -1,12 +1,12 @@
           MODULE=rsyslog
-         VERSION=8.2110.0
+         VERSION=8.2204.1
           SOURCE=$MODULE-$VERSION.tar.gz
   SOURCE_URL_FULL=https://github.com/rsyslog/rsyslog/archive/v${VERSION}.tar.gz
-      SOURCE_VFY=sha256:24a4fa47d03420622cb86103fbd016b81db8fdfc59d5b3b579d3ebf7aa4ec015
+      SOURCE_VFY=sha256:e3673dda3c7ed3dd5e79e21ff0cf2cef86e3d689c8862069e9ac2bea5c2b5073
         WEB_SITE=http://www.rsyslog.com/
       MAINTAINER=ratler@lunar-linux.org
          ENTERED=20080731
-         UPDATED=20211030
+         UPDATED=20220530
            SHORT="An enhanced multi-threaded syslogd"
 
 cat << EOF


### PR DESCRIPTION
This release fixes CVE-2022-24903 .
Many other fixes.