### PR TITLE
boost: Adding a patch (thanks gentoo folks) fixing a compile issue

### DIFF
--- a/libs/boost/DETAILS
+++ b/libs/boost/DETAILS
@@ -6,7 +6,7 @@
 SOURCE_DIRECTORY=$BUILD_DIRECTORY/${MODULE}_${VERSION//./_}
         WEB_SITE=https://www.boost.org
          ENTERED=20041115
-         UPDATED=20240721
+         UPDATED=20240803
            SHORT="A cross-platform supplement to the C++ standard library"
 
 cat << EOF

--- a/libs/boost/patch.d/003-boost-1.85.0-python-numpy-2.patch
+++ b/libs/boost/patch.d/003-boost-1.85.0-python-numpy-2.patch
@@ -1,0 +1,26 @@
+https://bugs.gentoo.org/932459
+https://github.com/boostorg/python/issues/431
+https://github.com/boostorg/python/pull/432
+
+From 33ac06ca59a68266d3d26edf08205d31ddab4a6c Mon Sep 17 00:00:00 2001
+From: Alexis DUBURCQ <alexis.duburcq@gmail.com>
+Date: Fri, 15 Mar 2024 14:10:16 +0100
+Subject: [PATCH] Support numpy 2.0.0b1
+
+--- a/libs/python/src/numpy/dtype.cpp
++++ b/libs/python/src/numpy/dtype.cpp
+@@ -98,7 +98,13 @@ python::detail::new_reference dtype::convert(object const & arg, bool align)
+   return python::detail::new_reference(reinterpret_cast<PyObject*>(obj));
+ }
+ 
+-int dtype::get_itemsize() const { return reinterpret_cast<PyArray_Descr*>(ptr())->elsize;}
++int dtype::get_itemsize() const {
++#if NPY_ABI_VERSION < 0x02000000
++  return reinterpret_cast<PyArray_Descr*>(ptr())->elsize;
++#else
++  return PyDataType_ELSIZE(reinterpret_cast<PyArray_Descr*>(ptr()));
++#endif
++}
+ 
+ bool equivalent(dtype const & a, dtype const & b) {
+     // On Windows x64, the behaviour described on 


### PR DESCRIPTION
dealing with numpy2. Which was the failure with PR#4094 (inkscape).