### PR TITLE
mtools: fix typo in UPDATED

### DIFF
--- a/filesys/mtools/DETAILS
+++ b/filesys/mtools/DETAILS
@@ -5,7 +5,7 @@
       SOURCE_VFY=sha256:a22fca42354011dd2293a7f51f228b46ebbd802e7740b0975912afecb79d5df4
         WEB_SITE=https://www.gnu.org/software/mtools/
          ENTERED=20010922
-         UPDATED=202204613
+         UPDATED=20220613
            SHORT="Utilities to access MS-DOS disks without mounting them"
 
 cat << EOF


### PR DESCRIPTION
This was causing mtools to always be candidate in the update list when running `lunar update`