### PR TITLE
xwayland: version bumped to 24.1.4

### DIFF
--- a/wayland/xwayland/DETAILS
+++ b/wayland/xwayland/DETAILS
@@ -1,11 +1,11 @@
           MODULE=xwayland
-         VERSION=24.1.3
+         VERSION=24.1.4
           SOURCE=$MODULE-$VERSION.tar.xz
       SOURCE_URL=$XORG_URL/individual/xserver
-     SOURCE_VFY=sha256:dcdb57a66cc9b124c8f936760592628ac4e744a7d7b3179aa86189ad7ea4cb10
+     SOURCE_VFY=sha256:d96a78dbab819f55750173444444995b5031ebdcc15b77afebbd8dbc02af34f4
         WEB_SITE=https://xorg.freedesktop.org/
          ENTERED=20230329
-         UPDATED=20241005
+         UPDATED=20241029
            SHORT="run X clients under wayland"
 
 cat << EOF


### PR DESCRIPTION
Fixes CVE-2024-9632: Heap-based buffer overflow privilege escalation in _XkbSetCompatMap
