### PR TITLE
darktable: Bump to 4.4.2. Adding two patches, notable one from the

### DIFF
--- a/graphics/darktable/DEPENDS
+++ b/graphics/darktable/DEPENDS
@@ -1,4 +1,5 @@
 # hard requirements
+depends python-setuptools
 depends sqlite
 depends libjpeg-turbo
 depends libpng

--- a/graphics/darktable/DEPENDS
+++ b/graphics/darktable/DEPENDS
@@ -16,6 +16,7 @@ depends dbus-glib
 depends isl
 depends openmp
 depends python-pyrsistent
+depends python-referencing
 
 # not hard requirements, but
 # important to functionality

--- a/graphics/darktable/DETAILS
+++ b/graphics/darktable/DETAILS
@@ -1,11 +1,11 @@
           MODULE=darktable
-         VERSION=4.2.1
+         VERSION=4.4.2
           SOURCE=$MODULE-$VERSION.tar.xz
       SOURCE_URL=https://github.com/darktable-org/darktable/releases/download/release-${VERSION}/
-      SOURCE_VFY=sha256:603a39c6074291a601f7feb16ebb453fd0c5b02a6f5d3c7ab6db612eadc97bac
+      SOURCE_VFY=sha256:c11d28434fdf2e9ce572b9b1f9bc4e64dcebf6148e25080b4c32eb51916cfa98
         WEB_SITE=https://darktable.org/
          ENTERED=20190818
-         UPDATED=20230224
+         UPDATED=20231031
            SHORT="An image darkroom"
 
 cat << EOF

--- a/graphics/darktable/PRE_BUILD
+++ b/graphics/darktable/PRE_BUILD
@@ -1,4 +1,0 @@
-default_pre_build &&
-
-# we know our llvm is newer than 3.8
-sedit 's/\sfind_llvm(.*$/find_package(LLVM CONFIG)/g' CMakeLists.txt

--- a/graphics/darktable/patch.d/darktable-3.4.0_jsonschema-automagic.patch
+++ b/graphics/darktable/patch.d/darktable-3.4.0_jsonschema-automagic.patch
@@ -1,0 +1,25 @@
+jsonschema is only used at install time to validate a file that release
+tarballs already include, treat running it as a late part of tests.
+
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -350,6 +350,9 @@
+ endif()
+ 
+ # we need jsonschema to check noiseprofiles.json
++# In case of Git clones this file is generated at build time, for releases
++# it is included in the tarball.
++if (WANT_JSON_VALIDATION)
+ find_program(jsonschema_BIN jsonschema)
+ if(${jsonschema_BIN} STREQUAL "jsonschema_BIN-NOTFOUND")
+   message(STATUS "Missing jsonschema, problems in noiseprofiles.json might go unnoticed")
+@@ -358,6 +361,9 @@
+   message(STATUS "Found jsonschema")
+   set(VALIDATE_JSON 1)
+ endif(${jsonschema_BIN} STREQUAL "jsonschema_BIN-NOTFOUND")
++else()
++  set(VALIDATE_JSON 0)
++endif()
+ 
+ # we need an XSLT interpreter to generate preferences_gen.h and darktablerc
+ find_program(Xsltproc_BIN xsltproc)

--- a/graphics/darktable/patch.d/libavif-1.patch
+++ b/graphics/darktable/patch.d/libavif-1.patch
@@ -1,0 +1,16 @@
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index e3eaa697fe..9a10fd7ba4 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -353,7 +353,10 @@ if(USE_WEBP)
+ endif(USE_WEBP)
+ 
+ if (USE_AVIF)
+-    find_package(libavif 0.8.2 CONFIG)
++    find_package(libavif 0.8.2 CONFIG QUIET)
++    if(NOT libavif_FOUND)
++      find_package(libavif 1 CONFIG)
++    endif()
+     if (TARGET avif)
+         list(APPEND LIBS avif)
+         add_definitions(-DHAVE_LIBAVIF=1)


### PR DESCRIPTION
gentoo folks dealing with json stuff and one from arch folks dealing with with libavif.