### PR TITLE
inkscape:bump to 1.2.1

### DIFF
--- a/graphics/inkscape/DEPENDS
+++ b/graphics/inkscape/DEPENDS
@@ -2,7 +2,7 @@ depends double-conversion
 depends gtk+-3
 depends gsl
 depends libsigc++2
-depends libsoup
+#depends libsoup
 depends gc
 depends potrace
 depends libxml2

--- a/graphics/inkscape/DEPENDS
+++ b/graphics/inkscape/DEPENDS
@@ -2,7 +2,7 @@ depends double-conversion
 depends gtk+-3
 depends gsl
 depends libsigc++2
-#depends libsoup
+depends libsoup
 depends gc
 depends potrace
 depends libxml2

--- a/graphics/inkscape/DETAILS
+++ b/graphics/inkscape/DETAILS
@@ -3,7 +3,7 @@
           SOURCE=$MODULE-$VERSION.tar.xz
    SOURCE_URL[0]=https://inkscape.org/gallery/item/34673/
    SOURCE_URL[1]=https://media.inkscape.org/dl/resources/file/
-SOURCE_DIRECTORY=$BUILD_DIRECTORY/inkscape-$VERSION\_2022-05-15_dc2aedaf03
+SOURCE_DIRECTORY=$BUILD_DIRECTORY/inkscape-$VERSION\_2022-07-14_9c6d41e410
       SOURCE_VFY=sha256:46ce7da0eba7ca4badc1db70e9cbb67e0adf9bb342687dc6e08b5ca21b8d4c1b
         WEB_SITE=https://inkscape.org/
          ENTERED=20190826

--- a/graphics/inkscape/DETAILS
+++ b/graphics/inkscape/DETAILS
@@ -1,12 +1,13 @@
           MODULE=inkscape
-         VERSION=1.2
+         VERSION=1.2.1
           SOURCE=$MODULE-$VERSION.tar.xz
-      SOURCE_URL=https://inkscape.org/gallery/item/33449/
+   SOURCE_URL[0]=https://inkscape.org/gallery/item/34673/
+   SOURCE_URL[1]=https://media.inkscape.org/dl/resources/file/
 SOURCE_DIRECTORY=$BUILD_DIRECTORY/inkscape-$VERSION\_2022-05-15_dc2aedaf03
-      SOURCE_VFY=sha256:8d9b31142554945664edfefe2d6b55910a5099765f7176a71107c34f1dcde6ad
+      SOURCE_VFY=sha256:46ce7da0eba7ca4badc1db70e9cbb67e0adf9bb342687dc6e08b5ca21b8d4c1b
         WEB_SITE=https://inkscape.org/
          ENTERED=20190826
-         UPDATED=20220517
+         UPDATED=20220808
            SHORT="Full featured vector graphics editor"
 
 cat << EOF

--- a/graphics/inkscape/DETAILS
+++ b/graphics/inkscape/DETAILS
@@ -1,6 +1,6 @@
           MODULE=inkscape
          VERSION=1.2
-          SOURCE=inkscape-$VERSION\_2022-05-15_dc2aedaf03.tar.xz 
+          SOURCE=$MODULE-$VERSION.tar.xz
       SOURCE_URL=https://inkscape.org/gallery/item/33449/
 SOURCE_DIRECTORY=$BUILD_DIRECTORY/inkscape-$VERSION\_2022-05-15_dc2aedaf03
       SOURCE_VFY=sha256:8d9b31142554945664edfefe2d6b55910a5099765f7176a71107c34f1dcde6ad


### PR DESCRIPTION
The original download address requires login to download.