### PR TITLE
php: version bumped to 8.4.1

### DIFF
--- a/compilers/php/CONFIGURE
+++ b/compilers/php/CONFIGURE
@@ -1,6 +1,5 @@
 mquery USE_REGGLOBALS  "Enable global variable support (potential security risk)?" n
 mquery USE_FPM         "Enable FastCGI Process Manager (fpm) support?" y "--enable-fpm " ""
-mquery USE_PEAR        "Enable PEAR (PHP Extension and Application Repository) support?" y "--with-pear " ""
 mquery USE_INTL        "Enable internationalization support?" y "--enable-intl=shared " ""
 mquery USE_BCMATH      "Enable bc style precision math functions?" y "--enable-bcmath=shared " ""
 mquery USE_CALENDAR    "Enable calendar conversion support?" y "--enable-calendar=shared " ""

--- a/compilers/php/DEPENDS
+++ b/compilers/php/DEPENDS
@@ -25,14 +25,6 @@ optional_depends readline \
                  "--with-readline" "" \
                  "for readline support"
 
-optional_depends aspell \
-                 "--with-pspell=shared" "" \
-                 "for aspell spelling functions"
-
-optional_depends mhash \
-                 "--with-mhash" "" \
-                 "for hash functions support"
-
 optional_depends gmp \
                  "--with-gmp=shared" "" \
                  "GNU math lib support"

--- a/compilers/php/DETAILS
+++ b/compilers/php/DETAILS
@@ -1,8 +1,8 @@
           MODULE=php
-         VERSION=8.3.14
+         VERSION=8.4.1
           SOURCE=php-$VERSION.tar.xz
       SOURCE_URL=https://www.php.net/distributions/
-      SOURCE_VFY=sha256:58b4cb9019bf70c0cbcdb814c7df79b9065059d14cf7dbf48d971f8e56ae9be7
+      SOURCE_VFY=sha256:94c8a4fd419d45748951fa6d73bd55f6bdf0adaefb8814880a67baa66027311f
         WEB_SITE=https://www.php.net
          ENTERED=20040919
          UPDATED=20241121


### PR DESCRIPTION
Removed deprecated configure options. Fixes CVE-2024-8929, CVE-2024-8932, CVE-2024-11233, CVE-2024-11234, and CVE-2024-11236