### PR TITLE
fluxbox: make NLS support optional

### DIFF
--- a/x11-wm/fluxbox/BUILD
+++ b/x11-wm/fluxbox/BUILD
@@ -1,4 +1,8 @@
-OPTS+=" --enable-nls" &&
+if [ "$WITH_NLS" == "y" ]; then
+  OPTS+=" --enable-nls"
+else
+  OPTS+=" --disable-nls"
+fi &&
 
 default_build &&
 

--- a/x11-wm/fluxbox/CONFIGURE
+++ b/x11-wm/fluxbox/CONFIGURE
@@ -1,0 +1,1 @@
+mquery WITH_NLS "Do you want native language support?" y


### PR DESCRIPTION
I was getting this error:

\+ running "default_make"
./src/defaults_tmp.cc ./src/defaults.cc differ: byte 224, line 9
make  all-recursive
make[1]: Entering directory '/usr/src/fluxbox-1.3.7'
Making all in nls/C
make[2]: Entering directory '/usr/src/fluxbox-1.3.7/nls/C'
conversion modules not available
make[2]: *** [Makefile:465: fluxbox.cat] Error 1
make[2]: Leaving directory '/usr/src/fluxbox-1.3.7/nls/C'
make[1]: *** [Makefile:4701: all-recursive] Error 1
make[1]: Leaving directory '/usr/src/fluxbox-1.3.7'
make: *** [Makefile:1599: all] Error 2
Creating /var/log/lunar/compile/fluxbox-1.3.7.xz 
! Problem detected during BUILD

Disabling NLS support fixed it.