### PR TITLE
chrono: version bumped to 0.2.44

### DIFF
--- a/utils/chrono/DETAILS
+++ b/utils/chrono/DETAILS
@@ -1,16 +1,17 @@
           MODULE=chrono
-         VERSION=0.2.43
-          SOURCE=$MODULE-$VERSION.tar.gz
-SOURCE_DIRECTORY=$BUILD_DIRECTORY/$MODULE-$MODULE-$VERSION
-      SOURCE_URL=https://github.com/esselfe/chrono/archive
-      SOURCE_VFY=sha256:8331242dd23f998c028dee2d652b285c63e2509526c24dbffdc805db4f782d1f
-        WEB_SITE=https://github.com/esselfe
+         VERSION=0.2.44
+          SOURCE=$MODULE-$VERSION.tar.xz
+SOURCE_DIRECTORY=$BUILD_DIRECTORY/$MODULE-$VERSION
+      SOURCE_URL=https://github.com/esselfe/$MODULE/releases/download/$MODULE-$VERSION
+      SOURCE_VFY=sha256:54c3f600ed4ef7f57e3c19eaf1c98c4630906906963ae279a294e224c729149a
+        WEB_SITE=https://github.com/esselfe/$MODULE
          ENTERED=20190618
-         UPDATED=20220620
+         UPDATED=20230827
            SHORT="A ncurses/X11 based chronometer"
 
 cat << EOF
 chrono is a ncurses-based and/or X11-based chronometer with millisecond
 precision, seconds, minutes, hours, days, months, years, pause, repeatable
-countdown and reset functions.
+countdown, beep and reset functions. It can also execute shell commands once
+the countdown reaches zero.
 EOF


### PR DESCRIPTION
- Fixes build error on systems where ncurses.h is not in /usr/include/ncursesw/.