### PR TITLE
pygtk: fix build with gcc 14

### DIFF
--- a/python/pygtk/BUILD
+++ b/python/pygtk/BUILD
@@ -2,7 +2,7 @@ export PYTHONDONTWRITEBYTECODE=1 &&
 
 OPTS+=" --prefix=/usr --enable-thread --disable-docs" &&
 
-./configure $OPTS PYTHON=python2 &&
+CFLAGS+=" -fpermissive" CXXFLAGS+=" -fpermissive" ./configure $OPTS PYTHON=python2 &&
 
 default_make &&
 


### PR DESCRIPTION
The error I was having was:

pango.c:5382:16: error: returning 'int' from a function with return type 'PangoFontMetrics *' {aka 'struct _PangoFontMetrics *'} makes pointer from integer without a cast [-Wint-conversion]
 5382 |         return pango_font_metrics_new();

This fix was found in the messages of the Arch pygtk package.