### PR TITLE
zfs, zfs-utils: Bump to 2.1.9

### DIFF
--- a/filesys/zfs-utils/DETAILS
+++ b/filesys/zfs-utils/DETAILS
@@ -1,14 +1,14 @@
           MODULE=zfs-utils
-         VERSION=2.1.7
+         VERSION=2.1.9
           SOURCE=zfs-$VERSION.tar.gz
 SOURCE_DIRECTORY=$BUILD_DIRECTORY/zfs-$VERSION
       SOURCE_URL=https://github.com/openzfs/zfs/releases/download/zfs-$VERSION/
-      SOURCE_VFY=sha256:6462e63e185de6ff10c64ffa6ed773201a082f9dd13e603d7e8136fcb4aca71b
+      SOURCE_VFY=sha256:6b172cdf2eb54e17fcd68f900fab33c1430c5c59848fa46fab83614922fe50f6
       MAINTAINER=ratler@lunar-linux.org
         WEB_SITE=http://zfsonlinux.org/
          LICENSE=cddl
          ENTERED=20130212
-         UPDATED=20230107
+         UPDATED=20230210
            SHORT="The ZFS file system utilities"
 
 cat << EOF

--- a/filesys/zfs/DETAILS
+++ b/filesys/zfs/DETAILS
@@ -1,13 +1,13 @@
           MODULE=zfs
-         VERSION=2.1.7
+         VERSION=2.1.9
           SOURCE=$MODULE-$VERSION.tar.gz
       SOURCE_URL=https://github.com/openzfs/zfs/releases/download/zfs-$VERSION/
-      SOURCE_VFY=sha256:6462e63e185de6ff10c64ffa6ed773201a082f9dd13e603d7e8136fcb4aca71b
+      SOURCE_VFY=sha256:6b172cdf2eb54e17fcd68f900fab33c1430c5c59848fa46fab83614922fe50f6
         WEB_SITE=http://zfsonlinux.org/
       MAINTAINER=ratler@lunar-linux.org
          LICENSE=cddl
          ENTERED=20130212
-         UPDATED=20230107
+         UPDATED=20230210
            SHORT="The ZFS file system"
 
 cat << EOF


### PR DESCRIPTION
Includes support for Linux 6.1, grep 3.8