### PR TITLE
freshplayer: Bump to 0.3.11. Reworked DEPENDS and adjusted BUILD.

### DIFF
--- a/video/freshplayerplugin/BUILD
+++ b/video/freshplayerplugin/BUILD
@@ -1,14 +1,16 @@
-  default_cmake_config &&
+# https://github.com/i-rinat/freshplayerplugin/issues/389
+OPTS+=" -DWITH_HWDEC=OFF"
 
-  make &&
-  prepare_install &&
+default_cmake_config &&
 
-  mkdir -p /usr/lib/lunar/plugins &&
-  install -m555 libfreshwrapper-*.so /usr/lib/lunar/plugins &&
+make &&
+prepare_install &&
 
-  install ../data/freshwrapper.conf.example /etc/ &&
-  
-  if [ ! -f /etc/freshwrapper.conf ] ; then
-   sedit "s:/opt/google/chrome/PepperFlash/:/usr/lib/lunar/plugins/:" ../data/freshwrapper.conf.example &&
-   install -Dm644 ../data/freshwrapper.conf.example /etc/freshwrapper.conf
-  fi
+mkdir -p /usr/lib/lunar/plugins &&
+install -m555 libfreshwrapper-*.so /usr/lib/lunar/plugins &&
+install ../data/freshwrapper.conf.example /etc/ &&
+
+if [ ! -f /etc/freshwrapper.conf ] ; then
+  sedit "s:/opt/google/chrome/PepperFlash/:/usr/lib/lunar/plugins/:" ../data/freshwrapper.conf.example &&
+  install -Dm644 ../data/freshwrapper.conf.example /etc/freshwrapper.conf
+fi

--- a/video/freshplayerplugin/DEPENDS
+++ b/video/freshplayerplugin/DEPENDS
@@ -1,5 +1,6 @@
 depends ragel
 depends alsa-utils
+depends v4l-utils
 depends glib-2
 depends mesa-lib
 depends xorgproto

--- a/video/freshplayerplugin/DEPENDS
+++ b/video/freshplayerplugin/DEPENDS
@@ -4,17 +4,18 @@ depends glib-2
 depends mesa-lib
 depends xorgproto
 depends cmake
+depends libglvnd
 depends uriparser
 depends libconfig
 depends libevent
 depends cairo
 depends pango
 depends freetype2
-depends pepperflash
+depends soxr
 
 optional_depends "gtk+-2"      "-DWITH_GTK=2"           ""                        "For gtk+-2 graphics support, ${PROBLEM_COLOR}if yes here say no to gtk+-3"
 optional_depends "gtk+-3"      "-DWITH_GTK=3"           ""                        "For gtk+-3 graphics support"
-optional_depends jack2        "-DWITH_JACK=TRUE"       "-DWITH_JACK=FALSE"       "For jack sound server support, ${PROBLEM_COLOR}if yes here then say yes to soxr${DEFAULT_COLOR}" n
-optional_depends "soxr"        ""                       ""                        "Needed if you said yes to jack"
 optional_depends "pulseaudio"  "-DWITH_PULSEAUDIO=TRUE" "-DWITH_PULSEAUDIO=FALSE" "For pulseaudio support"
 optional_depends "PDFlib-Lite" "-DWITH_LIBPDF=TRUE"     "-DWITH_LIBPDF=FALSE"     "For pdf support"
+
+optional_depends "pepperflash" "-DWITH_PEPPERFLASH=TRUE" "-DWITH_PEPPERFLASH=FALSE" "for pepperflash support" y

--- a/video/freshplayerplugin/DETAILS
+++ b/video/freshplayerplugin/DETAILS
@@ -1,12 +1,12 @@
           MODULE=freshplayerplugin
-         VERSION=v0.3.10
+         VERSION=v0.3.11
           SOURCE=$VERSION.tar.gz
       SOURCE_URL=https://github.com/i-rinat/freshplayerplugin/archive
 SOURCE_DIRECTORY=$BUILD_DIRECTORY/$MODULE-${VERSION#*v}
-      SOURCE_VFY=sha256:5695575999ee1741e091eab0b526b156981463fb62321063c94ed7c53557b09a
+      SOURCE_VFY=sha256:f8ffa50988bcf9c54fe7c1aacba20228153aef11f6c975ae49e0be4e68f8535d
         WEB_SITE=https://github.com/i-rinat/freshplayerplugin
          ENTERED=20140802
-         UPDATED=20190320
+         UPDATED=20240302
            SHORT="PPAPI-host NPAPI-plugin adapter"
 
 cat << EOF


### PR DESCRIPTION
Per; https://github.com/i-rinat/freshplayerplugin/issues/389, disabling hardware decoding.

If and when this module breaks again I highly recommend it be sent off to /dev/null, it doesn't deserve crater.