### PR TITLE
git: semi-cosmetic fix to DEPENDS file

### DIFF
--- a/devel/git/DEPENDS
+++ b/devel/git/DEPENDS
@@ -3,8 +3,8 @@ depends %OSSL
 depends rsync
 depends zlib
 
-optional_depends curl  "--with-curl"    "" "for http(s):// transports" y
-optional_depends expat "--with-expat"   "" "for git-push using http(s):// via WebDAV" y
+optional_depends curl  "--with-curl"    "" "for http(s) transports" y
+optional_depends expat "--with-expat"   "" "for git-push using http(s) via WebDAV" y
 optional_depends pcre  "--with-libpcre" "" "for perl regexp support in git-grep" y
 optional_depends tk    "--with-tcltk"   "" "for a Tk front-end git tool" n
 


### PR DESCRIPTION
Since the `depends.cache` file uses colons as field separators, colons in the optional_depends explanations confuses anything trying to parse it.