### PR TITLE
glusterfs: version bumped to 11.1

### DIFF
--- a/filesys/glusterfs/DEPENDS
+++ b/filesys/glusterfs/DEPENDS
@@ -6,6 +6,7 @@ depends userspace-rcu
 depends libxml2
 depends rpcsvc-proto
 depends liburing
+depends readline
 
 optional_depends rpcbind  "" "" "NFS server support"
 optional_depends libaio   "" "" "Asyncronus I/O support"

--- a/filesys/glusterfs/DETAILS
+++ b/filesys/glusterfs/DETAILS
@@ -1,11 +1,11 @@
           MODULE=glusterfs
-         VERSION=11.0
+         VERSION=11.1
           SOURCE=$MODULE-$VERSION.tar.gz
       SOURCE_URL=https://download.gluster.org/pub/gluster/glusterfs/${VERSION%.*}/$VERSION/
-      SOURCE_VFY=sha256:0ae8f4a90408813e45d4349e813f78b60e919e1009d29fd174c462f456142696
+      SOURCE_VFY=sha256:6a31b8450d02cd12f47f4571c031e9d6b8705279a0e8970ae9a05e1c87dffb76
         WEB_SITE=http://www.gluster.org/
          ENTERED=20140108
-         UPDATED=20231014
+         UPDATED=20240214
            SHORT="A distributed, replicated, self-healing filesystem"
 
 cat << EOF

--- a/filesys/glusterfs/tmpfiles.d/glusterfs.conf
+++ b/filesys/glusterfs/tmpfiles.d/glusterfs.conf
@@ -1,1 +1,1 @@
-d /var/run/glusterfs 0755 root root -
+d /run/glusterfs 0755 root root -


### PR DESCRIPTION
Systemd was giving this message:

Line references path below legacy directory /var/run/, updating /var/run/glusterfs → /run/glusterfs; please update the tmpfiles.d/ drop-in file accordingly.