### PR TITLE
python-attrs: Bump to 23.1.0. Requires a BUILD for their new way of

### DIFF
--- a/python/python-attrs/BUILD
+++ b/python/python-attrs/BUILD
@@ -1,0 +1,5 @@
+export PYTHONDONTWRITEBYTECODE=1 &&
+python -m build --wheel &&
+
+prepare_install &&
+python -m installer --destdir=/ dist/*.whl

--- a/python/python-attrs/DEPENDS
+++ b/python/python-attrs/DEPENDS
@@ -1,3 +1,2 @@
-depends python-hatchling
 depends python-pluggy
 depends python-editables

--- a/python/python-attrs/DEPENDS
+++ b/python/python-attrs/DEPENDS
@@ -1,1 +1,1 @@
-depends python-setuptools
+depends python-hatchling

--- a/python/python-attrs/DEPENDS
+++ b/python/python-attrs/DEPENDS
@@ -1,1 +1,3 @@
 depends python-hatchling
+depends python-pluggy
+depends python-editables

--- a/python/python-attrs/DETAILS
+++ b/python/python-attrs/DETAILS
@@ -1,14 +1,13 @@
           MODULE=python-attrs
-         VERSION=22.1.0
+         VERSION=23.1.0
           SOURCE=attrs-$VERSION.tar.gz
       SOURCE_URL=https://pypi.io/packages/source/a/attrs/
-      SOURCE_VFY=sha256:29adc2665447e5191d0e7c568fde78b21f9672d344281d0c6e1ab085429b22b6
+      SOURCE_VFY=sha256:6279836d581513a26f1bf235f9acd333bc9115683f14f7e8fae46c98fc50e015
 SOURCE_DIRECTORY=$BUILD_DIRECTORY/attrs-$VERSION
         WEB_SITE=https://attrs.readthedocs.org/
-            TYPE=python3
         REPLACES=cycler
          ENTERED=20180901
-         UPDATED=20220824
+         UPDATED=2023026
            SHORT="Attributes without boilerplate"
 
 cat << EOF

--- a/python/python-attrs/POST_INSTALL
+++ b/python/python-attrs/POST_INSTALL
@@ -1,0 +1,1 @@
+lunar fix python python-installer


### PR DESCRIPTION
installing, and a POST_INSTALL cause of byte compiling.