### PR TITLE
httpd: version bumped to 2.4.54

### DIFF
--- a/web/httpd/DETAILS
+++ b/web/httpd/DETAILS
@@ -1,11 +1,11 @@
           MODULE=httpd
-         VERSION=2.4.53
+         VERSION=2.4.54
           SOURCE=$MODULE-$VERSION.tar.bz2
       SOURCE_URL=http://www.apache.org/dist/httpd/
-      SOURCE_VFY=sha256:d0bbd1121a57b5f2a6ff92d7b96f8050c5a45d3f14db118f64979d525858db63
+      SOURCE_VFY=sha256:eb397feeefccaf254f8d45de3768d9d68e8e73851c49afd5b7176d1ecf80c340
         WEB_SITE=http://www.apache.org
          ENTERED=20020710
-         UPDATED=20220516
+         UPDATED=20220609
            SHORT="A popular HTTP server"
 
 cat << EOF


### PR DESCRIPTION
This release fixes 8 CVEs  
https://downloads.apache.org/httpd/CHANGES_2.4