### PR TITLE
xinput_calibrator: version bumped to 0.8.0

### DIFF
--- a/x11-utils/xinput_calibrator/BUILD
+++ b/x11-utils/xinput_calibrator/BUILD
@@ -1,4 +1,5 @@
 OPTS+=" --with-gui=x11"
 
-./autogen.sh &&
+autoreconf -fi &&
+
 default_build

--- a/x11-utils/xinput_calibrator/DETAILS
+++ b/x11-utils/xinput_calibrator/DETAILS
@@ -1,11 +1,11 @@
           MODULE=xinput_calibrator
-         VERSION=0.7.5
+         VERSION=0.8.0
           SOURCE=$MODULE-$VERSION.tar.gz
- SOURCE_URL_FULL=https://github.com/tias/xinput_calibrator/archive/v$VERSION.tar.gz
-      SOURCE_VFY=sha256:d8edbf84523d60f52311d086a1e3ad0f3536f448360063dd8029bf6290aa65e9
+      SOURCE_URL=https://xorg.freedesktop.org/archive/individual/app/
+      SOURCE_VFY=sha256:dae3b8ce3aaba6f0b1a6262156c6352642bec5661be071312da58cbe4b8174c7
         WEB_SITE=https://www.freedesktop.org/wiki/Software/xinput_calibrator/
          ENTERED=20160324
-         UPDATED=20160324
+         UPDATED=20240731
            SHORT="A generic touchscreen calibration program for X.Org"
 
 cat << EOF


### PR DESCRIPTION
This is from the email I got:

```
This is the first release of xinput_calibrator after the move from
https://github.com/tias/xinput_calibrator to our gitlab instance. The
aim of this move is so this little tool, still in use here and there,
can see some of the benefits of group maintainership and doesn't go
completely stale. Don't expect active maintainership or new features
being added, we're just trying to keep this on life support.

The git shortlog below is for the ~14 years of patches since the 0.7.5
release, the last 10 of which the project was sitting idle.
```

Also the new URL is taken from this email.