### PR TITLE
camlp4: Bump to 5.0.0+1. Yes its still in 4.x but adjusted to compile

### DIFF
--- a/compilers/camlp4/BUILD
+++ b/compilers/camlp4/BUILD
@@ -1,2 +1,8 @@
- ./configure $OPTS &&
- default_make
+CFLAGS+=' -ffat-lto-objects -w'
+
+./configure --bindir=/usr/bin --libdir=/usr/lib/ocaml --pkgdir=/usr/lib/ocaml &&
+
+make all camlp4/META &&
+prepare_install &&
+
+make BINDIR=/usr/bin LIBDIR=/usr/lib/ocaml PKGDIR=/usr/lib/ocaml install-META

--- a/compilers/camlp4/DEPENDS
+++ b/compilers/camlp4/DEPENDS
@@ -1,2 +1,4 @@
 depends ocaml
+depends camlp-streams
+depends findlib
 depends ocamlbuild

--- a/compilers/camlp4/DETAILS
+++ b/compilers/camlp4/DETAILS
@@ -1,13 +1,15 @@
           MODULE=camlp4
-         VERSION=4.14+1
+         VERSION=5.0.0+1
+  _ocaml5_commit=862936ff67fe01f8e2e35e667e4a7f2990ebc300
           SOURCE=$MODULE-$VERSION.tar.gz
- SOURCE_URL_FULL=https://github.com/ocaml/camlp4/archive/$VERSION.tar.gz
-      SOURCE_VFY=sha256:553b6805dffc05eb4749b0293df47a18b82b9d9dcc125d688e55f13cbec0b93a
-SOURCE_DIRECTORY=$BUILD_DIRECTORY/$MODULE-${VERSION/+/-}
+ SOURCE_URL_FULL=https://github.com/ocaml/camlp4/archive/862936ff67fe01f8e2e35e667e4a7f2990ebc300.tar.gz
+      SOURCE_VFY=sha256:02e5147b05c8c70b910e8b4deb59a34e60fc7b77f4ddee97545363b60a550a57
+SOURCE_DIRECTORY=$BUILD_DIRECTORY/$MODULE-862936ff67fe01f8e2e35e667e4a7f2990ebc300
         WEB_SITE=https://github.com/ocaml/camlp4
          ENTERED=20141029
-         UPDATED=20220328
+         UPDATED=20230624
            SHORT="Camlp4 is a preprocessor-pretty-printer of OCaml."
+PSAFE=no
 cat << EOF
 Camlp4 is a preprocessor-pretty-printer of OCaml that lives
 independently from (and is incompatible with) the Camlp5 project.


### PR DESCRIPTION
with the current ocaml 5.x.