### PR TITLE
strace: version bumped to 6.7

### DIFF
--- a/devel/strace/BUILD
+++ b/devel/strace/BUILD
@@ -1,7 +1,3 @@
 OPTS+=" --enable-mpers=no"
 
-if in_depends $MODULE libunwind; then
-  CPPFLAGS+=" -I/usr/include/libunwind"
-fi &&
-
 default_build

--- a/devel/strace/DETAILS
+++ b/devel/strace/DETAILS
@@ -1,11 +1,11 @@
           MODULE=strace
-         VERSION=6.6
+         VERSION=6.7
           SOURCE=$MODULE-$VERSION.tar.xz
       SOURCE_URL=https://strace.io/files/$VERSION/
-      SOURCE_VFY=sha256:421b4186c06b705163e64dc85f271ebdcf67660af8667283147d5e859fc8a96c
+      SOURCE_VFY=sha256:2090201e1a3ff32846f4fe421c1163b15f440bb38e31355d09f82d3949922af7
         WEB_SITE=https://strace.sourceforge.net
          ENTERED=20010922
-         UPDATED=20231101
+         UPDATED=20240129
            SHORT="System call tracing utility (like trace, truss, etc)"
 
 cat << EOF


### PR DESCRIPTION
The libunwind headers live in /usr/include