### PR TITLE
wireguard-tools: Extra tools to manage WireGuard VPNs

### DIFF
--- a/net/wireguard-tools/BUILD
+++ b/net/wireguard-tools/BUILD
@@ -1,0 +1,1 @@
+cd src && default_make

--- a/net/wireguard-tools/DETAILS
+++ b/net/wireguard-tools/DETAILS
@@ -1,0 +1,16 @@
+          MODULE=wireguard-tools
+         VERSION=1.0.20210914
+          SOURCE=$MODULE-$VERSION.tar.xz
+      SOURCE_URL=https://git.zx2c4.com/wireguard-tools/snapshot/
+      SOURCE_VFY=sha256:97ff31489217bb265b7ae850d3d0f335ab07d2652ba1feec88b734bc96bd05ac
+        WEB_SITE=https://www.wireguard.com/
+         ENTERED=20241004
+         UPDATED=20241004
+           SHORT="Tools to support the WireGuard VPN"
+
+cat << EOF
+WireGuard® is an extremely simple yet fast and modern VPN that utilizes
+state-of-the-art cryptography.  It consists of two components--a kernel
+module which is a standard part of the Linux kernel, and a collection of
+user-space tools.
+EOF


### PR DESCRIPTION
It's worth noting that wireguard itself is now a standard part of the kernel, so there's no need for a separate module for that.