### PR TITLE
ocaml-cairo: This is a test between ocaml-cairo and cairo on CI.

### DIFF
--- a/graphics/ocaml-cairo/DETAILS
+++ b/graphics/ocaml-cairo/DETAILS
@@ -5,7 +5,7 @@
       SOURCE_VFY=sha256:4be272a05a5d5282fc45cac8a560ea082b8fad4896bf7466173cc88af4bfbde8
         WEB_SITE=https://github.com/Chris00/ocaml-cairo
          ENTERED=20230618
-         UPDATED=20230618
+         UPDATED=20231018
            SHORT="ocaml bindings for cairo"
 
 cat << EOF


### PR DESCRIPTION
Locally, this fails with;
/usr/include/cairo/cairo-ft.h:46:10: fatal error: ft2build.h: No such file or directory

Of course the file exists and ft2build.h is in the header.