### PR TITLE
bind/bind-utils: version bumped to 9.18.28

### DIFF
--- a/net/bind-utils/DETAILS
+++ b/net/bind-utils/DETAILS
@@ -1,12 +1,12 @@
           MODULE=bind-utils
-         VERSION=9.18.27
+         VERSION=9.18.28
           SOURCE=bind-$VERSION.tar.xz
       SOURCE_URL=http://ftp.isc.org/isc/bind9/$VERSION/
-      SOURCE_VFY=sha256:ea3f3d8cfa2f6ae78c8722751d008f54bc17a3aed2be3f7399eb7bf5f4cda8f1
+      SOURCE_VFY=sha256:e7cce9a165f7b619eefc4832f0a8dc16b005d29e3890aed6008c506ea286a5e7
 SOURCE_DIRECTORY=$BUILD_DIRECTORY/bind-$VERSION
         WEB_SITE=http://www.isc.org/products/BIND
          ENTERED=20050513
-         UPDATED=20240516
+         UPDATED=20240727
            SHORT="Collection of BIND related client programs"
 
 cat << EOF

--- a/net/bind/DETAILS
+++ b/net/bind/DETAILS
@@ -1,11 +1,11 @@
-         VERSION=9.18.27
+         VERSION=9.18.28
           SOURCE=bind-$VERSION.tar.xz
       SOURCE_URL=http://ftp.isc.org/isc/bind9/$VERSION/
-      SOURCE_VFY=sha256:ea3f3d8cfa2f6ae78c8722751d008f54bc17a3aed2be3f7399eb7bf5f4cda8f1
+      SOURCE_VFY=sha256:e7cce9a165f7b619eefc4832f0a8dc16b005d29e3890aed6008c506ea286a5e7
 SOURCE_DIRECTORY=$BUILD_DIRECTORY/bind-$VERSION
         WEB_SITE=http://www.isc.org/products/BIND
          ENTERED=20050513
-         UPDATED=20240516
+         UPDATED=20240727
            SHORT="Collection of BIND related client programs"
 PSAFE=no
 cat << EOF


### PR DESCRIPTION
Fixes 4 CVEs:

https://www.cve.org/CVERecord?id=CVE-2024-1975
https://www.cve.org/CVERecord?id=CVE-2024-4076
https://www.cve.org/CVERecord?id=CVE-2024-1737
https://www.cve.org/CVERecord?id=CVE-2024-0760