### PR TITLE
docbook-utils: fix broken URL

### DIFF
--- a/doc-tools/docbook-utils/DETAILS
+++ b/doc-tools/docbook-utils/DETAILS
@@ -1,11 +1,11 @@
           MODULE=docbook-utils
          VERSION=0.6.14
           SOURCE=$MODULE-$VERSION.tar.gz
-      SOURCE_URL=ftp://sources.redhat.com/pub/docbook-tools/new-trials/SOURCES/
+      SOURCE_URL=https://sourceware.org/ftp/docbook-tools/new-trials/SOURCES
       SOURCE_VFY=sha256:48faab8ee8a7605c9342fb7b906e0815e3cee84a489182af38e8f7c0df2e92e9
         WEB_SITE=http://sources.redhat.com/docbook-tools/
          ENTERED=20040331
-         UPDATED=20200901
+         UPDATED=20220811
            SHORT="Tools to convert DocBook to various formats"
 
 cat << EOF


### PR DESCRIPTION
The URL from RedHat was broken, so use the URL that BLFS uses.