### PR TITLE
xsel: fix hash and prevent double configure

### DIFF
--- a/x11-apps/xsel/DETAILS
+++ b/x11-apps/xsel/DETAILS
@@ -2,10 +2,10 @@
          VERSION=1.2.1
           SOURCE=$MODULE-$VERSION.tar.gz
  SOURCE_URL_FULL=https://github.com/kfish/$MODULE/archive/refs/tags/$VERSION.tar.gz
-      SOURCE_VFY=sha256:9bab322703ae741fdff8e4cd5260a2a41e0acfe016706d8af69cd0fdce961ed5
+      SOURCE_VFY=sha256:18487761f5ca626a036d65ef2db8ad9923bf61685e06e7533676c56d7d60eb14
         WEB_SITE=http://www.vergenet.net/~conrad/software/xsel/
          ENTERED=20190324
-         UPDATED=20230827
+         UPDATED=20240121
            SHORT="Getting and setting the contents of the X selection"
 
 cat << EOF

--- a/x11-apps/xsel/PRE_BUILD
+++ b/x11-apps/xsel/PRE_BUILD
@@ -1,3 +1,3 @@
 default_pre_build
 
-./autogen.sh
+autoreconf -fi


### PR DESCRIPTION
The configure script was running twice, so fix that with autoreconf.