### PR TITLE
net-tools: Fix long description

### DIFF
--- a/net/net-tools/DETAILS
+++ b/net/net-tools/DETAILS
@@ -11,15 +11,7 @@
            LUNAR_RESTART_SERVICES=off
 
 cat << EOF
-The Net-tools package contains the arp, hostname, ifconfig, netstat,
-plipconfig rarp, route, and slattach programs.
-
-arp is used to manipulate the kernel's ARP cache, usually to add or
-delete an entry, or to dump the ARP cache.
-
-hostname, with its symlinks domainname, dnsdomainname, nisdomainname,
-ypdomainname, and nodename, is used to set or show the system's hostname
-(or other, depending on the symlink used).
+The Net-tools package contains the ifconfig, netstat, and route programs.
 
 The ifconfig command is the general command used to configure network
 interfaces.
@@ -28,14 +20,6 @@ netstat is a multi-purpose tool used to print the network connections,
 routing tables, interface statistics, masquerade connections, and
 multicast memberships.
 
-plipconfig is used to fine-tune the PLIP device parameters, hopefully
-making it faster.
-
-rarp, akin to the arp program, manipulates the system's RARP table.
-
 route is the general utility which is used to manipulate the IP routing
 table.
-
-slattach attaches a network interface to a serial line, i.e.. puts a
-normal terminal line into one of several "network" modes.
 EOF


### PR DESCRIPTION
The long description mentioned an awful lot of programs which are obsolete, replaced by some other package, or simply not part of net-tools any more.