### PR TITLE
poppler: Bump to 24.02.0. Per PR3483, pypoppler failed on

### DIFF
--- a/libs/poppler/BUILD
+++ b/libs/poppler/BUILD
@@ -1,6 +1,7 @@
 OPTS+=" -DBUILD_SHARED_LIBS=ON \
         -DENABLE_GTK_DOC=OFF \
         -DBUILD_GTK_TESTS=OFF \
+        -DENABLE_CMS=lcms2 \
         -DENABLE_UNSTABLE_API_ABI_HEADERS=ON"
 
 # If in depends we will now build qt5 libs

--- a/libs/poppler/DEPENDS
+++ b/libs/poppler/DEPENDS
@@ -2,6 +2,7 @@ depends zlib
 depends cmake
 depends fontconfig
 depends gobject-introspection
+depends lcms2
 depends nss
 depends gpgme
 
@@ -35,11 +36,6 @@ optional_depends tiff \
                  "-DENABLE_LIBTIFF=ON" \
                  "-DENABLE_LIBTIFF=OFF" \
                  "for TIFF image support"
-
-optional_depends lcms2 \
-                 "-DENABLE_CMS=lcms2" \
-                 "-DENABLE_CMS=none" \
-                 "for the color management system (needed by cups_filters)"
 
 optional_depends cairo \
                  "-DENABLE_GLIB=ON" \

--- a/libs/poppler/DETAILS
+++ b/libs/poppler/DETAILS
@@ -1,11 +1,11 @@
           MODULE=poppler
-         VERSION=24.01.0
+         VERSION=24.02.0
           SOURCE=$MODULE-$VERSION.tar.xz
       SOURCE_URL=https://poppler.freedesktop.org
-      SOURCE_VFY=sha256:c7def693a7a492830f49d497a80cc6b9c85cb57b15e9be2d2d615153b79cae08
+      SOURCE_VFY=sha256:19187a3fdd05f33e7d604c4799c183de5ca0118640c88b370ddcf3136343222e
         WEB_SITE=https://poppler.freedesktop.org/
          ENTERED=20050918
-         UPDATED=20240107
+         UPDATED=20240218
            SHORT="A PDF rendering library"
 
 cat << EOF


### PR DESCRIPTION
poppler missing lcms2. Making lcms2 a depends.