### PR TITLE
openttd: move unpack ops into BUILD

### DIFF
--- a/games/openttd/BUILD
+++ b/games/openttd/BUILD
@@ -1,1 +1,13 @@
-default_cmake_build
+default_cmake_build &&
+
+prepare_install &&
+
+make install &&
+
+if [ ! -d /usr/share/games/openttd/baseset ]; then
+    mkdir -p /usr/share/games/openttd/baseset
+fi &&
+cd /usr/share/games/openttd/baseset/ &&
+unpack $SOURCE2 &&
+unpack $SOURCE3 &&
+unpack $SOURCE4

--- a/games/openttd/DEPENDS
+++ b/games/openttd/DEPENDS
@@ -4,3 +4,4 @@ depends zlib
 depends libpng
 depends freetype2
 depends fontconfig
+depends unzip

--- a/games/openttd/INSTALL
+++ b/games/openttd/INSTALL
@@ -1,8 +1,0 @@
-prepare_install &&
-
-{ [ -d /usr/share/games/openttd/baseset ] || 
-    mkdir -p /usr/share/games/openttd/baseset; } &&
-cd /usr/share/games/openttd/baseset/ &&
-unpack $SOURCE2 &&
-unpack $SOURCE3 &&
-unpack $SOURCE4


### PR DESCRIPTION
Strangely the unpacking of the game files seem to be ignored if put in INSTALL, so move everything in BUILD.
Note that an attempt was made to put the unpack calls in POST_INSTALL, and it works, but installwatch doesn't track those at this point and it was breaking resurrection of the module. Now it works :)