### PR TITLE
weechat: version 4.0.4 + allow incomplete docs

### DIFF
--- a/chat/weechat/BUILD
+++ b/chat/weechat/BUILD
@@ -1,4 +1,5 @@
 OPTS+=" -DENABLE_PHP=OFF \
-        -DENABLE_JAVASCRIPT=OFF"
+        -DENABLE_JAVASCRIPT=OFF \
+        -DENABLE_DOC_INCOMPLETE=ON"
 
 default_cmake_build

--- a/chat/weechat/DEPENDS
+++ b/chat/weechat/DEPENDS
@@ -51,9 +51,3 @@ optional_depends tcl \
                  "-DENABLE_TCL=OFF" \
                  "to compile the tcl plugin" \
                  "n"
-
-optional_depends php \
-                 "-DENABLE_PHP=ON" \
-                 "-DENABLE_PHP=OFF" \
-                 "to compile the PHP plugin" \
-                 "n"

--- a/chat/weechat/DETAILS
+++ b/chat/weechat/DETAILS
@@ -1,11 +1,11 @@
           MODULE=weechat
-         VERSION=4.0.2
+         VERSION=4.0.4
           SOURCE=$MODULE-$VERSION.tar.xz
-      SOURCE_URL=http://www.weechat.org/files/src
-      SOURCE_VFY=sha256:0e648ee0d024c8099425ee60d41b272924ec8e19800ee8f1441090708834023c
+      SOURCE_URL=https://www.weechat.org/files/src
+      SOURCE_VFY=sha256:ae5f4979b5ada0339b84e741d5f7e481ee91e3fecd40a09907b64751829eb6f6
         WEB_SITE=https://www.weechat.org/
          ENTERED=20050223
-         UPDATED=20230726
+         UPDATED=20230828
            SHORT="A very light and neat IRC client"
 
 cat << EOF


### PR DESCRIPTION
Now there's this message showing up when configuring:

[...]
CMake Error at CMakeLists.txt:154 (message):
   All plugins are required to build documentation.
   If you really want to build incomplete docs, enable this option:
     -DENABLE_DOC_INCOMPLETE=ON