### PR TITLE
go-bootstrap: Bump to 1.17.13 and adding some BUILD variables to

### DIFF
--- a/compilers/go-bootstrap/DETAILS
+++ b/compilers/go-bootstrap/DETAILS
@@ -1,15 +1,12 @@
           MODULE=go-bootstrap
-         VERSION=1.4.3
+         VERSION=1.17.13
           SOURCE=go${VERSION}.src.tar.gz
-         SOURCE2=go-1.4.3-support_new_relocation.patch
 SOURCE_DIRECTORY=$BUILD_DIRECTORY/go
       SOURCE_URL=http://storage.googleapis.com/golang
-     SOURCE2_URL=$PATCH_URL
-      SOURCE_VFY=sha256:9947fc705b0b841b5938c48b22dc33e9647ec0752bae66e50278df4f23f64959
-     SOURCE2_VFU=sha256:3bd901d920e53fed95b495a6daf012854826855993187a6d07970a7ef108ef28
+      SOURCE_VFY=sha256:a1a48b23afb206f95e7bbaa9b898d965f90826f6f1d1fc0c1d784ada0cd300fd
         WEB_SITE=http://golang.org/
          ENTERED=20140606
-         UPDATED=20210828
+         UPDATED=20240302
            SHORT="A bootstrap Go compiler and tools"
 
 cat << EOF

--- a/compilers/go-bootstrap/POST_INSTALL
+++ b/compilers/go-bootstrap/POST_INSTALL
@@ -1,7 +1,7 @@
 # Fix timestamps to avoid go tools to rebuild its files
-find /usr/lib/go1.4 -type f -exec touch -r /usr/lib/go1.4/pkg/*/runtime.a {} \;
+find /usr/lib/go1.$(lvu version go-bootstrap|cut -d"." -f2) -type f -exec touch -r /usr/lib/go1.$(lvu version go-bootstrap|cut -d"." -f2)/pkg/*/runtime.a {} \;
 
 # add the symlinks to /usr/bin
-for f in /usr/lib/go1.4/bin/*; do
+for f in /usr/lib/go1.$(lvu version go-bootstrap|cut -d"." -f2)/bin/*; do
    ln -sf $f /usr/bin/
 done

--- a/compilers/go-bootstrap/PRE_BUILD
+++ b/compilers/go-bootstrap/PRE_BUILD
@@ -1,2 +1,0 @@
-default_pre_build &&
-patch_it $SOURCE2 1

--- a/compilers/go-bootstrap/PRE_BUILD
+++ b/compilers/go-bootstrap/PRE_BUILD
@@ -1,0 +1,3 @@
+default_pre_build &&
+
+rm -rf /usr/lib/go1.4


### PR DESCRIPTION
make updates of go-bootstrap and go less painful.