### PR TITLE
opensp: add Gentoo patch for newer clang

### DIFF
--- a/doc-tools/opensp/patch.d/opensp-1.5.2-configure-clang16.patch
+++ b/doc-tools/opensp/patch.d/opensp-1.5.2-configure-clang16.patch
@@ -1,0 +1,198 @@
+https://bugs.gentoo.org/889600
+https://src.fedoraproject.org/rpms/opensp/blob/ad3afd1f07f600aa21cd6a3f1960db5570682e47/f/opensp-configure-c99.patch
+
+Avoid implicit function declarations because they have been removed
+from C in 1999.  Future compilers are likely to reject them by
+default.
+
+No need to upstream this because the aclocal.m4 file is not checked
+into the repository since:
+
+------------------------------------------------------------------------
+r412 | clasen | 1999-11-06 14:10:34 +0100 (Sat, 06 Nov 1999) | 3 lines
+Changed paths:
+   M /trunk/sp/Makefile.in
+   D /trunk/sp/config/aclocal.m4
+   D /trunk/sp/config/configure.in
+   M /trunk/sp/configure
+   A /trunk/sp/configure.in
+
+Install headers in $(includedir)/OpenSP, move configure.in to toplevel,
+remove generated file aclocal.m4.
+
+--- a/aclocal.m4
++++ b/aclocal.m4
+@@ -833,10 +833,6 @@ else
+ #  endif
+ #endif
+ 
+-#ifdef __cplusplus
+-extern "C" void exit (int);
+-#endif
+-
+ void fnord() { int i=42;}
+ int main ()
+ {
+@@ -850,7 +846,7 @@ int main ()
+       /* dlclose (self); */
+     }
+ 
+-    exit (status);
++    return status;
+ }]
+ EOF
+   if AC_TRY_EVAL(ac_link) && test -s conftest${ac_exeext} 2>/dev/null; then
+--- a/configure
++++ b/configure
+@@ -2917,7 +2917,7 @@ if { (eval echo "$as_me:$LINENO: \"$ac_compile\"") >&5
+   echo "$as_me:$LINENO: \$? = $ac_status" >&5
+   (exit $ac_status); }; }; then
+   for ac_declaration in \
+-   '' \
++   '#include <stdlib.h>' \
+    'extern "C" void std::exit (int) throw (); using std::exit;' \
+    'extern "C" void std::exit (int); using std::exit;' \
+    'extern "C" void exit (int) throw ();' \
+@@ -5186,8 +5186,8 @@ main ()
+   for (i = 0; i < 256; i++)
+     if (XOR (islower (i), ISLOWER (i))
+ 	|| toupper (i) != TOUPPER (i))
+-      exit(2);
+-  exit (0);
++      return 2;
++  return 0;
+ }
+ _ACEOF
+ rm -f conftest$ac_exeext
+@@ -9508,10 +9508,6 @@ else
+ #  endif
+ #endif
+ 
+-#ifdef __cplusplus
+-extern "C" void exit (int);
+-#endif
+-
+ void fnord() { int i=42;}
+ int main ()
+ {
+@@ -9525,7 +9521,7 @@ int main ()
+       /* dlclose (self); */
+     }
+ 
+-    exit (status);
++    return status;
+ }
+ EOF
+   if { (eval echo "$as_me:$LINENO: \"$ac_link\"") >&5
+@@ -9606,10 +9602,6 @@ else
+ #  endif
+ #endif
+ 
+-#ifdef __cplusplus
+-extern "C" void exit (int);
+-#endif
+-
+ void fnord() { int i=42;}
+ int main ()
+ {
+@@ -9623,7 +9615,7 @@ int main ()
+       /* dlclose (self); */
+     }
+ 
+-    exit (status);
++    return status;
+ }
+ EOF
+   if { (eval echo "$as_me:$LINENO: \"$ac_link\"") >&5
+@@ -13321,10 +13313,6 @@ else
+ #  endif
+ #endif
+ 
+-#ifdef __cplusplus
+-extern "C" void exit (int);
+-#endif
+-
+ void fnord() { int i=42;}
+ int main ()
+ {
+@@ -13338,7 +13326,7 @@ int main ()
+       /* dlclose (self); */
+     }
+ 
+-    exit (status);
++    return status;
+ }
+ EOF
+   if { (eval echo "$as_me:$LINENO: \"$ac_link\"") >&5
+@@ -13419,10 +13407,6 @@ else
+ #  endif
+ #endif
+ 
+-#ifdef __cplusplus
+-extern "C" void exit (int);
+-#endif
+-
+ void fnord() { int i=42;}
+ int main ()
+ {
+@@ -13436,7 +13420,7 @@ int main ()
+       /* dlclose (self); */
+     }
+ 
+-    exit (status);
++    return status;
+ }
+ EOF
+   if { (eval echo "$as_me:$LINENO: \"$ac_link\"") >&5
+@@ -19110,10 +19094,6 @@ else
+ #  endif
+ #endif
+ 
+-#ifdef __cplusplus
+-extern "C" void exit (int);
+-#endif
+-
+ void fnord() { int i=42;}
+ int main ()
+ {
+@@ -19127,7 +19107,7 @@ int main ()
+       /* dlclose (self); */
+     }
+ 
+-    exit (status);
++    return status;
+ }
+ EOF
+   if { (eval echo "$as_me:$LINENO: \"$ac_link\"") >&5
+@@ -19208,10 +19188,6 @@ else
+ #  endif
+ #endif
+ 
+-#ifdef __cplusplus
+-extern "C" void exit (int);
+-#endif
+-
+ void fnord() { int i=42;}
+ int main ()
+ {
+@@ -19225,7 +19201,7 @@ int main ()
+       /* dlclose (self); */
+     }
+ 
+-    exit (status);
++    return status;
+ }
+ EOF
+   if { (eval echo "$as_me:$LINENO: \"$ac_link\"") >&5
+@@ -27450,8 +27426,8 @@ main ()
+   for (i = 0; i < 256; i++)
+     if (XOR (islower (i), ISLOWER (i))
+ 	|| toupper (i) != TOUPPER (i))
+-      exit(2);
+-  exit (0);
++      return 2;
++  return 0;
+ }
+ _ACEOF
+ rm -f conftest$ac_exeext
+


### PR DESCRIPTION
The error I was getting in configure was:

checking size of size_t... configure: error: cannot compute sizeof (size_t), 77