### PR TITLE
httpd: opt for the CDN instead

### DIFF
--- a/web/httpd/DETAILS
+++ b/web/httpd/DETAILS
@@ -1,7 +1,7 @@
           MODULE=httpd
          VERSION=2.4.54
           SOURCE=$MODULE-$VERSION.tar.bz2
-      SOURCE_URL=http://www.apache.org/dist/httpd/
+      SOURCE_URL=http://dlcdn.apache.org/httpd/
       SOURCE_VFY=sha256:eb397feeefccaf254f8d45de3768d9d68e8e73851c49afd5b7176d1ecf80c340
         WEB_SITE=http://www.apache.org
          ENTERED=20020710


### PR DESCRIPTION
The main site mentions:  
`Do not download from www.apache.org. Please use a mirror site to help us save apache.org bandwidth.`
So the CDN (Content Delivery Network)  link should be used instead.