### PR TITLE
php: version bumped to 8.1.12

### DIFF
--- a/compilers/php/DEPENDS
+++ b/compilers/php/DEPENDS
@@ -5,6 +5,10 @@ depends enchant
 depends libzip
 depends icu4c
 
+optional_depends libsodium \
+                "--with-sodium=shared" "--without-sodium" \
+                "for support with libsodium"
+
 optional_depends gettext \
                  "--with-gettext=shared" "" \
                  "for GNU gettext support"

--- a/compilers/php/DETAILS
+++ b/compilers/php/DETAILS
@@ -1,11 +1,11 @@
           MODULE=php
-         VERSION=8.1.11
+         VERSION=8.1.12
           SOURCE=php-$VERSION.tar.xz
       SOURCE_URL=http://php.net/distributions/
-      SOURCE_VFY=sha256:3005198d7303f87ab31bc30695de76e8ad62783f806b6ab9744da59fe41cc5bd
+      SOURCE_VFY=sha256:08243359e2204d842082269eedc15f08d2eca726d0e65b93fb11f4bfc51bbbab
         WEB_SITE=http://www.php.net
          ENTERED=20040919
-         UPDATED=20221010
+         UPDATED=20221030
            SHORT="PHP: Hypertext Processor scripting language"
 
 cat << EOF


### PR DESCRIPTION
Fixes CVE-2022-31630 and CVE-2022-37454
https://www.php.net/ChangeLog-8.php#8.1.12