### PR TITLE
iwd: version bumped to 3.1

### DIFF
--- a/wifi/iwd/BUILD
+++ b/wifi/iwd/BUILD
@@ -1,14 +1,7 @@
-export READLINE_CFLAGS=$(pkgconf --cflags /lib/pkgconfig/readline.pc) &&
-export READLINE_LIBS=$(pkgconf --libs /lib/pkgconfig/readline.pc) &&
-
 OPTS+=" --enable-wired \
         --enable-hwsim \
         --disable-tools \
         --disable-manual-pages \
         --localstatedir=/var"
-
-if ! module_installed systemd; then
-   OPTS+=" --disable-systemd-service"
-fi
 
 default_build

--- a/wifi/iwd/DETAILS
+++ b/wifi/iwd/DETAILS
@@ -1,11 +1,11 @@
           MODULE=iwd
-         VERSION=2.19
+         VERSION=3.1
           SOURCE=$MODULE-$VERSION.tar.gz
       SOURCE_URL=https://www.kernel.org/pub/linux/network/wireless/
-      SOURCE_VFY=sha256:82f269e2501b8474bfda4389cc6774dbf05a9e684123ab358e8fb78e0166ccde
+      SOURCE_VFY=sha256:4656726d6047883fb46660362bc09784c597b6c14d86f657763427e81ba14f54
         WEB_SITE=https://git.kernel.org/cgit/network/wireless/iwd.git/
          ENTERED=20180216
-         UPDATED=20240721
+         UPDATED=20241108
            SHORT="Internet Wireless Daemon"
 
 cat << EOF


### PR DESCRIPTION
The readline pkgconfig file now resides in /usr/lib/pkgconfig and is found automatically. The systemd check is also removed since the other init systems have been taken out.