### PR TITLE
MPlayer: Bump to 1.5. Removed MPlayer-all and MPlayer-essentials. Per

### DIFF
--- a/video/MPlayer/BUILD
+++ b/video/MPlayer/BUILD
@@ -1,16 +1,20 @@
 # using CFLAGS other than MPlayer's auto-detected will break
-bad_flags compiler &&
+#bad_flags compiler &&
 
+#live555 is disabled by default and will be removed
+
+#Instead of using that bad_flags above, which still caused a build failure,
+#allow it to decided entirely what it wants to use by removing $OPTS.
+#MPlayer has always been very picky about these things.
 ./configure --prefix=/usr                \
             --mandir=/usr/share/man      \
             --codecsdir=/usr/lib/win32   \
             --confdir=/etc/mplayer       \
             --datadir=/usr/share/mplayer \
             --enable-dynamic-plugins     \
-            --disable-live               \
-            --disable-ggi                \
-            --disable-ggiwmh             \
-            $OPTS                       &&
+            --enable-menu                \
+            --enable-runtime-cpudetection \
+            --enable-gui                 &&
 
 sedit 's/-mtune=native//' config.mak &&
 

--- a/video/MPlayer/DEPENDS
+++ b/video/MPlayer/DEPENDS
@@ -98,12 +98,3 @@ optional_depends libass \
                  "--enable-ass" \
                  "--disable-ass" \
                  "ASS subtitle support"
-
-optional_depends MPlayer-essentials "" "" "installs gcc-3.3.6 for dlls"
-optional_depends MPlayer-all        "" "" "to install more foreign codecs"
-
-## live removed the obsolete synchronous client interface
-## which MPlayer still requires
-#optional_depends live555 \
-#                 "" "--disable-live" \
-#                 "for RTP/RTCP, RTSP, SIP support"

--- a/video/MPlayer/DEPENDS
+++ b/video/MPlayer/DEPENDS
@@ -1,6 +1,7 @@
 # Using minimal --enables, because MPlayer's build system is FLAKY.
 depends freetype2
 depends yasm
+depends gtk+-2
 
 optional_depends DirectFB \
                  "--enable-directfb" \

--- a/video/MPlayer/DETAILS
+++ b/video/MPlayer/DETAILS
@@ -1,19 +1,19 @@
           MODULE=MPlayer
-         VERSION=1.3.0
+         VERSION=1.5
           SOURCE=$MODULE-$VERSION.tar.xz
          SOURCE2=font-arial-iso-8859-1.tar.bz2
          SOURCE3=font-arial-iso-8859-2.tar.bz2
          SOURCE4=font-arial-cp1250.tar.bz2
          SOURCE5=font-arial-iso-8859-7.tar.bz2
          SOURCE6=Blue-1.11.tar.bz2
-   SOURCE_URL[0]=http://www.mplayerhq.hu/$MODULE/releases
+   SOURCE_URL[0]=https://mplayerhq.hu/MPlayer/releases/
    SOURCE_URL[1]=ftp://ftp1.mplayerhq.hu/$MODULE/releases
      SOURCE2_URL=ftp://ftp1.mplayerhq.hu/$MODULE/releases/fonts
      SOURCE3_URL=ftp://ftp1.mplayerhq.hu/$MODULE/releases/fonts
      SOURCE4_URL=ftp://ftp1.mplayerhq.hu/$MODULE/releases/fonts
      SOURCE5_URL=ftp://ftp1.mplayerhq.hu/$MODULE/releases/fonts
      SOURCE6_URL=ftp://ftp1.mplayerhq.hu/$MODULE/skins
-      SOURCE_VFY=sha256:3ad0846c92d89ab2e4e6fb83bf991ea677e7aa2ea775845814cbceb608b09843
+      SOURCE_VFY=sha256:650cd55bb3cb44c9b39ce36dac488428559799c5f18d16d98edb2b7256cbbf85
      SOURCE2_VFY=sha256:9730f481764f367c9089d0166fb6ccf9148808ffbbfeca635cf0e6db75765d29
      SOURCE3_VFY=sha256:71debfc960007c2f6242dfc91e8b1c005b30a99e129aeb00ab8c03f4371b41c1
      SOURCE4_VFY=sha256:423a07e780bb130cd8e4730715545c5d919c248dda595aab7a0a01de3c83fd12
@@ -21,7 +21,7 @@
      SOURCE6_VFY=sha256:b43babe52ee8ab6f35f85d4c4405169cb55777db090f6b846db4657e8c227331
         WEB_SITE=http://www.mplayerhq.hu
          ENTERED=20010922
-         UPDATED=20160217
+         UPDATED=20230123
            SHORT="A movie and animation player"
 
 cat << EOF

--- a/video/MPlayer/MPlayer-1.5-upstream_ffmpg6_fixes-1.patch
+++ b/video/MPlayer/MPlayer-1.5-upstream_ffmpg6_fixes-1.patch
@@ -1,0 +1,113 @@
+diff -Naur MPlayer-1.5/configure MPlayer-1.5-new/configure
+--- MPlayer-1.5/configure	2022-02-27 03:09:00.000000000 -0600
++++ MPlayer-1.5-new/configure	2023-03-06 22:19:46.220134696 -0600
+@@ -1591,26 +1591,26 @@
+ }
+ 
+ echocheck "ffmpeg/libavcodec/allcodecs.c"
+-libavdecoders_all=$(list_subparts_extern  AVCodec       decoder  codec/allcodecs.c)
+-libavencoders_all=$(list_subparts_extern  AVCodec       encoder  codec/allcodecs.c)
+-libavparsers_all=$(list_subparts_extern   AVCodecParser parser   codec/parsers.c)
++libavdecoders_all=$(list_subparts_extern  Codec       decoder  codec/allcodecs.c)
++libavencoders_all=$(list_subparts_extern  Codec       encoder  codec/allcodecs.c)
++libavparsers_all=$(list_subparts_extern   CodecParser parser   codec/parsers.c)
+ test $? -eq 0 && _list_subparts=found || _list_subparts="not found"
+ echores "$_list_subparts"
+ 
+ echocheck "ffmpeg/libavcodec/hwaccels.h"
+ libavhwaccels_all=$(list_subparts_extern  AVHWAccel hwaccel codec/hwaccels.h)
+-test $? -eq 0 || libavhwaccels_all=$(list_subparts  HWACCEL  hwaccel  codec/allcodecs.c)
++test $? -eq 0 || libavhwaccels_all=$(list_subparts  ACCEL  hwaccel  codec/allcodecs.c)
+ test $? -eq 0 && _list_subparts=found || _list_subparts="not found"
+ echores "$_list_subparts"
+ 
+ echocheck "ffmpeg/libavformat/allformats.c"
+-libavdemuxers_all=$(list_subparts_extern  AVInputFormat    demuxer  format/allformats.c)
+-libavmuxers_all=$(list_subparts_extern    AVOutputFormat   muxer    format/allformats.c)
++libavdemuxers_all=$(list_subparts_extern  InputFormat    demuxer  format/allformats.c)
++libavmuxers_all=$(list_subparts_extern    OutputFormat   muxer    format/allformats.c)
+ test $? -eq 0 && _list_subparts=found || _list_subparts="not found"
+ echores "$_list_subparts"
+ 
+ echocheck "ffmpeg/libavcodec/bitsteram_filters.c"
+-libavbsfs_all=$(list_subparts_extern AVBitStreamFilter bsf codec/bitstream_filters.c)
++libavbsfs_all=$(list_subparts_extern BitStreamFilter bsf codec/bitstream_filters.c)
+ test $? -eq 0 && _list_subparts_extern=found || _list_subparts_extern="not found"
+ echores "$_list_subparts_extern"
+ 
+diff -Naur MPlayer-1.5/libmpcodecs/ad_spdif.c MPlayer-1.5-new/libmpcodecs/ad_spdif.c
+--- MPlayer-1.5/libmpcodecs/ad_spdif.c	2021-05-01 12:45:31.000000000 -0500
++++ MPlayer-1.5-new/libmpcodecs/ad_spdif.c	2023-03-06 22:15:03.947106476 -0600
+@@ -79,7 +79,7 @@
+ 
+ static int init(sh_audio_t *sh)
+ {
+-    int i, x, in_size, srate, bps, *dtshd_rate, res;
++    int i, x, in_size, srate, bps, res;
+     unsigned char *start;
+     double pts;
+     static const struct {
+@@ -97,6 +97,7 @@
+     AVStream            *stream    = NULL;
+     const AVOption      *opt       = NULL;
+     struct spdifContext *spdif_ctx = NULL;
++    AVDictionary *opts = NULL;
+ 
+     spdif_ctx = av_mallocz(sizeof(*spdif_ctx));
+     if (!spdif_ctx)
+@@ -112,9 +113,6 @@
+     lavf_ctx->oformat = av_guess_format(FILENAME_SPDIFENC, NULL, NULL);
+     if (!lavf_ctx->oformat)
+         goto fail;
+-    lavf_ctx->priv_data = av_mallocz(lavf_ctx->oformat->priv_data_size);
+-    if (!lavf_ctx->priv_data)
+-        goto fail;
+     lavf_ctx->pb = avio_alloc_context(spdif_ctx->pb_buffer, OUTBUF_SIZE, 1, spdif_ctx,
+                             read_packet, write_packet, seek);
+     if (!lavf_ctx->pb)
+@@ -130,12 +128,17 @@
+             break;
+         }
+     }
+-    if ((res = avformat_write_header(lavf_ctx, NULL)) < 0) {
++    // FORCE USE DTS-HD
++    if (lavf_ctx->streams[0]->codecpar->codec_id == AV_CODEC_ID_DTS)
++        av_dict_set(&opts, "dtshd_rate", "768000" /* 192000*4 */, 0);
++    if ((res = avformat_write_header(lavf_ctx, opts)) < 0) {
++        av_dict_free(&opts);
+         if (res == AVERROR_PATCHWELCOME)
+             mp_msg(MSGT_DECAUDIO,MSGL_INFO,
+                "This codec is not supported by spdifenc.\n");
+         goto fail;
+     }
++    av_dict_free(&opts);
+     spdif_ctx->header_written = 1;
+ 
+     // get sample_rate & bitrate from parser
+@@ -177,13 +180,6 @@
+         sh->i_bps                       = bps;
+         break;
+     case AV_CODEC_ID_DTS: // FORCE USE DTS-HD
+-        opt = av_opt_find(&lavf_ctx->oformat->priv_class,
+-                          "dtshd_rate", NULL, 0, 0);
+-        if (!opt)
+-            goto fail;
+-        dtshd_rate                      = (int*)(((uint8_t*)lavf_ctx->priv_data) +
+-                                          opt->offset);
+-        *dtshd_rate                     = 192000*4;
+         spdif_ctx->iec61937_packet_size = 32768;
+         sh->sample_format               = AF_FORMAT_IEC61937_LE;
+         sh->samplerate                  = 192000; // DTS core require 48000
+diff -Naur MPlayer-1.5/libmpcodecs/ve_lavc.c MPlayer-1.5-new/libmpcodecs/ve_lavc.c
+--- MPlayer-1.5/libmpcodecs/ve_lavc.c	2021-05-14 14:56:16.000000000 -0500
++++ MPlayer-1.5-new/libmpcodecs/ve_lavc.c	2023-03-06 22:14:58.798125033 -0600
+@@ -441,8 +441,7 @@
+ 	    mp_msg(MSGT_MENCODER,MSGL_ERR,"error parsing vrc_q\n");
+             return 0;
+         }
+-        lavc_venc_context->rc_override=
+-            av_reallocp_array(lavc_venc_context->rc_override, i+1, sizeof(*lavc_venc_context->rc_override));
++        av_reallocp_array(&lavc_venc_context->rc_override, i+1, sizeof(*lavc_venc_context->rc_override));
+         lavc_venc_context->rc_override[i].start_frame= start;
+         lavc_venc_context->rc_override[i].end_frame  = end;
+         if(q>0){

--- a/video/MPlayer/PRE_BUILD
+++ b/video/MPlayer/PRE_BUILD
@@ -16,3 +16,6 @@ sedit '1s@/usr/bin/awk@/bin/awk@' vidix/pci_db2c.awk &&
 
 # --extra_* are expected only once, but we might need more
 sedit "s:extra_\([^=]*\)=\(\\\$.*\)$:extra_\1=\"\$extra_\1 \2\":" configure
+
+patch -Np1 -i $SCRIPT_DIRECTORY/MPlayer-1.5-upstream_ffmpg6_fixes-1.patch &&
+patch -Np1 -d ffmpeg -i $SCRIPT_DIRECTORY/ffmpeg-6.0-binutils_2.41-1.patch

--- a/video/MPlayer/ffmpeg-6.0-binutils_2.41-1.patch
+++ b/video/MPlayer/ffmpeg-6.0-binutils_2.41-1.patch
@@ -1,0 +1,80 @@
+Submitted By: Bruce Dubbs (bdubbs@linuxfromscratch.org)
+Date: 2023-08-06
+Initial Package Version: 6.0
+Origin: Upstream
+Upstream Status: Committed
+Description: Allow building with binutils-2.41. 
+
+From effadce6c756247ea8bae32dc13bb3e6f464f0eb Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?R=C3=A9mi=20Denis-Courmont?= <remi@remlab.net>
+Date: Sun, 16 Jul 2023 18:18:02 +0300
+Subject: [PATCH] avcodec/x86/mathops: clip constants used with shift
+ instructions within inline assembly
+
+Fixes assembling with binutil as >= 2.41
+
+Signed-off-by: James Almer <jamrial@gmail.com>
+---
+ libavcodec/x86/mathops.h | 26 +++++++++++++++++++++++---
+ 1 file changed, 23 insertions(+), 3 deletions(-)
+
+diff --git a/libavcodec/x86/mathops.h b/libavcodec/x86/mathops.h
+index 6298f5ed1983..ca7e2dffc107 100644
+--- a/libavcodec/x86/mathops.h
++++ b/libavcodec/x86/mathops.h
+@@ -35,12 +35,20 @@
+ static av_always_inline av_const int MULL(int a, int b, unsigned shift)
+ {
+     int rt, dummy;
++    if (__builtin_constant_p(shift))
+     __asm__ (
+         "imull %3               \n\t"
+         "shrdl %4, %%edx, %%eax \n\t"
+         :"=a"(rt), "=d"(dummy)
+-        :"a"(a), "rm"(b), "ci"((uint8_t)shift)
++        :"a"(a), "rm"(b), "i"(shift & 0x1F)
+     );
++    else
++        __asm__ (
++            "imull %3               \n\t"
++            "shrdl %4, %%edx, %%eax \n\t"
++            :"=a"(rt), "=d"(dummy)
++            :"a"(a), "rm"(b), "c"((uint8_t)shift)
++        );
+     return rt;
+ }
+ 
+@@ -113,19 +121,31 @@ __asm__ volatile(\
+ // avoid +32 for shift optimization (gcc should do that ...)
+ #define NEG_SSR32 NEG_SSR32
+ static inline  int32_t NEG_SSR32( int32_t a, int8_t s){
++    if (__builtin_constant_p(s))
+     __asm__ ("sarl %1, %0\n\t"
+          : "+r" (a)
+-         : "ic" ((uint8_t)(-s))
++         : "i" (-s & 0x1F)
+     );
++    else
++        __asm__ ("sarl %1, %0\n\t"
++               : "+r" (a)
++               : "c" ((uint8_t)(-s))
++        );
+     return a;
+ }
+ 
+ #define NEG_USR32 NEG_USR32
+ static inline uint32_t NEG_USR32(uint32_t a, int8_t s){
++    if (__builtin_constant_p(s))
+     __asm__ ("shrl %1, %0\n\t"
+          : "+r" (a)
+-         : "ic" ((uint8_t)(-s))
++         : "i" (-s & 0x1F)
+     );
++    else
++        __asm__ ("shrl %1, %0\n\t"
++               : "+r" (a)
++               : "c" ((uint8_t)(-s))
++        );
+     return a;
+ }
+ 


### PR DESCRIPTION
the changelog live555 is disabled by default and scheduled to be removed. Also in the BUILD, mplayer has always been a bit touchy about compile options and unsetting compiler wasn't enough, just remove $OPTS.

Added a couple of patches from the LFS folks. Thank you guys.

This will no doubt fail on CI.