### PR TITLE
libfido2: Adding. Per; https://github.com/Yubico/libu2f-host is

### DIFF
--- a/libs/libfido2/DEPENDS
+++ b/libs/libfido2/DEPENDS
@@ -1,0 +1,5 @@
+depends zlib
+depends cmake
+depends hidapi
+depends libcbor
+depends %OSSL

--- a/libs/libfido2/DETAILS
+++ b/libs/libfido2/DETAILS
@@ -1,0 +1,17 @@
+          MODULE=libfido2
+         VERSION=1.15.0
+          SOURCE=$MODULE-$VERSION.tar.gz
+ SOURCE_URL_FULL=https://github.com/Yubico/libfido2/archive/refs/tags/$VERSION.tar.gz
+      SOURCE_VFY=sha256:32e3e431cfe29b45f497300fdb7076971cb77fc584fcfa80084d823a6ed94fbb
+        WEB_SITE=https://developers.yubico.com/libfido2/
+            TYPE=cmake
+         ENTERED=20250109
+         UPDATED=20250109
+           SHORT="command-line tools to communicate with a FIDO device"
+
+cat << EOF
+libfido2 provides library functionality and command-line tools to communicate with
+a FIDO device over USB or NFC, and to verify attestation and assertion signatures.
+
+libfido2 supports the FIDO U2F (CTAP 1) and FIDO2 (CTAP 2) protocols.
+EOF


### PR DESCRIPTION
depreciated and not maintained. libfido2 is recommended.