### PR TITLE
sphinxtrain: Bump to 5.0.0. Converted to cmake.

### DIFF
--- a/science/sphinx/sphinxtrain/DEPENDS
+++ b/science/sphinx/sphinxtrain/DEPENDS
@@ -1,1 +1,2 @@
-depends sphinxbase
+depends cmake
+depends pocketsphinx

--- a/science/sphinx/sphinxtrain/DETAILS
+++ b/science/sphinx/sphinxtrain/DETAILS
@@ -1,11 +1,12 @@
           MODULE=sphinxtrain
-         VERSION=1.0.8
-          SOURCE=${MODULE}-$VERSION.tar.gz
-      SOURCE_URL=${SFORGE_URL}/cmusphinx/${MODULE}/$VERSION/
-      SOURCE_VFY=sha1:fccbb42203a388b353318d74a89fdf225aa7afe4
-        WEB_SITE=http://cmusphinx.sourceforge.net
+         VERSION=5.0.0
+          SOURCE=$MODULE-$VERSION.tar.gz
+ SOURCE_URL_FULL=https://github.com/cmusphinx/sphinxtrain/archive/refs/tags/v$VERSION.tar.gz
+      SOURCE_VFY=sha256:d95a1a83b57a528b3b00821ca35918b2dc05b8f1d8a3a77bc9d01c7719c143ed
+        WEB_SITE=https://github.com/cmusphinx/sphinxtrain
+            TYPE=cmake
          ENTERED=20130111
-         UPDATED=20130111
+         UPDATED=20231022
            SHORT="acoustic model training tools"
 
 cat << EOF


### PR DESCRIPTION
Depends sphinxbase is depreciated and will be moved to crater. This module now depends on pocketsphinx.