### PR TITLE
bind-utils: install missing libs

### DIFF
--- a/net/bind-utils/BUILD
+++ b/net/bind-utils/BUILD
@@ -20,4 +20,10 @@ make -C bin/dig    &&
 #make -C lib/lwres  &&
 
 prepare_install &&
-make -C bin/dig install
+make -C lib/isc    install &&
+make -C lib/dns    install &&
+make -C lib/ns     install &&
+make -C lib/isccfg install &&
+make -C lib/bind9  install &&
+make -C lib/irs    install &&
+make -C bin/dig    install


### PR DESCRIPTION
The utilities fail to execute because of missing shared libraries. Taken from the LinuxFromScratch book (BLFS-dev).