### PR TITLE
rustc: Adding a config.toml. Started with libopenraw failing on;

### DIFF
--- a/compilers/rustc/BUILD
+++ b/compilers/rustc/BUILD
@@ -1,4 +1,6 @@
-export PYTHONDONTWRITEBYTECODE=1 &&
+export PYTHONDONTWRITEBYTECODE=1
+export LIBSSH2_SYS_USE_PKG_CONFIG=1
+export LIBSQLITE3_SYS_USE_PKG_CONFIG=1
 
 ./configure --build=$BUILD \
             --prefix=/usr \
@@ -9,7 +11,7 @@ export PYTHONDONTWRITEBYTECODE=1 &&
             --disable-debug \
             --enable-extended &&
 
-sedit 's:#download-ci-llvm = "if-available":download-ci-llvm = false:' config.toml &&
+cp $SCRIPT_DIRECTORY/config.toml . &&
 
 CARGO_BUILD_JOBS="${MAKES:-1}"
 python3 ./x.py build --jobs $CARGO_BUILD_JOBS &&
@@ -17,4 +19,4 @@ make ${MAKES:+-j$MAKES} &&
 
 prepare_install &&
 
-python ./x.py install -v
+python ./x.py install  --stage=1 -v

--- a/compilers/rustc/BUILD
+++ b/compilers/rustc/BUILD
@@ -1,6 +1,5 @@
 export PYTHONDONTWRITEBYTECODE=1
 export LIBSSH2_SYS_USE_PKG_CONFIG=1
-export LIBSQLITE3_SYS_USE_PKG_CONFIG=1
 
 ./configure --build=$BUILD \
             --prefix=/usr \

--- a/compilers/rustc/DETAILS
+++ b/compilers/rustc/DETAILS
@@ -6,7 +6,7 @@
         SOURCE_VFY=sha256:172ecf3c7d1f9d9fb16cd2a628869782670416ded0129e524a86751f961448c0
           WEB_SITE=https://www.rust-lang.org/
            ENTERED=20150916
-           UPDATED=20240617
+           UPDATED=20240713
              SHORT="Rust language compiler"
              BUILD=${BUILD/pc/unknown}
 

--- a/compilers/rustc/config.toml
+++ b/compilers/rustc/config.toml
@@ -1,0 +1,53 @@
+# see config.toml.example for more possible options
+
+# Tell x.py the editors have reviewed the content of this file
+# and updated it to follow the major changes of the building system,
+# so x.py will not warn us to do such a review.
+change-id = 123711
+
+[llvm]
+# by default, rust will build for a myriad of architectures
+targets = "X86"
+download-ci-llvm = false
+ninja = true
+
+# When using system llvm prefer shared libraries
+link-shared = true
+
+[build]
+# omit docs to save time and space (default is to build them)
+docs = false
+compiler-docs = false
+
+# install extended tools: cargo, clippy, etc
+extended = true
+
+# Do not query new versions of dependencies online.
+locked-deps = true
+
+# Use the source code shipped in the tarball for the dependencies.
+# The combination of this and the "locked-deps" entry avoids downloading
+# many crates from Internet, and makes the Rustc build more stable.
+vendor = true
+
+[install]
+prefix = "/usr"
+docdir = "share/doc/rustc"
+
+[rust]
+channel = "stable"
+description = "for Lunar-Linux"
+optimize = true
+# Enable the same optimizations as the official upstream build.
+lto = "thin"
+codegen-units = 1
+
+[target.x86_64-unknown-linux-gnu]
+# NB the output of llvm-config (i.e. help options) may be
+# dumped to the screen when config.toml is parsed.
+llvm-config = "/usr/bin/llvm-config"
+
+[target.i686-unknown-linux-gnu]
+# NB the output of llvm-config (i.e. help options) may be
+# dumped to the screen when config.toml is parsed.
+llvm-config = "/usr/bin/llvm-config"


### PR DESCRIPTION
error[E0635]: unknown feature `stdsimd`

The sedit that was in BUILD about download-ci-llvm is now in config.toml. Additionally seems we were not actually using stable. The locked-deps and vendor entries puts us on stable.

Anyway, fixes libopenraw.