### PR TITLE
OpenBLAS: Adding. Will be a depends for armadilo bump.

### DIFF
--- a/science/OpenBLAS/DEPENDS
+++ b/science/OpenBLAS/DEPENDS
@@ -1,0 +1,1 @@
+depends cmake

--- a/science/OpenBLAS/DETAILS
+++ b/science/OpenBLAS/DETAILS
@@ -1,0 +1,15 @@
+         MODULE=OpenBLAS
+        VERSION=0.3.24
+         SOURCE=$MODULE-$VERSION.tar.gz
+     SOURCE_URL=https://github.com/OpenMathLib/OpenBLAS/releases/download/v$VERSION/
+     SOURCE_VFY=sha256:ceadc5065da97bd92404cac7254da66cc6eb192679cf1002098688978d4d5132
+       WEB_SITE=https://github.com/OpenMathLib/OpenBLAS
+           TYPE=cmake
+        ENTERED=20231001
+        UPDATED=20231001
+          SHORT="optimized BLAS (Basic Linear Algebra Subprograms) library"
+
+cat << EOF
+OpenBLAS is an optimized BLAS (Basic Linear Algebra Subprograms) library based on
+GotoBLAS2 1.13 BSD version.
+EOF


### PR DESCRIPTION
Armadilo looks for atlas and/or OpenBLAS. In its compile log it is clear atlas will be depreciated and if both is present will ignore atlas in favor of OpenBLAS. No switches are needed.