### PR TITLE
python-faust-cchardet: Adding. Will a depends for upcoming calibre bump.

### DIFF
--- a/python/python-faust-cchardet/BUILD
+++ b/python/python-faust-cchardet/BUILD
@@ -1,0 +1,5 @@
+export PYTHONDONTWRITEBYTECODE=1
+python -m build --wheel &&
+
+prepare_install &&
+python -m installer --destdir=/ dist/*.whl

--- a/python/python-faust-cchardet/DEPENDS
+++ b/python/python-faust-cchardet/DEPENDS
@@ -1,0 +1,3 @@
+depends python
+depends python-wheel
+depends python-pkgconfig

--- a/python/python-faust-cchardet/DETAILS
+++ b/python/python-faust-cchardet/DETAILS
@@ -1,0 +1,16 @@
+          MODULE=python-faust-cchardet
+         VERSION=2.1.19
+          SOURCE=faust-cchardet-$VERSION.tar.gz
+      SOURCE_URL=https://files.pythonhosted.org/packages/source/f/faust-cchardet/
+      SOURCE_VFY=sha256:f89386297cde0c8e0f5e21464bc2d6d0e4a4fc1b1d77cdb238ca24d740d872e0
+SOURCE_DIRECTORY=$BUILD_DIRECTORY/faust-cchardet-$VERSION
+        WEB_SITE=https://pypi.org/project/faust-cchardet/
+        REPLACES=python-cchardet
+         ENTERED=20240731
+         UPDATED=20240731
+           SHORT="fork of the original project cChardet since the original project is no longer maintained"
+
+cat << EOF
+This is a fork of the original project at https://github.com/PyYoshi/cChardet
+since the original project is no longer maintained.
+EOF


### PR DESCRIPTION
According to https://pypi.org/project/faust-cchardet/ python-cchardet it is no longer maintained. So this module will repace it. Before python-cchardet is removed, will have to wait unti CI updates itself with new modules.