### PR TITLE
fwupd: version bumped to 1.9.23

### DIFF
--- a/utils/fwupd/DETAILS
+++ b/utils/fwupd/DETAILS
@@ -1,12 +1,12 @@
           MODULE=fwupd
-         VERSION=1.9.22
+         VERSION=1.9.23
           SOURCE=$MODULE-$VERSION.tar.gz
- SOURCE_URL_FULL=https://github.com/hughsie/fwupd/archive/$VERSION.tar.gz
-      SOURCE_VFY=sha256:c4889516fac3d840e755315e8351c1e91d663df55e22633adf2cd5de0f260ea9
-        WEB_SITE=https://github.com/hughsie/fwupd
+ SOURCE_URL_FULL=https://github.com/fwupd/fwupd/archive/$VERSION.tar.gz
+      SOURCE_VFY=sha256:d8e015fd76bbc229c58a450693aaf936262ab761c488fa72b94175f54ac4b2d0
+        WEB_SITE=https://github.com/fwupd/fwupd
             TYPE=meson
          ENTERED=20181112
-         UPDATED=20240731
+         UPDATED=20240808
            SHORT="A firmware update utility"
 
 cat << EOF


### PR DESCRIPTION
The new URL is taken from a redirect from the original one.