### PR TITLE
gumbo-parser: Bump to 0.12.1. Changed SOURCE_URL and WEB_SITE based 

### DIFF
--- a/web/gumbo-parser/DETAILS
+++ b/web/gumbo-parser/DETAILS
@@ -1,11 +1,12 @@
           MODULE=gumbo-parser
-         VERSION=0.10.1
+         VERSION=0.12.1
           SOURCE=$MODULE-$VERSION.tar.gz
- SOURCE_URL_FULL=https://github.com/google/gumbo-parser/archive/v${VERSION}.tar.gz
-      SOURCE_VFY=sha256:28463053d44a5dfbc4b77bcf49c8cee119338ffa636cc17fc3378421d714efad
-        WEB_SITE=https://github.com/google/gumbo-parser
+ SOURCE_URL_FULL=https://codeberg.org/gumbo-parser/gumbo-parser/archive/$VERSION.tar.gz
+      SOURCE_VFY=sha256:c0bb5354e46539680724d638dbea07296b797229a7e965b13305c930ddc10d82
+SOURCE_DIRECTORY=$BUILD_DIRECTORY/$MODULE
+        WEB_SITE=https://codeberg.org/gumbo-parser/gumbo-parser
          ENTERED=20210113
-         UPDATED=20210113
+         UPDATED=20240731
            SHORT="HTML5 parsing algorithm implemented in pure C99"
 
 cat << EOF


### PR DESCRIPTION
on the the information of the README from the origianl site; https://github.com/google/gumbo-parser/commit/a0f9059087c690e700cf42df4cfa58a63c1dae95