### PR TITLE
mozjs version 91

### DIFF
--- a/compilers/mozjs91/BUILD
+++ b/compilers/mozjs91/BUILD
@@ -22,7 +22,7 @@ mk_add_options MOZ_OBJDIR=$SOURCE_DIRECTORY/obj
 mk_add_options MOZ_NOSPAM=1
 END
 
-if in_depends $MODULE llvm; then
+if in_depends $MODULE lld; then
   export CC=clang
   export CXX=clang++
   export AR=llvm-ar

--- a/compilers/mozjs91/BUILD
+++ b/compilers/mozjs91/BUILD
@@ -1,0 +1,47 @@
+export MACH_USE_SYSTEM_PYTHON=1
+
+cat > ./mozconfig <<END
+ac_add_options --enable-application=js
+ac_add_options --prefix=/usr
+ac_add_options --enable-release
+ac_add_options --enable-hardening
+ac_add_options --enable-optimize
+ac_add_options --enable-rust-simd
+ac_add_options --disable-bootstrap
+ac_add_options --disable-debug-symbols
+ac_add_options --disable-jemalloc
+ac_add_options --enable-strip
+ac_add_options --with-system-zlib
+ac_add_options --with-system-icu
+ac_add_options --with-system-nspr
+ac_add_options --enable-shared-js
+ac_add_options --enable-tests
+ac_add_options --with-intl-api
+ac_add_options --enable-readline
+mk_add_options MOZ_OBJDIR=$SOURCE_DIRECTORY/obj
+mk_add_options MOZ_NOSPAM=1
+END
+
+if in_depends $MODULE llvm; then
+  export CC=clang
+  export CXX=clang++
+  export AR=llvm-ar
+  export NM=llvm-nm
+  export RANLIB=llvm-ranlib
+echo "ac_add_options --enable-linker=lld" >> ./mozconfig
+fi &&
+
+if [[ $STATIC_LIB == "n" ]]; then
+sedit 's/ifneq (,$(REAL_LIBRARY))/ifneq (libjs_static.a,$(REAL_LIBRARY))/' ./js/src/build/Makefile.in
+fi &&
+
+if module_installed ccache; then
+  if [[ $ENABLE_CCACHE == "y" ]]; then
+  echo "ac_add_options --enable-ccache" >> ./mozconfig
+  fi
+fi  &&
+
+./mach build &&
+prepare_install &&
+cd $SOURCE_DIRECTORY/obj &&
+make DESTDIR=/ install

--- a/compilers/mozjs91/CONFIGURE
+++ b/compilers/mozjs91/CONFIGURE
@@ -1,0 +1,2 @@
+mquery STATIC_LIB "Install static library of mozjs(not needed for gnome3)?" n
+mquery ENABLE_CCACHE "Build JS with ccache support?" y

--- a/compilers/mozjs91/DEPENDS
+++ b/compilers/mozjs91/DEPENDS
@@ -1,0 +1,10 @@
+depends autoconf-mozilla
+depends python
+depends icu4c
+depends readline
+depends libffi
+depends nspr
+depends zip
+depends zlib
+
+optional_depends llvm "" "" "compile with llvm instead of gcc" "y"

--- a/compilers/mozjs91/DEPENDS
+++ b/compilers/mozjs91/DEPENDS
@@ -8,4 +8,4 @@ depends zip
 depends zlib
 depends sqlite
 
-optional_depends llvm "" "" "compile with llvm instead of gcc" "y"
+optional_depends lld "" "" "compile with llvm instead of gcc" "y"

--- a/compilers/mozjs91/DEPENDS
+++ b/compilers/mozjs91/DEPENDS
@@ -6,5 +6,6 @@ depends libffi
 depends nspr
 depends zip
 depends zlib
+depends sqlite
 
 optional_depends llvm "" "" "compile with llvm instead of gcc" "y"

--- a/compilers/mozjs91/DETAILS
+++ b/compilers/mozjs91/DETAILS
@@ -1,0 +1,17 @@
+          MODULE=mozjs91
+         VERSION=91.12.0
+          SOURCE=firefox-${VERSION}esr.source.tar.xz
+SOURCE_DIRECTORY=$BUILD_DIRECTORY/firefox-${VERSION}
+      SOURCE_URL=https://archive.mozilla.org/pub/firefox/releases/${VERSION}esr/source/
+      SOURCE_VFY=sha256:6c0b8ff1826885eeace19ec87ae9e5a6512284d4863930713c8a288a03832b5c
+        WEB_SITE=http://developer.mozilla.org/en-US/docs/Mozilla/Projects/SpiderMonkey/Releases/24/
+         ENTERED=20140418
+         UPDATED=20220728
+           SHORT="JavaScript interpreter and libraries"
+
+cat << EOF
+This is SpiderMonkey, Mozilla's C implementation of JavaScript.
+SpiderMonkey is written in C and contains a compiler, interpreter, decompiler,
+garbage collector, and standard classes. It is intended to be embedded in other
+applications that provide host environments for JavaScript.
+EOF


### PR DESCRIPTION
New version of mozjs that uses the latest Firefox ESR.

Note: PRE_BUILD was integrated into BUILD, and there's no longer an option to remove the js-shell, so the CONFIGURE option and it's if statement in BUILD were removed.