### PR TITLE
XML-SAX: fix first-time installs

### DIFF
--- a/perl/XML-SAX/BUILD
+++ b/perl/XML-SAX/BUILD
@@ -1,3 +1,8 @@
 export PERL_MM_USE_DEFAULT=1 
 
-default_perl_build
+perl Makefile.PL &&
+
+make &&
+
+prepare_install &&
+make install


### PR DESCRIPTION
For some reason, during the installation phase, it fails with missing SAX.pm. Note that it succeeds if it's already installed, like during updates only.