### PR TITLE
zziplib: fix wrong libs in pkgconfig file

### DIFF
--- a/archive/zziplib/BUILD
+++ b/archive/zziplib/BUILD
@@ -1,3 +1,9 @@
 OPTS+=" -DZZIPDOCS=OFF"
 
-default_cmake_build
+default_cmake_build &&
+
+# This fix should be temporary until the pkgconfig file is properly generated
+sedit 's/-lzzip/&-0/' /usr/lib/pkgconfig/zziplib.pc &&
+sedit 's/-lzzipfseeko/&-0/' /usr/lib/pkgconfig/zzipfseeko.pc &&
+sedit 's/-lzzipmmapped/&-0/' /usr/lib/pkgconfig/zzipmmapped.pc &&
+sedit 's/-lzzipwrap/&-0/' /usr/lib/pkgconfig/zzipwrap.pc


### PR DESCRIPTION
The .pc files seem to be incorrectly generated. The installed libs end in -0.so so add a temporary fix until this situation is resolved upstream.