### PR TITLE
libvpx: version bumped to 1.13.1, security fix

### DIFF
--- a/video/libvpx/DETAILS
+++ b/video/libvpx/DETAILS
@@ -1,11 +1,11 @@
           MODULE=libvpx
-         VERSION=1.13.0
+         VERSION=1.13.1
           SOURCE=$MODULE-$VERSION.tar.gz
  SOURCE_URL_FULL=https://github.com/webmproject/libvpx/archive/v$VERSION.tar.gz
-      SOURCE_VFY=sha256:cb2a393c9c1fae7aba76b950bb0ad393ba105409fe1a147ccd61b0aaa1501066
+      SOURCE_VFY=sha256:00dae80465567272abd077f59355f95ac91d7809a2d3006f9ace2637dd429d14
         WEB_SITE=https://github.com/webmproject/libvpx/
          ENTERED=20100618
-         UPDATED=20230816
+         UPDATED=20231013
            SHORT="Googles VP8 and VP9 codec"
 
 cat << EOF


### PR DESCRIPTION
Fixes CVE-2023-5217 (heap buffer overflow)