### PR TITLE
openttd: unpack game files in POST_INSTALL

### DIFF
--- a/games/openttd/INSTALL
+++ b/games/openttd/INSTALL
@@ -1,8 +1,0 @@
-prepare_install &&
-
-{ [ -d /usr/share/games/openttd/baseset ] || 
-    mkdir -p /usr/share/games/openttd/baseset; } &&
-cd /usr/share/games/openttd/baseset/ &&
-unpack $SOURCE2 &&
-unpack $SOURCE3 &&
-unpack $SOURCE4

--- a/games/openttd/POST_INSTALL
+++ b/games/openttd/POST_INSTALL
@@ -1,0 +1,7 @@
+if [ ! -d /usr/share/games/openttd/baseset ]; then
+    mkdir -p /usr/share/games/openttd/baseset
+fi
+cd /usr/share/games/openttd/baseset/ &&
+unpack $SOURCE2 &&
+unpack $SOURCE3 &&
+unpack $SOURCE4

--- a/games/openttd/POST_REMOVE
+++ b/games/openttd/POST_REMOVE
@@ -1,0 +1,2 @@
+# Get rid of the game files leftover from the POST_INSTALL
+rm -rf /usr/share/games/openttd


### PR DESCRIPTION
Lately the INSTALL file doesn't unpack the game files anymore.
It seems to work if I put the ops in POST_INSTALL though.