### PR TITLE
qemu: fix build error with missing libfdt.a

### DIFF
--- a/virtual/qemu/BUILD
+++ b/virtual/qemu/BUILD
@@ -18,6 +18,7 @@ OPTS+=" --sbindir=/usr/bin"
             --localstatedir=/var \
             --audio-drv-list="$AUDIO_LIST" \
             --enable-attr \
+            --enable-fdt=internal \
             --enable-modules \
             --enable-vhost-net \
             $OPTS &&


### PR DESCRIPTION
By default qemu configures with the system fdt, so use the internal one instead.

I was getting:

[...]
    RDMA support                                 : NO
    PVRDMA support                               : NO
    fdt support                                  : system
    libcap-ng support                            : YES
    bpf support                                  : NO
[...]
\+ saving library "/usr/lib/qemu/ui-opengl.so"
\+ saving library "/usr/lib/qemu/ui-sdl.so"
\+ calling "lrm --upgrade qemu"
\+ updating lunar state files after module removal
Removed module: qemu
changing dir to build for /usr/bin/make "install"...
make[1]: Entering directory '/usr/src/qemu-8.1.0/build'
ninja: error: '/usr/lib/libfdt.a', needed by 'qemu-system-aarch64', missing and no known rule to make it
make[1]: *** [Makefile:162: run-ninja] Error 1
make[1]: Leaving directory '/usr/src/qemu-8.1.0/build'
make: *** [GNUmakefile:11: install] Error 2