### PR TITLE
Go - bump to 1.20.5 (and add second bootstrap)

### DIFF
--- a/compilers/go-bootstrap2/BUILD
+++ b/compilers/go-bootstrap2/BUILD
@@ -1,0 +1,50 @@
+export GOOS=linux
+export GOROOT=$SOURCE_DIRECTORY
+export GOBIN=$GOROOT/bin
+export GOROOT_FINAL=/usr/lib/go1.19
+export GOPATH=$BUILD_DIRECTORY
+
+if module_installed go; then
+  export GOROOT_BOOTSTRAP=/usr/lib/go
+else
+  export GOROOT_BOOTSTRAP=/usr/lib/go1.4
+fi &&
+
+case "$(arch)" in
+  x86_64) export GOARCH=amd64 ;;
+  i686)   export GOARCH=386 ;;
+esac &&
+
+cd src &&
+./make.bash --no-clean -v &&
+
+PATH="$GOBIN:$PATH" go install -v -buildmode=shared std &&
+case "$GOARCH" in
+  amd64) PATH="$GOBIN:$PATH" go install -v -race std ;;
+  386)   PATH="$GOBIN:$PATH" go install -v       std ;;
+esac &&
+
+prepare_install &&
+
+cd $SOURCE_DIRECTORY &&
+
+mkdir -p $GOROOT_FINAL &&
+cp -a bin pkg src lib misc api test $GOROOT_FINAL &&
+install -Dm644 VERSION $GOROOT_FINAL/VERSION &&
+
+rm -rf $GOROOT_FINAL/pkg/bootstrap $GOROOT_FINAL/pkg/tool/*/api &&
+
+# TODO: Figure out if really needed
+rm -rf $GOROOT_FINAL/pkg/obj/go-build/* &&
+
+# Remove object files from target src dir
+find $GOROOT_FINAL/src/ -type f -name '*.[ao]' -delete &&
+
+# Remove all executable source files
+find $GOROOT_FINAL/src -type f -executable -delete &&
+
+# For gox
+install -Dm755 src/make.bash $GOROOT_FINAL/src/make.bash &&
+install -Dm755 src/run.bash $GOROOT_FINAL/src/run.bash &&
+
+find $GOROOT_FINAL/pkg -type f -exec touch '{}' +

--- a/compilers/go-bootstrap2/CONFIGURE
+++ b/compilers/go-bootstrap2/CONFIGURE
@@ -1,0 +1,2 @@
+mquery RUN_TESTS "Run tests for the go compiler and tools to make sure everything is ok before installing?" y
+mquery GO_PIE "Do you want to install go with PIE enabled by default (experimental)?" n

--- a/compilers/go-bootstrap2/DEPENDS
+++ b/compilers/go-bootstrap2/DEPENDS
@@ -1,0 +1,3 @@
+optional_depends mercurial  "" "" "for mercurial repositories support" "n"
+optional_depends subversion "" "" "for subversion repositories support" "n"
+optional_depends bzr        "" "" "for bzr repositories support" "n"

--- a/compilers/go-bootstrap2/DETAILS
+++ b/compilers/go-bootstrap2/DETAILS
@@ -1,0 +1,18 @@
+          MODULE=go-bootstrap2
+         VERSION=1.19.5
+          SOURCE=go$VERSION.src.tar.gz
+         #SOURCE2=go-default_build_pie.patch
++SOURCE_DIRECTORY=$BUILD_DIRECTORY/go
+   SOURCE_URL[0]=https://dl.google.com/go/
+   SOURCE_URL[1]=https://go.dev/dl/
+       #SOURCE2_URL=$PATCH_URL
+      SOURCE_VFY=sha256:8e486e8e85a281fc5ce3f0bedc5b9d2dbf6276d7db0b25d3ec034f313da0375f
+     #SOURCE2_VFY=sha256:be1269689de3cf5c926cf7de07f88d2a6d1ecbfc86694baaf5baee3bdcfdd79a
+        WEB_SITE=http://golang.org/
+         ENTERED=20140606
+         UPDATED=20230308
+           SHORT="Compiler and tools for the Go programming language from Google"
+
+cat << EOF
+Compiler and tools for the Go programming language from Google.
+EOF

--- a/compilers/go-bootstrap2/POST_INSTALL
+++ b/compilers/go-bootstrap2/POST_INSTALL
@@ -1,0 +1,8 @@
+rm -fR /usr/src/src
+
+# Fix timestamps in order to stop go from rebuilding lots of packages
+find /usr/lib/go -type f -exec touch -r /usr/lib/go/pkg/*/runtime.a {} \;
+
+if module_installed go-bootstrap; then
+  lrm go-bootstrap
+fi

--- a/compilers/go-bootstrap2/PRE_BUILD
+++ b/compilers/go-bootstrap2/PRE_BUILD
@@ -1,0 +1,15 @@
+# if go is already installed we'll use it for the bootstrap
+if ! ( ( module_installed go ) || (module_installed go-bootstrap) ); then
+  # install a minimal go compiler for the bootstrap
+  lin go-bootstrap
+fi &&
+
+default_pre_build &&
+
+# Fix path for test suite
+sedit "s;/bin/hostname;/usr&;g" src/os/os_test.go &&
+
+# Build a PIE enabled version?
+if [[ "$GO_PIE" = "y" ]]; then
+   patch_it $SOURCE2 1
+fi

--- a/compilers/go/BUILD
+++ b/compilers/go/BUILD
@@ -16,7 +16,8 @@ case "$(arch)" in
 esac &&
 
 cd src &&
-./make.bash --no-clean -v &&
+#--no-clean is deprecated and has no effect
+./make.bash -v &&
 
 PATH="$GOBIN:$PATH" go install -v -buildmode=shared std &&
 case "$GOARCH" in

--- a/compilers/go/BUILD
+++ b/compilers/go/BUILD
@@ -6,8 +6,8 @@ export GOPATH=$BUILD_DIRECTORY
 
 if module_installed go; then
   export GOROOT_BOOTSTRAP=/usr/lib/go
-else
-  export GOROOT_BOOTSTRAP=/usr/lib/go1.4
+#else
+#  export GOROOT_BOOTSTRAP=/usr/lib/go1.4
 fi &&
 
 case "$(arch)" in

--- a/compilers/go/BUILD
+++ b/compilers/go/BUILD
@@ -5,9 +5,9 @@ export GOROOT_FINAL=/usr/lib/go
 export GOPATH=$BUILD_DIRECTORY
 
 if module_installed go; then
-  export GOROOT_BOOTSTRAP=/usr/lib/go
-#else
-#  export GOROOT_BOOTSTRAP=/usr/lib/go1.4
+  export GOROOT_BOOTSTRAP=$GOROOT_FINAL
+else
+  export GOROOT_BOOTSTRAP=/usr/lib/go1.19
 fi &&
 
 case "$(arch)" in
@@ -29,36 +29,36 @@ prepare_install &&
 
 cd $SOURCE_DIRECTORY &&
 
-mkdir -p /usr/lib/go &&
-cp -a bin pkg src lib misc api test /usr/lib/go/ &&
-install -Dm644 VERSION /usr/lib/go/VERSION &&
+mkdir -p $GOROOT_FINAL &&
+cp -a bin pkg src lib misc api test $GOROOT_FINAL/ &&
+install -Dm644 VERSION $GOROOT_FINAL/VERSION &&
 
 mkdir -p /usr/share/doc/go &&
 cp -r doc/* /usr/share/doc/go/ &&
 
-ln -sf /usr/share/doc/go /usr/lib/go/doc &&
+ln -sf /usr/share/doc/go $GOROOT_FINAL/doc &&
 # add the symlinks to /usr/bin
-for f in /usr/lib/go/bin/*; do
+for f in $GOROOT_FINAL/bin/*; do
    ln -sf $f /usr/bin/
 done &&
 
-rm -rf /usr/lib/go/pkg/bootstrap /usr/lib/go/pkg/tool/*/api &&
+rm -rf $GOROOT_FINAL/pkg/bootstrap $GOROOT_FINAL/pkg/tool/*/api &&
 
 # TODO: Figure out if really needed
-rm -rf /usr/lib/go/pkg/obj/go-build/* &&
+rm -rf $GOROOT_FINAL/pkg/obj/go-build/* &&
 
 # Remove object files from target src dir
-find /usr/lib/go/src/ -type f -name '*.[ao]' -delete &&
+find $GOROOT_FINAL/src/ -type f -name '*.[ao]' -delete &&
 
 # Remove all executable source files
-find /usr/lib/go/src -type f -executable -delete &&
+find $GOROOT_FINAL/src -type f -executable -delete &&
 
 # For gox
-install -Dm755 src/make.bash /usr/lib/go/src/make.bash &&
-install -Dm755 src/run.bash /usr/lib/go/src/run.bash &&
+install -Dm755 src/make.bash $GOROOT_FINAL/src/make.bash &&
+install -Dm755 src/run.bash $GOROOT_FINAL/src/run.bash &&
 
 # For godoc
-#install -Dm644 favicon.ico /usr/lib/go/favicon.ico &&
+#install -Dm644 favicon.ico $GOROOT_FINAL/favicon.ico &&
 rm -f /usr/share/go/doc/articles/wiki/get.bin &&
 
-find /usr/lib/go/pkg -type f -exec touch '{}' +
+find $GOROOT_FINAL/pkg -type f -exec touch '{}' +

--- a/compilers/go/DEPENDS
+++ b/compilers/go/DEPENDS
@@ -1,3 +1,5 @@
+depends git
+
 optional_depends mercurial  "" "" "for mercurial repositories support" "n"
 optional_depends subversion "" "" "for subversion repositories support" "n"
 optional_depends bzr        "" "" "for bzr repositories support" "n"

--- a/compilers/go/DETAILS
+++ b/compilers/go/DETAILS
@@ -7,7 +7,7 @@
 SOURCE_DIRECTORY=$BUILD_DIRECTORY/$MODULE
         WEB_SITE=http://golang.org/
          ENTERED=20140606
-         UPDATED=20230702
+         UPDATED=20230708
            SHORT="Compiler and tools for the Go programming language from Google"
 
 cat << EOF

--- a/compilers/go/DETAILS
+++ b/compilers/go/DETAILS
@@ -1,16 +1,13 @@
           MODULE=go
-         VERSION=1.19.5
+         VERSION=1.20.5
           SOURCE=${MODULE}$VERSION.src.tar.gz
-         #SOURCE2=go-default_build_pie.patch
-SOURCE_DIRECTORY=$BUILD_DIRECTORY/$MODULE
    SOURCE_URL[0]=https://dl.google.com/go/
    SOURCE_URL[1]=https://go.dev/dl/
-       #SOURCE2_URL=$PATCH_URL
-      SOURCE_VFY=sha256:8e486e8e85a281fc5ce3f0bedc5b9d2dbf6276d7db0b25d3ec034f313da0375f
-     #SOURCE2_VFY=sha256:be1269689de3cf5c926cf7de07f88d2a6d1ecbfc86694baaf5baee3bdcfdd79a
+      SOURCE_VFY=sha256:9a15c133ba2cfafe79652f4815b62e7cfc267f68df1b9454c6ab2a3ca8b96a88
+SOURCE_DIRECTORY=$BUILD_DIRECTORY/$MODULE
         WEB_SITE=http://golang.org/
          ENTERED=20140606
-         UPDATED=20230308
+         UPDATED=20230702
            SHORT="Compiler and tools for the Go programming language from Google"
 
 cat << EOF

--- a/compilers/go/POST_INSTALL
+++ b/compilers/go/POST_INSTALL
@@ -3,6 +3,6 @@ rm -fR /usr/src/src
 # Fix timestamps in order to stop go from rebuilding lots of packages
 find /usr/lib/go -type f -exec touch -r /usr/lib/go/pkg/*/runtime.a {} \;
 
-if module_installed go-bootstrap; then
-  lrm go-bootstrap
+if module_installed go-bootstrap2; then
+  lrm go-bootstrap2
 fi

--- a/compilers/go/PRE_BUILD
+++ b/compilers/go/PRE_BUILD
@@ -1,7 +1,7 @@
 # if go is already installed we'll use it for the bootstrap
 if ! ( ( module_installed go ) || (module_installed go-bootstrap) ); then
-  # install a minimal go compiler for the bootstrap
-  lin go-bootstrap
+  # install a previous go compiler for the bootstrap
+  lin go-bootstrap2
 fi &&
 
 default_pre_build &&

--- a/compilers/go/PRE_BUILD
+++ b/compilers/go/PRE_BUILD
@@ -1,5 +1,5 @@
 # if go is already installed we'll use it for the bootstrap
-if ! ( ( module_installed go ) || (module_installed go-bootstrap) ); then
+if ! ( ( module_installed go ) || (module_installed go-bootstrap2) ); then
   # install a previous go compiler for the bootstrap
   lin go-bootstrap2
 fi &&


### PR DESCRIPTION
This expands _greatly_ on #2346--going from nothing to go 1.20.5 requires a boot strap from C to Go 1.4, and then yet another bootstrap from Go 1.4 to Go 1.19. So this PR adds that second bootstrap.