### PR TITLE
tcc: use clone, now working with the newer glibc

### DIFF
--- a/compilers/tcc/DETAILS
+++ b/compilers/tcc/DETAILS
@@ -1,11 +1,12 @@
             MODULE=tcc
            VERSION=0.9.27
             SOURCE=$MODULE-$VERSION.tar.bz2
-        SOURCE_URL=http://download.savannah.nongnu.org/releases/tinycc
-        SOURCE_VFY=sha256:de23af78fca90ce32dff2dd45b3432b2334740bb9bb7b05bf60fdbfc396ceb9c
+            COMMIT=be8f8947106854cb0eca11691aa4dc99fb4cf845
+        SOURCE_URL=git+https://github.com/TinyCC/tinycc:$COMMIT
+        SOURCE_VFY=d4deb5861ab8570bd02abdbc022cb9f4d247f49b376fb71b856e8e08776ad6c8
           WEB_SITE=http://bellard.org/tcc
            ENTERED=20060509
-           UPDATED=20180105
+           UPDATED=20231119
              SHORT="Tiny C compiler"
 
 cat << EOF


### PR DESCRIPTION
This module was failing with:

[...]
ar rcs libtcc.a libtcc.o tccpp.o tccgen.o tccelf.o tccasm.o tccrun.o x86_64-gen.o x86_64-link.o i386-asm.o
gcc -o tcc tcc.o libtcc.a -lm -ldl -s -Wl,-z,relro,-z,now,--sort-common 
make[1]: Entering directory '/usr/src/tcc-0.9.27/lib'
../tcc -c libtcc1.c -o libtcc1.o -B..
../tcc -c alloca86_64.S -o alloca86_64.o -B..
../tcc -c alloca86_64-bt.S -o alloca86_64-bt.o -B..
../tcc -c va_list.c -o va_list.o -B..
../tcc -c bcheck.c -o bcheck.o -B..
bcheck.c:738: error: '__malloc_hook' undeclared
make[1]: *** [Makefile:64: bcheck.o] Error 1
make[1]: Leaving directory '/usr/src/tcc-0.9.27/lib'
make: *** [Makefile:230: libtcc1.a] Error 2

According to the home page the project is unmaintained but there's a github repo that seems active and which have fixed this issue.