### PR TITLE
Python-cryptography: moving it to moonbase-other

### DIFF
--- a/python/python-asn1crypto/DEPENDS
+++ b/python/python-asn1crypto/DEPENDS
@@ -1,0 +1,1 @@
+depends python-setuptools

--- a/python/python-asn1crypto/DETAILS
+++ b/python/python-asn1crypto/DETAILS
@@ -1,0 +1,15 @@
+          MODULE=python-asn1crypto
+         VERSION=1.5.1
+          SOURCE=asn1crypto-$VERSION.tar.gz
+      SOURCE_URL=https://pypi.python.org/packages/source/a/asn1crypto
+      SOURCE_VFY=sha256:13ae38502be632115abf8a24cbe5f4da52e3b5231990aff31123c805306ccb9c
+SOURCE_DIRECTORY=$BUILD_DIRECTORY/asn1crypto-$VERSION
+        WEB_SITE=https://pypi.org/project/asn1crypto/
+            TYPE=python3
+         ENTERED=20180806
+         UPDATED=20220528
+           SHORT="Python ASN.1 library with a focus on performance and a pythonic API"
+
+cat << EOF
+Python ASN.1 library with a focus on performance and a pythonic API.
+EOF

--- a/python/python-cffi/DEPENDS
+++ b/python/python-cffi/DEPENDS
@@ -1,0 +1,2 @@
+depends python-setuptools
+depends python-pycparser

--- a/python/python-cffi/DETAILS
+++ b/python/python-cffi/DETAILS
@@ -1,0 +1,16 @@
+          MODULE=python-cffi
+         VERSION=1.15.1
+          SOURCE=cffi-$VERSION.tar.gz
+      SOURCE_URL=https://files.pythonhosted.org/packages/2b/a8/050ab4f0c3d4c1b8aaa805f70e26e84d0e27004907c5b8ecc1d31815f92a/
+      SOURCE_VFY=sha256:d400bfb9a37b1351253cb402671cea7e89bdecc294e8016a707f6d1d8ac934f9
+SOURCE_DIRECTORY=$BUILD_DIRECTORY/cffi-$VERSION
+        WEB_SITE=http://cffi.readthedocs.org/
+         ENTERED=20150214
+         UPDATED=20220825
+            TYPE=python3
+        REPLACES=cffi
+           SHORT="Foreign Function Interface for Python calling C code"
+
+cat << EOF
+Foreign function interface for Python calling C code.
+EOF

--- a/python/python-idna/DEPENDS
+++ b/python/python-idna/DEPENDS
@@ -1,0 +1,1 @@
+depends python-setuptools

--- a/python/python-idna/DETAILS
+++ b/python/python-idna/DETAILS
@@ -1,0 +1,15 @@
+          MODULE=python-idna
+         VERSION=3.4
+          SOURCE=idna-$VERSION.tar.gz
+      SOURCE_URL=https://pypi.python.org/packages/source/i/idna
+      SOURCE_VFY=sha256:814f528e8dead7d329833b91c5faa87d60bf71824cd12a7530b5526063d02cb4
+SOURCE_DIRECTORY=$BUILD_DIRECTORY/idna-$VERSION
+        WEB_SITE=https://pypi.org/project/idna/
+            TYPE=python3
+         ENTERED=20180806
+         UPDATED=20221025
+           SHORT="Internationalized Domain Names in Applications (IDNA)"
+
+cat << EOF
+Internationalized Domain Names in Applications (IDNA).
+EOF

--- a/python/python-ply/DEPENDS
+++ b/python/python-ply/DEPENDS
@@ -1,0 +1,2 @@
+depends python
+depends python-setuptools

--- a/python/python-ply/DETAILS
+++ b/python/python-ply/DETAILS
@@ -1,0 +1,29 @@
+            MODULE=python-ply
+           VERSION=3.11
+            SOURCE=ply-$VERSION.tar.gz
+        SOURCE_URL=http://www.dabeaz.com/ply/
+        SOURCE_VFY=sha256:00c7c1aaa88358b9c765b6d3000c6eec0ba42abca5351b095321aef446081da3
+  SOURCE_DIRECTORY=$BUILD_DIRECTORY/ply-$VERSION
+          WEB_SITE=http://www.dabeaz.com/ply/
+           ENTERED=20140930
+           UPDATED=20180218
+              TYPE=python3
+          REPLACES=ply
+             SHORT="lex and yacc parsing tools for Python"
+
+cat << EOF
+PLY is an implementation of lex and yacc parsing tools for Python.
+In a nutshell, PLY is nothing more than a straightforward lex/yacc implementation.
+Here is a list of its essential features:
+ - It's implemented entirely in Python.
+ - It uses LR-parsing which is reasonably efficient and well suited for larger
+   grammars.
+ - PLY provides most of the standard lex/yacc features including support for
+   empty productions, precedence rules, error recovery, and support for
+   ambiguous grammars.
+ - PLY is straightforward to use and provides very extensive error checking.
+ - PLY doesn't try to do anything more or less than provide the basic lex/yacc
+   functionality.
+In other words, it's not a large parsing framework or a component of some
+larger system.
+EOF

--- a/python/python-pyasn1/DEPENDS
+++ b/python/python-pyasn1/DEPENDS
@@ -1,0 +1,1 @@
+depends python-setuptools

--- a/python/python-pyasn1/DETAILS
+++ b/python/python-pyasn1/DETAILS
@@ -1,0 +1,18 @@
+          MODULE=python-pyasn1
+         VERSION=0.4.8
+          SOURCE=pyasn1-$VERSION.tar.gz
+      SOURCE_URL=https://pypi.io/packages/source/p/pyasn1/
+SOURCE_DIRECTORY=$BUILD_DIRECTORY/pyasn1-$VERSION
+      SOURCE_VFY=sha256:aef77c9fb94a3ac588e87841208bdec464471d9871bd5050a287cc9a475cd0ba
+        WEB_SITE=http://sourceforge.net/projects/pyasn1/
+         ENTERED=20160723
+         UPDATED=20191124
+            TYPE=python3
+        REPLACES=pyasn1
+           SHORT="ASN.1 library for Python"
+
+cat << EOF
+ASN.1 types and codecs (BER, CER, DER) implementation in Python.
+A collection of various ASN.1-based protocols data structures is supplied in a
+dedicated Python package.
+EOF

--- a/python/python-pycparser/DEPENDS
+++ b/python/python-pycparser/DEPENDS
@@ -1,0 +1,2 @@
+depends python-setuptools
+depends python-ply

--- a/python/python-pycparser/DETAILS
+++ b/python/python-pycparser/DETAILS
@@ -1,0 +1,16 @@
+          MODULE=python-pycparser
+         VERSION=2.21
+          SOURCE=pycparser-$VERSION.tar.gz
+ SOURCE_URL_FULL=http://github.com/eliben/pycparser/archive/release_v$VERSION.tar.gz
+SOURCE_DIRECTORY=$BUILD_DIRECTORY/pycparser-release_v$VERSION
+      SOURCE_VFY=sha256:3c797eb2eb1ba57772bb99ffa7caed23c3a2c2ae58daef114c9b09d3a6da97e2
+        WEB_SITE=http://github.com/eliben/pycparser/
+            TYPE=python3
+         ENTERED=20150214
+         UPDATED=20211204
+        REPLACES=pycparser
+           SHORT="C parser and AST generator written in Python"
+
+cat << EOF
+C parser and AST generator written in Python
+EOF


### PR DESCRIPTION
It's only "needed" for one function used in one module in core (ca-certificates) and that module doesn't even do anything with what it uses python-cryptography for, so to make life simpler, I just removed the requirement for python-cryptography to be in core.

This is python-cryptography from core, and all of its dependencies.