### PR TITLE
pspdfutils: Adding. This will replace psutils. Here in the

### DIFF
--- a/printer/pspdfutils/BUILD
+++ b/printer/pspdfutils/BUILD
@@ -1,0 +1,4 @@
+python -m build --wheel &&
+
+prepare_install &&
+python -m installer dist/*.whl

--- a/printer/pspdfutils/DEPENDS
+++ b/printer/pspdfutils/DEPENDS
@@ -1,0 +1,3 @@
+depends libpaper
+depends python-installer
+depends python-build

--- a/printer/pspdfutils/DETAILS
+++ b/printer/pspdfutils/DETAILS
@@ -1,0 +1,17 @@
+          MODULE=pspdfutils
+         VERSION=3.3.2
+          SOURCE=$MODULE-$VERSION.tar.gz
+      SOURCE_URL=https://pypi.python.org/packages/source/p/pspdfutils/
+      SOURCE_VFY=sha256:a20a2a1359811bd0ad72e15349351a26774ddf8e355c2cde4250a70cf77fdf0c
+        WEB_SITE=https://pypi.org/project/pspdfutils/
+         ENTERED=20231025
+         UPDATED=20231025
+        REPLACES=psutils
+           SHORT="Utilities for manipulating PostScript files"
+
+cat << EOF
+A small set of invaluable utilities for manipulating PostScript files by selecting
+certain pages, re-ordering pages to facilitate printing books, changing the paper
+size, fitting several pages on a single sheet, etc. This package also includes some
+utilities to "fix" some broken PostScript formats.
+EOF


### PR DESCRIPTION
installation section mention is made of using pypi.org as the source url. Note the naming; pspdfutils.

The three modules dependent on psutils, groff, a2ps and texlive, compile fine with this version.