### PR TITLE
fluxbox: fix pointer comparison to zero error

### DIFF
--- a/x11-wm/fluxbox/PRE_BUILD
+++ b/x11-wm/fluxbox/PRE_BUILD
@@ -1,0 +1,3 @@
+default_pre_build &&
+
+sedit 's/\(text_prop.value\) > 0/\1 != NULL/' util/fluxbox-remote.cc


### PR DESCRIPTION
The build was giving:
`util/fluxbox-remote.cc:76:32: error: ordered comparison of pointer with integer zero ('unsigned char*' and 'int')
   76 |             && text_prop.value > 0`
so introduce a fix for comparison with NULL instead.