### PR TITLE
python-psutil: Bump to 6.0.0. Since CI currently doesn't want to pull…

### DIFF
--- a/python/python-psutil/DEPENDS
+++ b/python/python-psutil/DEPENDS
@@ -1,2 +1,6 @@
 depends procps
+depends python-setuptools
+depends python-toml
+depends python-build
+depends python-installer
 depends python-wheel

--- a/python/python-psutil/DETAILS
+++ b/python/python-psutil/DETAILS
@@ -1,12 +1,12 @@
           MODULE=python-psutil
-         VERSION=5.9.8
+         VERSION=6.0.0
           SOURCE=$MODULE-${VERSION}.tar.gz
  SOURCE_URL_FULL=https://github.com/giampaolo/psutil/archive/release-${VERSION}.tar.gz
-      SOURCE_VFY=sha256:962fbb077209fda6416046b704b51ed17a61edde41a4573886640026e2c53bae
+      SOURCE_VFY=sha256:187588c10ff4804b91e0c947d6b1a4006dbb633261c0f869865de518603c5d5e
 SOURCE_DIRECTORY=$BUILD_DIRECTORY/psutil-release-${VERSION}
         WEB_SITE=https://github.com/giampaolo/psutil/
          ENTERED=20200524
-         UPDATED=20240205
+         UPDATED=20240711
            SHORT="A cross-platform process and system utilities module for Python"
 
 cat << EOF


### PR DESCRIPTION
… in some

depends, lets try a more pedantic list of depends.