### PR TITLE
postfix: Version bumped to 3.8.4

### DIFF
--- a/mail/postfix/DETAILS
+++ b/mail/postfix/DETAILS
@@ -1,12 +1,12 @@
           MODULE=postfix
-         VERSION=3.8.3
+         VERSION=3.8.4
           SOURCE=$MODULE-$VERSION.tar.gz
    SOURCE_URL[0]=https://de.postfix.org/ftpmirror/official/
    SOURCE_URL[1]=ftp://ftp.porcupine.org/mirrors/postfix-release/official/
-      SOURCE_VFY=sha256:16946c9874a786a09f53b17d1c83dc1faae35cbf80bab34ab01798b70420968b
+      SOURCE_VFY=sha256:6f5848c5d8b6a7d2c5af0a9f75b0bd3f103451e912591464ab867fde085e6236
         WEB_SITE=https://www.postfix.org/
          ENTERED=20020125
-         UPDATED=20231105
+         UPDATED=20231223
            SHORT="A fast and secure drop-in replacement for sendmail"
 
 cat << EOF


### PR DESCRIPTION
This includes a fix for https://www.postfix.org/smtp-smuggling.html wherein an attacker can fool your mail server into delivering emails to where it's not supposed to, via the magic of poorly-formed line endings.