### PR TITLE
nghttp2: version bumped to 1.57.0

### DIFF
--- a/web/nghttp2/DETAILS
+++ b/web/nghttp2/DETAILS
@@ -1,11 +1,11 @@
           MODULE=nghttp2
-         VERSION=1.55.1
+         VERSION=1.57.0
           SOURCE=$MODULE-$VERSION.tar.gz
  SOURCE_URL_FULL=https://github.com/nghttp2/nghttp2/archive/v$VERSION.tar.gz
-      SOURCE_VFY=sha256:b89dece5bc3382b82c22db8dc8d1e062258cb7af8e4ad55278fa7149645a588d
-        WEB_SITE=http://nghttp2.org/
+      SOURCE_VFY=sha256:3c0b4e023dddf2afa087aa4409f7dbe03c099b4c63655e7545a607035085848a
+        WEB_SITE=https://nghttp2.org/
          ENTERED=20160412
-         UPDATED=20230814
+         UPDATED=20231013
            SHORT="Framing layer of HTTP/2 implemented as a reusable C library"
 
 cat << EOF


### PR DESCRIPTION
Fixes [CVE-2023-44487](https://github.com/nghttp2/nghttp2/security/advisories/GHSA-vx74-f528-fxqg)