### PR TITLE
powertop: version bumped to 2.15

### DIFF
--- a/utils/powertop/DETAILS
+++ b/utils/powertop/DETAILS
@@ -1,11 +1,11 @@
           MODULE=powertop
-         VERSION=2.13
+         VERSION=2.15
           SOURCE=$MODULE-$VERSION.tar.gz
- SOURCE_URL_FULL=http://github.com/fenrus75/powertop/archive/v$VERSION.tar.gz
-      SOURCE_VFY=sha256:e490c82dbfa87c98430c16151081fbe86e6f45d8be3dd8c48b89e8868dda85a1
-        WEB_SITE=http://01.org/powertop/
+ SOURCE_URL_FULL=https://github.com/fenrus75/powertop/archive/v$VERSION.tar.gz
+      SOURCE_VFY=sha256:e58ab3fd7b8ff5f4dd0d17f11848817e7d83c0a6918145ac81de03b5dccf8f49
+        WEB_SITE=https://github.com/fenrus75/powertop/
          ENTERED=20070514
-         UPDATED=20200707
+         UPDATED=20240812
            SHORT="Measure power usage on tickless kernels"
 
 cat << EOF

--- a/utils/powertop/PRE_BUILD
+++ b/utils/powertop/PRE_BUILD
@@ -1,6 +1,4 @@
 default_pre_build &&
 
 # https://bugzilla.redhat.com/show_bug.cgi?id=1826935
-autoreconf -fi || autoreconf -fi &&
-
-./autogen.sh
+autoreconf -fi || autoreconf -fi


### PR DESCRIPTION
The old website URL redirects to intel.com, weird.