### PR TITLE
ripgrep: version bumped to 14.1.1

### DIFF
--- a/utils/ripgrep/BUILD
+++ b/utils/ripgrep/BUILD
@@ -6,18 +6,18 @@ install -Dm755 target/release/rg /usr/bin/ &&
 
 if module_installed bash-completion; then
    mkdir -p "/usr/share/bash-completion/completions"
-   target/release/rg --generate complete-bash > "/usr/share/bash-completion/completions/rg"
+   rg --generate=complete-bash > "/usr/share/bash-completion/completions/rg"
 fi &&
 
 if module_installed zsh; then
    mkdir -p "/usr/share/zsh/site-functions"
-   target/release/rg --generate complete-zsh > "/usr/share/zsh/site-functions/_rg"
+   rg --generate=complete-zsh > "/usr/share/zsh/site-functions/_rg"
 fi &&
 
 if module_installed fish; then
    mkdir -p "/usr/share/fish/vendor_completions.d"
-   target/release/rg --generate complete-fish > "/usr/share/fish/vendor_completions.d/rg.fish"
+   rg --generate=complete-fish > "/usr/share/fish/vendor_completions.d/rg.fish"
 fi &&
 
 mkdir -p "/usr/share/man/man1"
-target/release/rg --generate man >  "/usr/share/man/man1/rg.1"
+rg --generate=man >  "/usr/share/man/man1/rg.1"

--- a/utils/ripgrep/BUILD
+++ b/utils/ripgrep/BUILD
@@ -6,18 +6,22 @@ install -Dm755 target/release/rg /usr/bin/ &&
 
 if module_installed bash-completion; then
    mkdir -p "/usr/share/bash-completion/completions"
-   rg --generate=complete-bash > "/usr/share/bash-completion/completions/rg"
+   rg --generate=complete-bash > rg.bash
+   install -m644 rg.bash "/usr/share/bash-completion/completions/rg"
 fi &&
 
 if module_installed zsh; then
    mkdir -p "/usr/share/zsh/site-functions"
-   rg --generate=complete-zsh > "/usr/share/zsh/site-functions/_rg"
+   rg --generate=complete-zsh > rg.zsh
+   install -m644 rg.zsh "/usr/share/zsh/site-functions/_rg"
 fi &&
 
 if module_installed fish; then
    mkdir -p "/usr/share/fish/vendor_completions.d"
-   rg --generate=complete-fish > "/usr/share/fish/vendor_completions.d/rg.fish"
+   rg --generate=complete-fish > rg.fish
+   install -m644 rg.fish "/usr/share/fish/vendor_completions.d/rg.fish"
 fi &&
 
 mkdir -p "/usr/share/man/man1"
-rg --generate=man >  "/usr/share/man/man1/rg.1"
+rg --generate=man > rg.1
+install -m644 rg.1 "/usr/share/man/man1/rg.1"

--- a/utils/ripgrep/DETAILS
+++ b/utils/ripgrep/DETAILS
@@ -1,11 +1,11 @@
           MODULE=ripgrep
-         VERSION=14.1.0
+         VERSION=14.1.1
           SOURCE=$MODULE-$VERSION.tar.gz
  SOURCE_URL_FULL=https://github.com/BurntSushi/ripgrep/archive/$VERSION.tar.gz
-      SOURCE_VFY=sha256:33c6169596a6bbfdc81415910008f26e0809422fda2d849562637996553b2ab6
+      SOURCE_VFY=sha256:4dad02a2f9c8c3c8d89434e47337aa654cb0e2aa50e806589132f186bf5c2b66
         WEB_SITE=https://github.com/BurntSushi/ripgrep/
          ENTERED=20190417
-         UPDATED=20240107
+         UPDATED=20240923
            SHORT="Recursively searches directories for a regex pattern"
 
 cat << EOF


### PR DESCRIPTION
Weird thing is 'rg --generate=...' shell completion generation doesn't seem to work in BUILD but does on the CLI.