### PR TITLE
wireless-regdb: version bumped to 2024.07.04 + fix wrong path

### DIFF
--- a/wifi/wireless-regdb/BUILD
+++ b/wifi/wireless-regdb/BUILD
@@ -1,20 +1,13 @@
 prepare_install &&
-make install DESTDIR=/usr MANDIR=/usr/share/man FIRMWARE_PATH=/usr/lib/firmware &&
-
-# Install and verify regulatory.bin file
-echo "Installing the regulatory.bin file"
-install -D -m644 regulatory.bin /usr/lib/crda/regulatory.bin &&
-
-install -D -m644 regulatory.bin.5 /usr/share/man/man5/regulatory.bin.5 &&
-install -D -m644 regulatory.db /usr/lib/firmware/regulatory.db &&
-install -D -m644 regulatory.db.p7s /usr/lib/firmware/regulatory.db.p7s &&
-install -D -m644 regulatory.db.5 /usr/share/man/man5/regulatory.db.5 &&
+make install DESTDIR=/ PREFIX=/usr MANDIR=/usr/share/man \
+  FIRMWARE_PATH=/usr/lib/firmware &&
 
 mkdir -p /etc/conf.d
-if [ -f /etc/conf.d/wireless-regdom ]; then
+if [[ ! -f /etc/conf.d/wireless-regdom ]]; then
   echo "Installing /etc/conf.d/wireless-regdom"
   for dom in $(grep ^country db.txt | cut -d' ' -f2 | sed 's|:||g'); do
      echo "#WIRELESS_REGDOM=\"${dom}\"" >> /etc/conf.d/wireless-regdom.tmp
   done &&
   sort -u /etc/conf.d/wireless-regdom.tmp >> /etc/conf.d/wireless-regdom
+  rm /etc/conf.d/wireless-regdom.tmp
 fi

--- a/wifi/wireless-regdb/DETAILS
+++ b/wifi/wireless-regdb/DETAILS
@@ -1,11 +1,11 @@
           MODULE=wireless-regdb
-         VERSION=2024.01.23
+         VERSION=2024.07.04
           SOURCE=$MODULE-$VERSION.tar.xz
       SOURCE_URL=https://mirrors.edge.kernel.org/pub/software/network/${MODULE}
-      SOURCE_VFY=sha256:c8a61c9acf76fa7eb4239e89f640dee3e87098d9f69b4d3518c9c60fc6d20c55
+      SOURCE_VFY=sha256:9832a14e1be24abff7be30dee3c9a1afb5fdfcf475a0d91aafef039f8d85f5eb
         WEB_SITE=https://wireless.wiki.kernel.org/en/developers/regulatory/${MODULE}/
          ENTERED=20181004
-         UPDATED=20240201
+         UPDATED=20240804
            SHORT="Central Regulatory Domain Database"
 
 cat << EOF


### PR DESCRIPTION
This module was installing in /usr/usr/lib/firmware :P