### PR TITLE
gh: version bumped to 2.55.0

### DIFF
--- a/devel/gh/DETAILS
+++ b/devel/gh/DETAILS
@@ -1,12 +1,12 @@
           MODULE=gh
-         VERSION=2.53.0
-          SOURCE=cli-$VERSION.tar.gz
+         VERSION=2.55.0
+          SOURCE=gh-cli-$VERSION.tar.gz
  SOURCE_URL_FULL=https://github.com/cli/cli/archive/refs/tags/v$VERSION.tar.gz
-      SOURCE_VFY=sha256:5e47d567216b1f63a4939e634f9067c9b60b0852625edf8ad10e1b9be5033cff
-SOURCE_DIRECTORY=$BUILD_DIRECTORY/$MODULE-$VERSION
+      SOURCE_VFY=sha256:f467cfdaedd372a5c20bb0daad017a0b3f75fa25179f1e4dcdc1d01ed59e62a5
+SOURCE_DIRECTORY=$BUILD_DIRECTORY/cli-$VERSION
         WEB_SITE=https://cli.github.com/
          ENTERED=20210423
-         UPDATED=20240801
+         UPDATED=20240823
            SHORT="Official command-line wrapper for GitHub"
 
 cat << EOF

--- a/devel/gh/PRE_BUILD
+++ b/devel/gh/PRE_BUILD
@@ -1,8 +1,5 @@
 default_pre_build &&
 
-# do not use "cli-*" folder name
-tar -x --strip-components=1 -f $SOURCE_CACHE/$SOURCE &&
-
 sedit 's:/usr/local:/usr:' Makefile
 
 export GOPROXY=https://proxy.golang.org


### PR DESCRIPTION
With the previous PRE_BUILD setup there was a leftover directory in /usr/src once lin is finished (cli-2.55.0).