### PR TITLE
gpm: remove annoying error message after login

### DIFF
--- a/utils/gpm/profile.d/gpm.rc
+++ b/utils/gpm/profile.d/gpm.rc
@@ -1,3 +1,3 @@
 case $( /usr/bin/tty ) in
-  /dev/tty[0-9]*) [ -n "$(pidof -s gpm)" ] && /usr/bin/disable-paste ;;
+  /dev/tty[0-9]*) [ -n "$(pidof -s gpm 2>/dev/null)" ] && /usr/bin/disable-paste ;;
 esac

--- a/utils/gpm/profile.d/gpm.rc
+++ b/utils/gpm/profile.d/gpm.rc
@@ -1,3 +1,3 @@
-case $( /usr/bin/tty ) in
+case $(/usr/bin/tty) in
   /dev/tty[0-9]*) [ -n "$(pidof -s gpm 2>/dev/null)" ] && /usr/bin/disable-paste ;;
 esac

--- a/utils/gpm/profile.d/gpm.rc
+++ b/utils/gpm/profile.d/gpm.rc
@@ -1,3 +1,3 @@
 case $(/usr/bin/tty) in
-  /dev/tty[0-9]*) [ -n "$(pidof -s gpm 2>/dev/null)" ] && /usr/bin/disable-paste ;;
+  /dev/tty[0-9]*) [ -n "$(pidof -s gpm &>/dev/null)" ] && /usr/bin/disable-paste ;;
 esac


### PR DESCRIPTION
When login in a tty the message "pidof: invalid session id: gpm" appears.
So redirect stderr to /dev/null.