### PR TITLE
httpd: version bumped to 2.4.59

### DIFF
--- a/web/httpd/DETAILS
+++ b/web/httpd/DETAILS
@@ -1,11 +1,11 @@
           MODULE=httpd
-         VERSION=2.4.58
+         VERSION=2.4.59
           SOURCE=$MODULE-$VERSION.tar.bz2
       SOURCE_URL=http://dlcdn.apache.org/httpd/
-      SOURCE_VFY=sha256:fa16d72a078210a54c47dd5bef2f8b9b8a01d94909a51453956b3ec6442ea4c5
+      SOURCE_VFY=sha256:ec51501ec480284ff52f637258135d333230a7d229c3afa6f6c2f9040e321323
         WEB_SITE=http://www.apache.org
          ENTERED=20020710
-         UPDATED=20231019
+         UPDATED=20240404
            SHORT="A popular HTTP server"
 
 cat << EOF


### PR DESCRIPTION
Fixes 3 CVEs: [CVE-2023-38709](https://www.cve.org/CVERecord?id=CVE-2023-38709) [CVE-2024-24795](https://www.cve.org/CVERecord?id=CVE-2024-24795) and [CVE-2024-27316](https://www.cve.org/CVERecord?id=CVE-2024-27316)