### PR TITLE
FreeImage: fix build with newer gcc 14

### DIFF
--- a/graphics/FreeImage/BUILD
+++ b/graphics/FreeImage/BUILD
@@ -1,7 +1,7 @@
 # we need the visibility flags, so don't *overwrite* them
 # otherwise modules which link to libfreeimage might get confused
 # Following the lead of arch linux
-export CFLAGS+=" -O3 -fPIC -fexceptions -fvisibility=hidden" &&
+export CFLAGS+=" -O3 -fPIC -fexceptions -fvisibility=hidden -fpermissive" &&
 
 # Adding c++98 for now to skirt around c++11 incompatibilities
 export CXXFLAGS+=" -O3 -fPIC -fexceptions -fvisibility=hidden \


### PR DESCRIPTION
The error I was getting was:

```
Source/ZLib/gzlib.c: In function 'gz_open':
Source/ZLib/gzlib.c:14:17: error: implicit declaration of function 'lseek'; did you mean 'fseek'? [-Wimplicit-function-declaration]
   14 | #  define LSEEK lseek
      |                 ^~~~~
Source/ZLib/gzlib.c:252:9: note: in expansion of macro 'LSEEK'
  252 |         LSEEK(state->fd, 0, SEEK_END);  /* so gzoffset() is correct */
      |         ^~~~~
make: *** [Makefile:61: Source/ZLib/gzlib.o] Error 1
make: *** Waiting for unfinished jobs....
Source/ZLib/gzread.c: In function 'gz_load':
Source/ZLib/gzread.c:35:15: error: implicit declaration of function 'read'; did you mean 'fread'? [-Wimplicit-function-declaration]
   35 |         ret = read(state->fd, buf + *have, get);
      |               ^~~~
      |               fread
Source/ZLib/gzread.c: In function 'gzclose_r':
Source/ZLib/gzread.c:651:11: error: implicit declaration of function 'close'; did you mean 'pclose'? [-Wimplicit-function-declaration]
  651 |     ret = close(state->fd);
      |           ^~~~~
      |           pclose
make: *** [Makefile:61: Source/ZLib/gzread.o] Error 1
```