### PR TITLE
alsa-utils: Bump to 1.2.12. Add switches --disable-rst2man and

### DIFF
--- a/audio/alsa-utils/BUILD
+++ b/audio/alsa-utils/BUILD
@@ -7,7 +7,9 @@ if module_installed systemd; then
 fi
 
 OPTS+=" --exec-prefix=/usr \
-        --disable-alsaconf"
+        --disable-alsaconf \
+        --disable-rst2man  \
+        --disable-xmlto"
 
 default_build &&
 

--- a/audio/alsa-utils/DEPENDS
+++ b/audio/alsa-utils/DEPENDS
@@ -6,5 +6,3 @@ depends psmisc
 optional_depends fftw "" "" "for alsabat install"
 
 optional_depends libsamplerate "" "" "for sample rate converter support"
-
-optional_depends xmlto "" "--disable-xmlto" "generate the man pages with xmlto"

--- a/audio/alsa-utils/DETAILS
+++ b/audio/alsa-utils/DETAILS
@@ -1,11 +1,11 @@
           MODULE=alsa-utils
-         VERSION=1.2.11
+         VERSION=1.2.12
           SOURCE=$MODULE-$VERSION.tar.bz2
       SOURCE_URL=https://www.alsa-project.org/files/pub/utils/
-      SOURCE_VFY=sha256:9ac6ca3a883f151e568dcf979b8d2e5cbecc51b819bb0e6bb8a2e9b34cc428a7
+      SOURCE_VFY=sha256:98bc6677d0c0074006679051822324a0ab0879aea558a8f68b511780d30cd924
         WEB_SITE=https://www.alsa-project.org
          ENTERED=20010922
-         UPDATED=20240130
+         UPDATED=20240707
            SHORT="Utilities for Advanced Linux Sound Architecture"
 
 cat << EOF


### PR DESCRIPTION
--disable-xmlto to BUILD and removing xmlto optional_depends.