### PR TITLE
postfix: Bump to 3.7.4

### DIFF
--- a/mail/postfix/DETAILS
+++ b/mail/postfix/DETAILS
@@ -1,12 +1,12 @@
           MODULE=postfix
-         VERSION=3.7.2
+         VERSION=3.7.4
           SOURCE=$MODULE-$VERSION.tar.gz
    SOURCE_URL[0]=https://de.postfix.org/ftpmirror/official/
    SOURCE_URL[1]=ftp://ftp.porcupine.org/mirrors/postfix-release/official/
-      SOURCE_VFY=sha256:3785f76c2924a02873c0be0f0cd124a9166fc1aaf77ea2a06bd4ad795a6ed416
+      SOURCE_VFY=sha256:4c137a2303448f25993836837deeae87fac5d4d03af11ade8e9bead806328645
         WEB_SITE=http://www.postfix.org/
          ENTERED=20020125
-         UPDATED=20220606
+         UPDATED=20230205
            SHORT="A fast and secure drop-in replacement for sendmail"
 
 cat << EOF


### PR DESCRIPTION
Note that postfix-3.7.2 seems to have been deleted from postfix.org. I wonder what was wrong with it.