### PR TITLE
CPU-X: version bumped to 5.0.4

### DIFF
--- a/utils/CPU-X/DETAILS
+++ b/utils/CPU-X/DETAILS
@@ -1,11 +1,12 @@
           MODULE=CPU-X
-         VERSION=5.0.3
+         VERSION=5.0.4
           SOURCE=$MODULE-$VERSION.tar.gz
- SOURCE_URL_FULL=https://github.com/X0rg/CPU-X/archive/v$VERSION.tar.gz
-      SOURCE_VFY=sha256:0d3f862a8734e3b2363880195109fae4e0e22a70a6265dba359e5a88b6ec5ea0
-        WEB_SITE=https://github.com/X0rg/CPU-X/
+ SOURCE_URL_FULL=https://github.com/TheTumultuousUnicornOfDarkness/CPU-X/archive/v$VERSION.tar.gz
+      SOURCE_VFY=sha256:7375e7184656f2630327afb13120e715956a509b40ae0fdb9edb5306638dce21
+        WEB_SITE=https://thetumultuousunicornofdarkness.github.io/CPU-X/
+            TYPE=cmake
          ENTERED=20160201
-         UPDATED=20240119
+         UPDATED=20240805
            SHORT="Gathers information on CPU, motherboard and more"
 
 cat << EOF


### PR DESCRIPTION
The new URL is a Github redirect from the old one. The new website URL is taken from the new Github profile description.