### PR TITLE
Revert "libxkbcommon: version bumped to 1.6.0"

### DIFF
--- a/x11-utils/libxkbcommon/DETAILS
+++ b/x11-utils/libxkbcommon/DETAILS
@@ -1,12 +1,12 @@
           MODULE=libxkbcommon
-         VERSION=1.6.0
+         VERSION=1.5.0
           SOURCE=xkbcommon-$VERSION.tar.gz
  SOURCE_DIRECTORY=$BUILD_DIRECTORY/$MODULE-xkbcommon-$VERSION
        SOURCE_URL=https://github.com/xkbcommon/libxkbcommon/archive/
-      SOURCE_VFY=sha256:4aa6c1cad7dce1238d6f48b6729f1998c7e3f0667a21100d5268c91a5830ad7b
-        WEB_SITE=https://xkbcommon.org/
+      SOURCE_VFY=sha256:053e6a6a2c3179eba20c3ada827fb8833a6663b7ffd278fdb8530c3cbf924780
+        WEB_SITE=http://xkbcommon.org/
          ENTERED=20140918
-         UPDATED=20231014
+         UPDATED=20230814
            SHORT="A library to handle keyboard descriptions"
 
 cat << EOF


### PR DESCRIPTION
Reverts lunar-linux/moonbase-other#3112 which breaks qt5.