### PR TITLE
apr: use CDN link instead

### DIFF
--- a/libs/apr/DETAILS
+++ b/libs/apr/DETAILS
@@ -1,7 +1,7 @@
           MODULE=apr
          VERSION=1.7.0
           SOURCE=$MODULE-$VERSION.tar.bz2
-   SOURCE_URL[0]=http://www.apache.org/dist/apr
+   SOURCE_URL[0]=http://dlcdn.apache.org/apr
    SOURCE_URL[1]=ftp://mirror2.dataphone.se/pub/apache/apr
    SOURCE_URL[2]=http://www.apache.org/dist/apr
       SOURCE_VFY=sha256:e2e148f0b2e99b8e5c6caa09f6d4fb4dd3e83f744aa72a952f94f5a14436f7ea


### PR DESCRIPTION
The main site says:
`Do not download from www.apache.org. Please use a mirror site to help us save apache.org bandwidth.`
So the CDN link should be used here too.