### PR TITLE
pigz: version bumped to 2.8

### DIFF
--- a/archive/pigz/BUILD
+++ b/archive/pigz/BUILD
@@ -3,9 +3,7 @@ make &&
 prepare_install &&
 
 install -Dm755 $MODULE /usr/bin/ &&
-pushd /usr/bin &&
-    ln -sf pigz unpigz &&
-popd &&
+ln -sf pigz /usr/bin/unpigz &&
 
 mkdir -p /usr/share/doc/$MODULE/ &&
 install -Dm644 $MODULE.1 /usr/share/man/man1/ &&

--- a/archive/pigz/DETAILS
+++ b/archive/pigz/DETAILS
@@ -1,11 +1,11 @@
           MODULE=pigz
-         VERSION=2.7
+         VERSION=2.8
           SOURCE=$MODULE-$VERSION.tar.gz
       SOURCE_URL=https://zlib.net/pigz/
-      SOURCE_VFY=sha256:b4c9e60344a08d5db37ca7ad00a5b2c76ccb9556354b722d56d55ca7e8b1c707
+      SOURCE_VFY=sha256:eb872b4f0e1f0ebe59c9f7bd8c506c4204893ba6a8492de31df416f0d5170fd0
         WEB_SITE=https://zlib.net/pigz/
          ENTERED=20190520
-         UPDATED=20220603
+         UPDATED=20240210
            SHORT="Parallel implementation of the gzip file compressor"
 
 cat << EOF


### PR DESCRIPTION
pushd and popd add unnecessary output, so reduce noise with a simple ln command.