### PR TITLE
xwayland: version bumped to 23.2.4

### DIFF
--- a/wayland/xwayland/DETAILS
+++ b/wayland/xwayland/DETAILS
@@ -1,11 +1,11 @@
           MODULE=xwayland
-         VERSION=23.2.1
+         VERSION=23.2.4
           SOURCE=$MODULE-$VERSION.tar.xz
       SOURCE_URL=$XORG_URL/individual/xserver
-     SOURCE_VFY=sha256:eebc2692c3aa80617d78428bc6ec7b91b254a98214d2a70e997098503cd6ef90
+     SOURCE_VFY=sha256:a99e159b6d0d33098b3b6ab22a88bfcece23c8b9d0ca72c535c55dcb0681b46b
         WEB_SITE=https://xorg.freedesktop.org/
          ENTERED=20230329
-         UPDATED=20230930
+         UPDATED=20240119
            SHORT="run X clients under wayland"
 
 cat << EOF

--- a/wayland/xwayland/DETAILS
+++ b/wayland/xwayland/DETAILS
@@ -5,7 +5,7 @@
      SOURCE_VFY=sha256:a99e159b6d0d33098b3b6ab22a88bfcece23c8b9d0ca72c535c55dcb0681b46b
         WEB_SITE=https://xorg.freedesktop.org/
          ENTERED=20230329
-         UPDATED=20240119
+         UPDATED=20240121
            SHORT="run X clients under wayland"
 
 cat << EOF


### PR DESCRIPTION
Fixes 6 CVEs:

1) CVE-2023-6816 can be triggered by passing an invalid array index to DeviceFocusEvent or ProcXIQueryPointer.

2) CVE-2024-0229 can be triggered if a device has both a button and a key class and zero buttons.

3) CVE-2024-21885 can be triggered if a device with a given ID was removed and a new device with the same ID added both in the same operation.

4) CVE-2024-21886 can be triggered by disabling a master device with disabled slave devices.

5) CVE-2024-0409 can be triggered by enabling SELinux xserver_object_manager and running a client.

6) CVE-2024-0408 can be triggered by enabling SELinux xserver_object_manager and creating a GLX PBuffer.