### PR TITLE
mongodb: Bump to 7.0.12. Removed boost from depends, current version …

### DIFF
--- a/sql/mongodb/BUILD
+++ b/sql/mongodb/BUILD
@@ -1,27 +1,25 @@
 add_priv_user mongodb:mongodb -d /var/lib/mongodb -s /usr/bin/false &&
 
-OPTS+=" --use-system-boost \
-        --use-system-pcre \
-        --use-system-yaml \
-        --use-system-zlib \
-        --use-system-snappy\
-        --disable-warnings-as-errors"
+_opts+=" --use-system-pcre2 
+         --use-system-yaml
+         --use-system-zlib
+         --use-system-snappy
+         --disable-warnings-as-errors
+         --use-system-stemmer
+         --use-system-zstd
+         --use-system-mongo-c
+         --use-system-tcmalloc
+         --use-system-libunwind
+         --ssl
+         --runtime-hardening=off
+         MONGO_VERSION=$VERSION"
 
-if [[ "$(arch)" =~ ^i.86$ ]]; then
-  # WiredTiger must be disabled manually when building for i686
-  OPTS+=" --wiredtiger=off"
-fi
-
-scons -j${MAKES:=1} core tools $OPTS &&
-
-# Due to a dependency bug in the SConstructs the installation may fail when the
-# install directory is a parent of the build directory (eg installing in /usr and building in /usr/src).
-# We temporarily install into $SOURCE_DIRECTORY/__mongodb and copy it to /usr as a workaround.
-scons -j${MAKES:=1} install --prefix=$SOURCE_DIRECTORY/__mongodb --nostrip $OPTS &&
+python3 buildscripts/scons.py $_opts install-devcore &&
 
 prepare_install &&
-
-cp -rf --remove-destination $SOURCE_DIRECTORY/__mongodb/* /usr/ &&
+install -D build/install/bin/mongo /usr/bin/mongo &&
+install -D build/install/bin/mongod /usr/bin/mongod &&
+install -D build/install/bin/mongos /usr/bin/mongos &&
 
 if [ ! -f /etc/mongodb.conf ]; then
   install -m 644 $SCRIPT_DIRECTORY/mongodb.conf /etc/mongodb.conf

--- a/sql/mongodb/DEPENDS
+++ b/sql/mongodb/DEPENDS
@@ -7,6 +7,7 @@ depends snappy
 depends mongo-c-driver
 depends yaml-cpp
 depends rpds-py
+depends snowballstemmer
 depends python-jsonschema
 depends python-yaml
 depends python-cheetah3

--- a/sql/mongodb/DEPENDS
+++ b/sql/mongodb/DEPENDS
@@ -1,29 +1,21 @@
 depends readline
 depends ncurses
 depends scons
-depends boost
+depends gperftools
 depends pcre
 depends snappy
+depends mongo-c-driver
 depends yaml-cpp
-depends python2-yaml
-depends python2-cheetah
-depends python2-regex
-depends python2-typing
+depends rpds-py
+depends python-jsonschema
+depends python-yaml
+depends python-cheetah3
+depends python-regex
+depends python-typing
+depends python-pymongo
 depends zlib
-
-optional_depends libpcap "" "" "for building mongosniff"
-
-optional_depends snappy  \
-                 "--use-system-snappy" "" \
-                 "for snappy comp/decomp library support"
-
-optional_depends yaml-cpp \
-                 "--use-system-yaml" "" \
-                 "for YAML parser support"
-
-optional_depends %OSSL \
-                 "--ssl" "" \
-                 "for SSL support"
+depends %OSSL
+depends libpcap
 
 optional_depends cyrus-sasl \
                  "--use-sasl-client" "" \

--- a/sql/mongodb/DEPENDS
+++ b/sql/mongodb/DEPENDS
@@ -7,7 +7,7 @@ depends snappy
 depends mongo-c-driver
 depends yaml-cpp
 depends rpds-py
-depends snowballstemmer
+depends snowball
 depends python-jsonschema
 depends python-yaml
 depends python-cheetah3

--- a/sql/mongodb/DETAILS
+++ b/sql/mongodb/DETAILS
@@ -1,12 +1,12 @@
           MODULE=mongodb
-         VERSION=4.0.12
-          SOURCE=$MODULE-src-r$VERSION.tar.gz
-      SOURCE_URL=http://downloads.mongodb.org/src
-SOURCE_DIRECTORY=$BUILD_DIRECTORY/$MODULE-src-r$VERSION
-      SOURCE_VFY=sha256:2132def2478c7d45b028a9b79db346a19f9c56f456b52c0ff243982c89c20dc9
+         VERSION=7.0.12
+          SOURCE=$MODULE-r$VERSION.tar.gz
+ SOURCE_URL_FULL=https://github.com/mongodb/mongo/archive/refs/tags/r$VERSION.tar.gz
+      SOURCE_VFY=sha256:267a396bd8ab6a114c932e9cb2c65565d3556852473015c88ffddda3693b25c3
+SOURCE_DIRECTORY=$BUILD_DIRECTORY/mongo-r$VERSION
         WEB_SITE=http://www.mongodb.org/
          ENTERED=20101205
-         UPDATED=20190821
+         UPDATED=20240723
            SHORT="A scalable, high-performance, key-values, document-oriented database"
 
 cat << EOF

--- a/sql/mongodb/PRE_BUILD
+++ b/sql/mongodb/PRE_BUILD
@@ -1,4 +1,0 @@
-default_pre_build &&
-
-# Broken tls13 support, removing to fix build
-sedit '/counts.tls13/d' src/mongo/util/net/ssl_manager_openssl.cpp

--- a/sql/mongodb/patch.d/extrapatch-sconstruct.patch
+++ b/sql/mongodb/patch.d/extrapatch-sconstruct.patch
@@ -1,0 +1,16 @@
+--- a/SConstruct
++++ b/SConstruct
+@@ -3217,8 +3205,12 @@ if not env.TargetOSIs('windows', 'macOS') and (env.Too
+     # setting it for both C and C++ by setting both of CFLAGS and
+     # CXXFLAGS.
+ 
++    arm_march_flag = "armv8-a"
++    if get_option('use-hardware-crc32') == "on":
++        arm_march_flag += "+crc"
++
+     default_targeting_flags_for_architecture = {
+-        "aarch64": {"-march=": "armv8.2-a", "-mtune=": "generic"},
++        "aarch64": {"-march=": arm_march_flag, "-mtune=": "generic"},
+         "i386": {"-march=": "nocona", "-mtune=": "generic"},
+         "ppc64le": {"-mcpu=": "power8", "-mtune=": "power8", "-mcmodel=": "medium"},
+         "s390x": {"-march=": "z196", "-mtune=": "zEC12"},

--- a/sql/mongodb/patch.d/mongodb-4.4.29-no-enterprise.patch
+++ b/sql/mongodb/patch.d/mongodb-4.4.29-no-enterprise.patch
@@ -1,0 +1,24 @@
+ buildscripts/moduleconfig.py | 3 ---
+ 1 file changed, 3 deletions(-)
+
+diff --git a/buildscripts/moduleconfig.py b/buildscripts/moduleconfig.py
+index b4d0bba0490..03541fab940 100644
+--- a/buildscripts/moduleconfig.py
++++ b/buildscripts/moduleconfig.py
+@@ -27,7 +27,6 @@ MongoDB SConscript files do.
+ __all__ = ('discover_modules', 'discover_module_directories', 'configure_modules',
+            'register_module_test')  # pylint: disable=undefined-all-variable
+ 
+-import imp
+ import inspect
+ import os
+ 
+@@ -71,8 +70,6 @@ def discover_modules(module_root, allowed_modules):
+             print("adding module: %s" % (name))
+             fp = open(build_py, "r")
+             try:
+-                module = imp.load_module("module_" + name, fp, build_py,
+-                                         (".py", "r", imp.PY_SOURCE))
+                 if getattr(module, "name", None) is None:
+                     module.name = name
+                 found_modules.append(module)

--- a/sql/mongodb/patch.d/mongodb-5.0.2-no-compass.patch
+++ b/sql/mongodb/patch.d/mongodb-5.0.2-no-compass.patch
@@ -1,0 +1,12 @@
+diff --git a/src/mongo/installer/SConscript b/src/mongo/installer/SConscript
+index 5bd89fe9..489e70ac 100644
+--- a/src/mongo/installer/SConscript
++++ b/src/mongo/installer/SConscript
+@@ -7,7 +7,6 @@ env = env.Clone()
+ 
+ env.SConscript(
+     dirs=[
+-        'compass',
+         'msi',
+     ],
+     exports=[

--- a/sql/mongodb/patch.d/mongodb-5.0.2-skip-reqs-check.patch
+++ b/sql/mongodb/patch.d/mongodb-5.0.2-skip-reqs-check.patch
@@ -1,0 +1,24 @@
+diff --git a/buildscripts/scons.py b/buildscripts/scons.py
+index 534fca32..c38f64df 100755
+--- a/buildscripts/scons.py
++++ b/buildscripts/scons.py
+@@ -19,13 +19,13 @@ SITE_TOOLS_DIR = os.path.join(MONGODB_ROOT, 'site_scons')
+ sys.path = [SCONS_DIR, SITE_TOOLS_DIR] + sys.path
+ 
+ # pylint: disable=C0413
+-from mongo.pip_requirements import verify_requirements, MissingRequirements
++#from mongo.pip_requirements import verify_requirements, MissingRequirements
+ 
+-try:
+-    verify_requirements('etc/pip/compile-requirements.txt')
+-except MissingRequirements as ex:
+-    print(ex)
+-    sys.exit(1)
++#try:
++#    verify_requirements('etc/pip/compile-requirements.txt')
++#except MissingRequirements as ex:
++#    print(ex)
++#    sys.exit(1)
+ 
+ try:
+     import SCons.Script

--- a/sql/mongodb/patch.d/mongodb-7.0.2-sconstruct.patch
+++ b/sql/mongodb/patch.d/mongodb-7.0.2-sconstruct.patch
@@ -1,0 +1,159 @@
+diff --git a/SConstruct b/SConstruct
+index 92d557b..80ee9e8 100644
+--- a/SConstruct
++++ b/SConstruct
+@@ -23,7 +23,6 @@ from pkg_resources import parse_version
+ 
+ import SCons
+ import SCons.Script
+-from mongo_tooling_metrics.lib.top_level_metrics import SConsToolingMetrics
+ from site_scons.mongo import build_profiles
+ 
+ # This must be first, even before EnsureSConsVersion, if
+@@ -1649,13 +1648,6 @@ env.AddMethod(lambda env, name, **kwargs: add_option(name, **kwargs), 'AddOption
+ 
+ # The placement of this is intentional. Here we setup an atexit method to store tooling metrics.
+ # We should only register this function after env, env_vars and the parser have been properly initialized.
+-SConsToolingMetrics.register_metrics(
+-    utc_starttime=datetime.utcnow(),
+-    artifact_dir=env.Dir('$BUILD_DIR').get_abspath(),
+-    env_vars=env_vars,
+-    env=env,
+-    parser=_parser,
+-)
+ 
+ if get_option('build-metrics'):
+     env['BUILD_METRICS_ARTIFACTS_DIR'] = '$BUILD_ROOT/$VARIANT_DIR'
+@@ -3026,7 +3018,6 @@ if env.TargetOSIs('posix'):
+     env.Append(
+         CCFLAGS=[
+             "-fasynchronous-unwind-tables",
+-            "-g2" if not env.TargetOSIs('emscripten') else "-g",
+             "-Wall",
+             "-Wsign-compare",
+             "-Wno-unknown-pragmas",
+@@ -3093,6 +3084,8 @@ if env.TargetOSIs('posix'):
+ 
+     # env.Append( " -Wconversion" ) TODO: this doesn't really work yet
+     env.Append(CXXFLAGS=["-Woverloaded-virtual"])
++    env.Append(CXXFLAGS=os.environ['CXXFLAGS'])
++    env.Append(LINKFLAGS=os.environ['LDFLAGS'])
+ 
+     # On OS X, clang doesn't want the pthread flag at link time, or it
+     # issues warnings which make it impossible for us to declare link
+@@ -3143,7 +3136,7 @@ if env.TargetOSIs('posix'):
+         ], )
+ 
+     #make scons colorgcc friendly
+-    for key in ('HOME', 'TERM'):
++    for key in ('HOME', 'TERM', 'PATH'):
+         try:
+             env['ENV'][key] = os.environ[key]
+         except KeyError:
+@@ -3543,33 +3536,6 @@ def doConfigure(myenv):
+         myenv.AddMethod(
+             functools.partial(var_func, var=var, func=CheckFlag), f"Check{var}Supported")
+ 
+-    if myenv.ToolchainIs('gcc', 'clang'):
+-        # This tells clang/gcc to use the gold linker if it is available - we prefer the gold linker
+-        # because it is much faster. Don't use it if the user has already configured another linker
+-        # selection manually.
+-        if any(flag.startswith('-fuse-ld=') for flag in env['LINKFLAGS']):
+-            myenv.FatalError(
+-                f"Use the '--linker' option instead of modifying the LINKFLAGS directly.")
+-
+-        linker_ld = get_option('linker')
+-        if linker_ld == 'auto':
+-            if not env.TargetOSIs('darwin', 'macOS'):
+-                if not myenv.AddToLINKFLAGSIfSupported('-fuse-ld=lld'):
+-                    myenv.FatalError(
+-                        f"The recommended linker 'lld' is not supported with the current compiler configuration, you can try the 'gold' linker with '--linker=gold'."
+-                    )
+-        elif link_model.startswith("dynamic") and linker_ld == 'bfd':
+-            # BFD is not supported due to issues with it causing warnings from some of
+-            # the third party libraries that mongodb is linked with:
+-            # https://jira.mongodb.org/browse/SERVER-49465
+-            myenv.FatalError(f"Linker {linker_ld} is not supported with dynamic link model builds.")
+-        else:
+-            if not myenv.AddToLINKFLAGSIfSupported(f'-fuse-ld={linker_ld}'):
+-                myenv.FatalError(f"Linker {linker_ld} could not be configured.")
+-
+-        if has_option('gcov') and myenv.AddToCCFLAGSIfSupported('-fprofile-update=single'):
+-            myenv.AppendUnique(LINKFLAGS=['-fprofile-update=single'])
+-
+     detectCompiler = Configure(
+         myenv,
+         help=False,
+@@ -4621,43 +4587,6 @@ def doConfigure(myenv):
+     if optBuild == "off" and myenv.ToolchainIs('clang') and env.TargetOSIs('darwin'):
+         myenv.AddToLINKFLAGSIfSupported("-Wl,-no_deduplicate")
+ 
+-    # Apply any link time optimization settings as selected by the 'lto' option.
+-    if has_option('lto'):
+-        if myenv.ToolchainIs('msvc'):
+-            # Note that this is actually more aggressive than LTO, it is whole program
+-            # optimization due to /GL. However, this is historically what we have done for
+-            # windows, so we are keeping it.
+-            #
+-            # /GL implies /LTCG, so no need to say it in CCFLAGS, but we do need /LTCG on the
+-            # link flags.
+-            myenv.Append(CCFLAGS=['/GL'])
+-            myenv.Append(LINKFLAGS=['/LTCG'])
+-            myenv.Append(ARFLAGS=['/LTCG'])
+-        elif myenv.ToolchainIs('gcc', 'clang'):
+-            # For GCC and clang, the flag is -flto, and we need to pass it both on the compile
+-            # and link lines.
+-            if not myenv.AddToCCFLAGSIfSupported('-flto') or \
+-                    not myenv.AddToLINKFLAGSIfSupported('-flto'):
+-                myenv.ConfError("Link time optimization requested, "
+-                                "but selected compiler does not honor -flto")
+-
+-            if myenv.TargetOSIs('darwin'):
+-                myenv.AddToLINKFLAGSIfSupported('-Wl,-object_path_lto,${TARGET}.lto')
+-            else:
+-                # According to intel benchmarks -fno-plt increases perf
+-                # See PM-2215
+-                if linker_ld != "gold":
+-                    myenv.ConfError("lto compilation currently only works with the --linker=gold")
+-                if link_model != "object":
+-                    myenv.ConfError(
+-                        "lto compilation currently only works with the --link-model=object")
+-                if not myenv.AddToCCFLAGSIfSupported('-fno-plt') or \
+-                    not myenv.AddToLINKFLAGSIfSupported('-fno-plt'):
+-                    myenv.ConfError("-fno-plt is not supported by the compiler")
+-
+-        else:
+-            myenv.ConfError("Don't know how to enable --lto on current toolchain")
+-
+     if get_option('runtime-hardening') == "on" and optBuild != "off":
+         # Older glibc doesn't work well with _FORTIFY_SOURCE=2. Selecting 2.11 as the minimum was an
+         # emperical decision, as that is the oldest non-broken glibc we seem to require. It is possible
+@@ -5120,17 +5049,13 @@ def doConfigure(myenv):
+         "BOOST_LOG_NO_SHORTHAND_NAMES",
+         "BOOST_LOG_USE_NATIVE_SYSLOG",
+         "BOOST_LOG_WITHOUT_THREAD_ATTR",
++        "BOOST_LOG_DYN_LINK",
+         "BOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS",
+         "BOOST_SYSTEM_NO_DEPRECATED",
+         "BOOST_THREAD_USES_DATETIME",
+         ("BOOST_THREAD_VERSION", "5"),
+     ])
+ 
+-    if link_model.startswith("dynamic") and not link_model == 'dynamic-sdk':
+-        conf.env.AppendUnique(CPPDEFINES=[
+-            "BOOST_LOG_DYN_LINK",
+-        ])
+-
+     if use_system_version_of_library("boost"):
+         if not conf.CheckCXXHeader("boost/filesystem/operations.hpp"):
+             myenv.ConfError("can't find boost headers")
+@@ -5327,6 +5252,9 @@ def doConfigure(myenv):
+ 
+     mongoc_mode = get_option('use-system-mongo-c')
+     conf.env['MONGO_HAVE_LIBMONGOC'] = False
++    conf.env.ParseConfig('pkg-config libbson-1.0 libmongoc-1.0 --cflags')
++    conf.env['LIBDEPS_LIBBSON_SYSLIBDEP'] = 'bson-1.0'
++
+     if mongoc_mode != 'off':
+         if conf.CheckLibWithHeader(
+             ["mongoc-1.0"],


### PR DESCRIPTION
…removes

boost/filesystem/convenience.hpp and needed by mongo. Till then we will use their version.