### PR TITLE
mutt: change mime-types dependency to media-types

### DIFF
--- a/mail/mutt/DEPENDS
+++ b/mail/mutt/DEPENDS
@@ -1,5 +1,5 @@
 depends ncurses
-depends mime-types
+depends media-types
 
 optional_depends %OSSL   "--with-ssl"     "--without-ssl"     "for SSL support with pop/imap"
 optional_depends gnutls  "--with-gnutls"  "--without-gnutls"  "for TLS support"


### PR DESCRIPTION
I wonder if we can do some sort of automated monitoring for modules that depend on stuff that's been cratered