### PR TITLE
httpd: version bumped to 2.4.60

### DIFF
--- a/web/httpd/DETAILS
+++ b/web/httpd/DETAILS
@@ -1,11 +1,11 @@
           MODULE=httpd
-         VERSION=2.4.59
+         VERSION=2.4.60
           SOURCE=$MODULE-$VERSION.tar.bz2
       SOURCE_URL=http://dlcdn.apache.org/httpd/
-      SOURCE_VFY=sha256:ec51501ec480284ff52f637258135d333230a7d229c3afa6f6c2f9040e321323
+      SOURCE_VFY=sha256:7b1ec7ec5635da7cb01550513215a90f8b2f52bb7c90cf3e97ede936d3e55b0f
         WEB_SITE=http://www.apache.org
          ENTERED=20020710
-         UPDATED=20240404
+         UPDATED=20240701
            SHORT="A popular HTTP server"
 
 cat << EOF


### PR DESCRIPTION
Fixes [CVE-2024-36387](https://www.cve.org/CVERecord?id=CVE-2024-36387), [CVE-2024-38472](https://www.cve.org/CVERecord?id=CVE-2024-38472), [CVE-2024-38473](https://www.cve.org/CVERecord?id=CVE-2024-38473), [CVE-2024-38474](https://www.cve.org/CVERecord?id=CVE-2024-38474), [CVE-2024-38475](https://www.cve.org/CVERecord?id=CVE-2024-38475), [CVE-2024-38477](https://www.cve.org/CVERecord?id=CVE-2024-38477) and [CVE-2024-39573](https://www.cve.org/CVERecord?id=CVE-2024-39573)