### PR TITLE
python-pycairo: This needs to use meson so py3cairo.h gets installed

### DIFF
--- a/python/python-pycairo/BUILD
+++ b/python/python-pycairo/BUILD
@@ -1,4 +1,0 @@
-python -m build --wheel &&
-
-prepare_install &&
-python -m installer --destdir=/ dist/*.whl

--- a/python/python-pycairo/DETAILS
+++ b/python/python-pycairo/DETAILS
@@ -5,6 +5,7 @@
       SOURCE_VFY=sha256:5cb21e7a00a2afcafea7f14390235be33497a2cce53a98a19389492a60628430
 SOURCE_DIRECTORY=$BUILD_DIRECTORY/pycairo-$VERSION
         WEB_SITE=https://pypi.org/project/pycairo/
+            TYPE=meson
          ENTERED=20210207
          UPDATED=20250111
            SHORT="Python bindings for the cairo graphics library"


### PR DESCRIPTION
which is needed by meld PR4954.