### PR TITLE
libwebp: version bumped to 1.3.2

### DIFF
--- a/graphics/libwebp/DETAILS
+++ b/graphics/libwebp/DETAILS
@@ -1,12 +1,12 @@
           MODULE=libwebp
-         VERSION=1.3.1
+         VERSION=1.3.2
           SOURCE=$MODULE-$VERSION.tar.gz
       SOURCE_URL[0]=http://downloads.webmproject.org/releases/webp/
       SOURCE_URL[1]=http://distfiles.gentoo.org/distfiles/
-      SOURCE_VFY=sha256:b3779627c2dfd31e3d8c4485962c2efe17785ef975e2be5c8c0c9e6cd3c4ef66
+      SOURCE_VFY=sha256:2a499607df669e40258e53d0ade8035ba4ec0175244869d1025d460562aa09b4
         WEB_SITE=https://developers.google.com/speed/webp/
          ENTERED=20110917
-         UPDATED=20230802
+         UPDATED=20230914
            SHORT="New image format that provides lossy compression for photographic images"
 
 cat << EOF


### PR DESCRIPTION
Caught in my emails, from a Slackware security release:
"Security fix for lossless decoder (chromium: #1479274, CVE-2023-4863)"