### PR TITLE
Vulkan-Loader:depends spirv-headers

### DIFF
--- a/kernel/Vulkan-Loader/DEPENDS
+++ b/kernel/Vulkan-Loader/DEPENDS
@@ -3,3 +3,4 @@ depends libXrandr
 depends python-lxml
 depends cmake
 depends Vulkan-Headers
+depends spirv-headers


### PR DESCRIPTION
Vulkan-Loader looks like need spirv-headers,just let CI make a test.