### PR TITLE
XML-SAX-Expat: Adding a BUILD which should fix compiling with;

### DIFF
--- a/perl/XML-SAX-Expat/BUILD
+++ b/perl/XML-SAX-Expat/BUILD
@@ -1,0 +1,3 @@
+PERL_MM_USE_DEFAULT=1 perl Makefile.PL &&
+
+default_make

--- a/perl/XML-SAX-Expat/DEPENDS
+++ b/perl/XML-SAX-Expat/DEPENDS
@@ -1,2 +1,3 @@
+depends perl
 depends XML-SAX
 depends XML-Parser

--- a/perl/XML-SAX-Expat/DEPENDS
+++ b/perl/XML-SAX-Expat/DEPENDS
@@ -1,3 +1,4 @@
 depends perl
+depends libwww-perl
 depends XML-SAX
 depends XML-Parser

--- a/perl/XML-SAX-Expat/DETAILS
+++ b/perl/XML-SAX-Expat/DETAILS
@@ -4,11 +4,9 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/B/BJ/BJOERN
       SOURCE_VFY=sha256:4c016213d0ce7db2c494e30086b59917b302db8c292dcd21f39deebd9780c83f
         WEB_SITE=http://search.cpan.org/~bjoern/XML-SAX-Expat/
-            TYPE=perl
          ENTERED=20130906
          UPDATED=20150705
            SHORT="Perl SAX2 Driver for Expat"
-
 PSAFE=no
 cat << EOF
 This is an implementation of a SAX2 driver


### PR DESCRIPTION
could not find ParserDetails.ini in /usr/lib/perl5/site_perl/5.40.0/XML/SAX