### PR TITLE
minizip-ng: Adding. Comaptibility is left disabled so it does not

### DIFF
--- a/archive/minizip-ng/BUILD
+++ b/archive/minizip-ng/BUILD
@@ -1,0 +1,13 @@
+OPTS+=" -DCMAKE_BUILD_TYPE=Release \
+        -DCMAKE_INSTALL_PREFIX=/usr \
+        -DCMAKE_INSTALL_LIBDIR=lib \
+        -DMZ_COMPAT=OFF \
+        -G Ninja \
+        -Wno-dev"
+
+cmake -B $MODULE-$VERSION -S . $OPTS &&
+cmake --build $MODULE-$VERSION &&
+
+prepare_install &&
+
+cmake --install $MODULE-$VERSION

--- a/archive/minizip-ng/DEPENDS
+++ b/archive/minizip-ng/DEPENDS
@@ -1,0 +1,6 @@
+depends bzip2
+depends xz
+depends cmake
+depends zstd
+depends zlib-ng
+depends %OSSL

--- a/archive/minizip-ng/DETAILS
+++ b/archive/minizip-ng/DETAILS
@@ -1,0 +1,16 @@
+          MODULE=minizip-ng
+         VERSION=4.0.8
+          SOURCE=$MODULE-$VERSION.tar.gz
+ SOURCE_URL_FULL=https://github.com/zlib-ng/minizip-ng/archive/refs/tags/$VERSION.tar.gz
+      SOURCE_VFY=sha256:c3e9ceab2bec26cb72eba1cf46d0e2c7cad5d2fe3adf5df77e17d6bbfea4ec8f
+        WEB_SITE=https://github.com/zlib-ng/minizip-ng
+         ENTERED=20250108
+         UPDATED=20250108
+           SHORT="a zip manipulation library written in C"
+
+cat << EOF
+The motivation behind this repository has been the need for new features and bug
+fixes to the original library which had not been maintained for a long period of
+time. The code has been largely refactored and rewritten in order to help improve
+maintainability and readability.
+EOF


### PR DESCRIPTION
over write a pc file from minizip.