### PR TITLE
foomatic-db-engine: Bump to 4.0-20231024. We don't use any of the

### DIFF
--- a/printer/foomatic-db-engine/DETAILS
+++ b/printer/foomatic-db-engine/DETAILS
@@ -1,12 +1,12 @@
           MODULE=foomatic-db-engine
-         VERSION=4.0-20221021
+         VERSION=4.0-20231024
           SOURCE=$MODULE-$VERSION.tar.gz
       SOURCE_URL=https://www.openprinting.org/download/foomatic/
      SOURCE2_URL=$MIRROR_URL
-      SOURCE_VFY=sha256:4b85f8baacf5a73e68bc44c28381d244ab55f64b3f72f9923b9f5fe53878424d
+      SOURCE_VFY=sha256:6ce2bda3b5c453a970edd95eb59caaf87a76a3f8d8bcadc8c5c65d3f673fdda9
         WEB_SITE=http://www.linux-foundation.org/en/OpenPrinting/Database/Foomatic
          ENTERED=20051228
-         UPDATED=20221022
+         UPDATED=20231025
            SHORT="generates PPD files from the data in Foomatic's XML database"
 
 cat << EOF


### PR DESCRIPTION
"current" foomatics because they change often. This would cause un-needed effort maintaining them, unless you disable sha256, which we prefer *not* to do.

If you want them bumped, a copy needs to be uploaded to mirrors on robusta. For those without acces, I'm generally around so message if in need when you decide to bump any of the foomatic stuff.