### PR TITLE
rustc: Fix broken build when MAKES isn't set

### DIFF
--- a/compilers/rustc/BUILD
+++ b/compilers/rustc/BUILD
@@ -21,8 +21,8 @@ sedit '416i codegen-units-std = 1' config.toml &&
 # disable docs because it broke the build
 sedit 's|#docs = true|docs = false|' config.toml &&
 
-CARGO_BUILD_JOBS="${MAKES}"
-python3 ./x.py build --exclude miri --jobs ${MAKES} &&
+CARGO_BUILD_JOBS="${MAKES:-1}"
+python3 ./x.py build --exclude miri --jobs $CARGO_BUILD_JOBS &&
 make ${MAKES:+-j$MAKES} &&
 
 prepare_install &&


### PR DESCRIPTION
Default to 1 build at a time if MAKES isn't set to some other value, just like how the rest of the system works.