### PR TITLE
libprojectM: Bump to 4.0.0. Now uses cmake.

### DIFF
--- a/video/libprojectM/DEPENDS
+++ b/video/libprojectM/DEPENDS
@@ -1,5 +1,5 @@
+depends cmake
 depends ftgl
 depends libvisual
 
-optional_depends SDL2 "--enable-sdl" "--disalbe-sdl" "To build the SDL2 app"
-optional_depends qt5  "--enable-qt"  "--disable-qt"  "For qt5 support"
+optional_depends SDL2 "-DENABLE_SDL_UI=ON" "-DENABLE_SDL_UI=OFF" "build developer test UI"

--- a/video/libprojectM/DETAILS
+++ b/video/libprojectM/DETAILS
@@ -1,12 +1,13 @@
           MODULE=libprojectM
-         VERSION=2.2.1
+         VERSION=4.0.0
           SOURCE=projectm-$VERSION.tar.gz
  SOURCE_URL_FULL=https://github.com/projectM-visualizer/projectm/archive/v$VERSION.tar.gz
+      SOURCE_VFY=sha256:4f4147f72b8e7578847d96f0f4b8bd3c8900ce6181a7a167912ce7a2626030d8
 SOURCE_DIRECTORY=$BUILD_DIRECTORY/projectm-$VERSION
-      SOURCE_VFY=sha256:a8dad73af6d6d2d30ab472f97dba7f6f61293454dd5cf02b2b21be327c0233b4
         WEB_SITE=http://xmms-projectm.sourceforge.net/
+            TYPE=cmake
          ENTERED=20060712
-         UPDATED=20181108
+         UPDATED=20231016
            SHORT="music visualizer"
 
 cat << EOF

--- a/video/libprojectM/PRE_BUILD
+++ b/video/libprojectM/PRE_BUILD
@@ -1,7 +1,9 @@
 default_pre_build &&
 
-./autogen.sh &&
+OPTS+=" -DENABLE_LLVM=OFF"
 
-export MOC=/usr/lib/qt5/bin/moc &&
-export UIC=/usr/lib/qt5/bin/uic &&
-export RCC=/usr/lib/qt5/bin/rcc
+#source /etc/profile.d/qt5.rc &&
+
+#export MOC=/usr/lib/qt5/bin/moc &&
+#export UIC=/usr/lib/qt5/bin/uic &&
+#export RCC=/usr/lib/qt5/bin/rcc

--- a/video/libprojectM/PRE_BUILD
+++ b/video/libprojectM/PRE_BUILD
@@ -1,9 +1,3 @@
 default_pre_build &&
 
 OPTS+=" -DENABLE_LLVM=OFF"
-
-#source /etc/profile.d/qt5.rc &&
-
-#export MOC=/usr/lib/qt5/bin/moc &&
-#export UIC=/usr/lib/qt5/bin/uic &&
-#export RCC=/usr/lib/qt5/bin/rcc


### PR DESCRIPTION
Adjusted PRE_BUILD to see if it really uses/needs qt5. Greping the compile for qt revealed no results. We shall see.