### PR TITLE
git: version bumped to 2.43.0

### DIFF
--- a/devel/git/DETAILS
+++ b/devel/git/DETAILS
@@ -1,14 +1,14 @@
           MODULE=git
-         VERSION=2.42.1
+         VERSION=2.43.0
           SOURCE=$MODULE-$VERSION.tar.xz
          SOURCE2=$MODULE-manpages-$VERSION.tar.xz
       SOURCE_URL=https://www.kernel.org/pub/software/scm/git/
      SOURCE2_URL=https://www.kernel.org/pub/software/scm/git/
-      SOURCE_VFY=sha256:8e46fa96bf35a65625d85fde50391e39bc0620d1bb39afb70b96c4a237a1a4f7
-     SOURCE2_VFY=sha256:3d0495a10351b3541056a7923c63f3fd8a54992914cf56301809af8c69636b5d
+      SOURCE_VFY=sha256:5446603e73d911781d259e565750dcd277a42836c8e392cac91cf137aa9b76ec
+     SOURCE2_VFY=sha256:ef18df09444a60c70be996a481fde093928996055f61a585e9ea07b5bdc6d4d8
         WEB_SITE=https://git-scm.com
          ENTERED=20050728
-         UPDATED=20231103
+         UPDATED=20231121
            SHORT="Fast version control system"
 
 cat << EOF


### PR DESCRIPTION
Weirdly the build process fails if passing --with-libpcre2 instead of --with-libpcre