### PR TITLE
httpd: version bumped to 2.4.56

### DIFF
--- a/web/httpd/BUILD
+++ b/web/httpd/BUILD
@@ -16,7 +16,7 @@ OPTS=" --datadir=/srv/http              \
        --enable-layout=GNU              \
        --enable-layout=Lunar            \
        --enable-exception-hook          \
-	   --with-mpm=event                 \
+       --with-mpm=event                 \
        --with-apr=/usr/bin/apr-1-config \
        --with-apr-util=/usr/bin/apu-1-config" &&
 

--- a/web/httpd/DETAILS
+++ b/web/httpd/DETAILS
@@ -1,11 +1,11 @@
           MODULE=httpd
-         VERSION=2.4.55
+         VERSION=2.4.56
           SOURCE=$MODULE-$VERSION.tar.bz2
       SOURCE_URL=http://dlcdn.apache.org/httpd/
-      SOURCE_VFY=sha256:11d6ba19e36c0b93ca62e47e6ffc2d2f2884942694bce0f23f39c71bdc5f69ac
+      SOURCE_VFY=sha256:d8d45f1398ba84edd05bb33ca7593ac2989b17cb9c7a0cafe5442d41afdb2d7c
         WEB_SITE=http://www.apache.org
          ENTERED=20020710
-         UPDATED=20230119
+         UPDATED=20230309
            SHORT="A popular HTTP server"
 
 cat << EOF


### PR DESCRIPTION
Fixes CVE-2023-27522 and CVE-2023-25690 amongst other fixes.
https://dlcdn.apache.org/httpd/CHANGES_2.4.56