### PR TITLE
zlib-ng: Adding. Compatibility mode left disabled since it would

### DIFF
--- a/archive/zlib-ng/BUILD
+++ b/archive/zlib-ng/BUILD
@@ -1,0 +1,13 @@
+OPTS+=" -DCMAKE_BUILD_TYPE=Release \
+        -DCMAKE_INSTALL_PREFIX=/usr \
+        -DCMAKE_INSTALL_LIBDIR=lib \
+        -DWITH_NATIVE_INSTRUCTIONS=ON \
+        -DWITH_GTEST=OFF \
+        -G Ninja \
+        -Wno-dev"
+
+cmake -B $MODULE-$VERSION -S . $OPTS &&
+cmake --build $MODULE-$VERSION &&
+
+prepare_install &&
+cmake --install $MODULE-$VERSION

--- a/archive/zlib-ng/DEPENDS
+++ b/archive/zlib-ng/DEPENDS
@@ -1,0 +1,2 @@
+depends cmake
+depends ninja

--- a/archive/zlib-ng/DETAILS
+++ b/archive/zlib-ng/DETAILS
@@ -1,0 +1,14 @@
+          MODULE=zlib-ng
+         VERSION=2.2.3
+          SOURCE=$MODULE-$VERSION.tar.gz
+ SOURCE_URL_FULL=https://github.com/zlib-ng/zlib-ng/archive/refs/tags/$VERSION.tar.gz
+      SOURCE_VFY=sha256:f2fb245c35082fe9ea7a22b332730f63cf1d42f04d84fe48294207d033cba4dd
+        WEB_SITE=https://github.com/zlib-ng/zlib-ng
+         ENTERED=20250108
+         UPDATED=20250108
+           SHORT="a fork of zlib"
+
+cat << EOF
+The motivation for this fork was seeing several 3rd party contributions with new
+optimizations not getting implemented into the official zlib repository.
+EOF


### PR DESCRIPTION
over write a couple of headers and zlib.pc from core. This way no zlib files are trampled.