### PR TITLE
jq: version bumped to 1.7.1 (security fix)

### DIFF
--- a/utils/jq/BUILD
+++ b/utils/jq/BUILD
@@ -1,0 +1,3 @@
+OPTS+=" --disable-static"
+
+default_build

--- a/utils/jq/DETAILS
+++ b/utils/jq/DETAILS
@@ -1,11 +1,11 @@
           MODULE=jq
-         VERSION=1.6
+         VERSION=1.7.1
           SOURCE=${MODULE}-${VERSION}.tar.gz
       SOURCE_URL=https://github.com/stedolan/jq/releases/download/$MODULE-$VERSION
-      SOURCE_VFY=sha256:5de8c8e29aaa3fb9cc6b47bb27299f271354ebb72514e3accadc7d38b5bbaa72
+      SOURCE_VFY=sha256:478c9ca129fd2e3443fe27314b455e211e0d8c60bc8ff7df703873deeee580c2
         WEB_SITE=http://stedolan.github.io/jq/
          ENTERED=20180725
-         UPDATED=20181201
+         UPDATED=20181230
            SHORT="Command-line JSON processor"
 
 cat << EOF


### PR DESCRIPTION
Fixes 2 CVEs:

    CVE-2023-50246: Fix heap buffer overflow in jvp_literal_number_literal
    CVE-2023-50268: fix stack-buffer-overflow if comparing nan with payload
