### PR TITLE
kexec-tools: version bumped to 2.0.28 + new patch

### DIFF
--- a/utils/kexec-tools/DETAILS
+++ b/utils/kexec-tools/DETAILS
@@ -1,12 +1,12 @@
           MODULE=kexec-tools
-         VERSION=2.0.26
+         VERSION=2.0.28
           SOURCE=${MODULE}-${VERSION}.tar.xz
       SOURCE_URL=http://kernel.org/pub/linux/utils/kernel/kexec/
 SOURCE_DIRECTORY=$BUILD_DIRECTORY/$MODULE-$VERSION
-      SOURCE_VFY=sha256:7fe36a064101cd5c515e41b2be393dce3ca88adce59d6ee668e0af7c0c4570cd
+      SOURCE_VFY=sha256:d2f0ef872f39e2fe4b1b01feb62b0001383207239b9f8041f98a95564161d053
         WEB_SITE=http://kernel.org/pub/linux/utils/kernel/kexec/README.html
          ENTERED=20070716
-         UPDATED=20230816
+         UPDATED=20240429
            SHORT="Execute (boot) a new linux kernel from within one"
 cat << EOF
 kexec is a set of systems call that allows you to load another kernel

--- a/utils/kexec-tools/patch.d/kexec-tools-binutils_2.42_fix.patch
+++ b/utils/kexec-tools/patch.d/kexec-tools-binutils_2.42_fix.patch
@@ -1,0 +1,50 @@
+`binutils-2.42` introduced stricter checks on what `.arch` can be used
+in 64-bit mode and started failing the build as:
+
+    $ as-2.42 --64 -o entry32-16-debug.o entry32-16-debug.s
+    purgatory/arch/i386/entry32-16-debug.S: Assembler messages:
+    purgatory/arch/i386/entry32-16-debug.S:28: Error: 64bit mode not supported on `i386'.
+
+The change moves `.code32` before `.arch 386` as suggested in
+https://sourceware.org/PR31319
+
+Signed-off-by: Sergei Trofimovich <slyich@gmail.com>
+---
+ purgatory/arch/i386/entry32-16-debug.S | 2 +-
+ purgatory/arch/i386/entry32-16.S       | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/purgatory/arch/i386/entry32-16-debug.S b/purgatory/arch/i386/entry32-16-debug.S
+index 5167944..297d6f5 100644
+--- a/purgatory/arch/i386/entry32-16-debug.S
++++ b/purgatory/arch/i386/entry32-16-debug.S
+@@ -25,10 +25,10 @@
+ 	.globl entry16_debug_pre32
+ 	.globl entry16_debug_first32
+ 	.globl entry16_debug_old_first32
++	.code32
+ 	.arch i386
+ 	.balign 16
+ entry16_debug:
+-	.code32
+ 	/* Compute where I am running at (assumes esp valid) */
+ 	call	1f
+ 1:	popl	%ebx
+diff --git a/purgatory/arch/i386/entry32-16.S b/purgatory/arch/i386/entry32-16.S
+index c051aab..7a84565 100644
+--- a/purgatory/arch/i386/entry32-16.S
++++ b/purgatory/arch/i386/entry32-16.S
+@@ -20,10 +20,10 @@
+ #undef i386	
+ 	.text
+ 	.globl entry16, entry16_regs
++	.code32
+ 	.arch i386
+ 	.balign 16
+ entry16:
+-	.code32
+ 	/* Compute where I am running at (assumes esp valid) */
+ 	call	1f
+ 1:	popl	%ebx
+-- 
+2.43.0


### PR DESCRIPTION
The build was failing with:

purgatory/arch/i386/entry32-16.S:23: Error: 64bit mode not supported on `i386'.