### PR TITLE
httpd: version bumped to 2.4.61

### DIFF
--- a/web/httpd/DETAILS
+++ b/web/httpd/DETAILS
@@ -1,11 +1,11 @@
           MODULE=httpd
-         VERSION=2.4.60
+         VERSION=2.4.61
           SOURCE=$MODULE-$VERSION.tar.bz2
       SOURCE_URL=http://dlcdn.apache.org/httpd/
-      SOURCE_VFY=sha256:7b1ec7ec5635da7cb01550513215a90f8b2f52bb7c90cf3e97ede936d3e55b0f
+      SOURCE_VFY=sha256:ea8ba86fd95bd594d15e46d25ac5bbda82ae0c9122ad93998cc539c133eaceb6
         WEB_SITE=http://www.apache.org
          ENTERED=20020710
-         UPDATED=20240701
+         UPDATED=20240704
            SHORT="A popular HTTP server"
 
 cat << EOF


### PR DESCRIPTION
Fixes [CVE-2024-39884](https://www.cve.org/CVERecord?id=CVE-2024-39884)