### PR TITLE
apr-util: use CDN link instead

### DIFF
--- a/libs/apr-util/DETAILS
+++ b/libs/apr-util/DETAILS
@@ -1,7 +1,7 @@
           MODULE=apr-util
          VERSION=1.6.1
           SOURCE=$MODULE-$VERSION.tar.bz2
-   SOURCE_URL[0]=http://www.apache.org/dist/apr
+   SOURCE_URL[0]=http://dlcdn.apache.org/apr
    SOURCE_URL[1]=ftp://mirror2.dataphone.se/pub/apache/apr
    SOURCE_URL[2]=http://www.apache.org/dist/apr
       SOURCE_VFY=sha256:d3e12f7b6ad12687572a3a39475545a072608f4ba03a6ce8a3778f607dd0035b


### PR DESCRIPTION
The main site says:
`Do not download from www.apache.org. Please use a mirror site to help us save apache.org bandwidth.`
So use the CDN link instead.