### PR TITLE
zfs: Version bumped to 2.2.4

### DIFF
--- a/filesys/zfs-utils/DETAILS
+++ b/filesys/zfs-utils/DETAILS
@@ -1,14 +1,14 @@
           MODULE=zfs-utils
-         VERSION=2.2.3
+         VERSION=2.2.4
           SOURCE=zfs-$VERSION.tar.gz
 SOURCE_DIRECTORY=$BUILD_DIRECTORY/zfs-$VERSION
       SOURCE_URL=https://github.com/openzfs/zfs/releases/download/zfs-$VERSION/
-      SOURCE_VFY=sha256:30a512f34ec5c841b8b2b32cc9c1a03fd49391b26c9164d3fb30573fb5d81ac3
+      SOURCE_VFY=sha256:9790905f7683d41759418e1ef3432828c31116654ff040e91356ff1c21c31ec0
       MAINTAINER=ratler@lunar-linux.org
         WEB_SITE=http://zfsonlinux.org/
          LICENSE=cddl
          ENTERED=20130212
-         UPDATED=20240224
+         UPDATED=20240505
            SHORT="The ZFS file system utilities"
 
 cat << EOF

--- a/filesys/zfs/DETAILS
+++ b/filesys/zfs/DETAILS
@@ -1,13 +1,13 @@
           MODULE=zfs
-         VERSION=2.2.3
+         VERSION=2.2.4
           SOURCE=$MODULE-$VERSION.tar.gz
       SOURCE_URL=https://github.com/openzfs/zfs/releases/download/zfs-$VERSION/
-      SOURCE_VFY=sha256:30a512f34ec5c841b8b2b32cc9c1a03fd49391b26c9164d3fb30573fb5d81ac3
+      SOURCE_VFY=sha256:9790905f7683d41759418e1ef3432828c31116654ff040e91356ff1c21c31ec0
         WEB_SITE=http://zfsonlinux.org/
       MAINTAINER=ratler@lunar-linux.org
          LICENSE=cddl
          ENTERED=20130212
-         UPDATED=20240224
+         UPDATED=20240505
            SHORT="The ZFS file system"
 
 cat << EOF


### PR DESCRIPTION
This includes support for Linux 6.8 kernels, so it'll be nice for it to work with a recent daily ISO