### PR TITLE
meld: Bump to 3.22.2 and add python-pycairo depends.

### DIFF
--- a/devel/meld/BUILD
+++ b/devel/meld/BUILD
@@ -1,0 +1,4 @@
+OPTS+=" -Dbyte-compile=false"
+
+
+default_meson_build

--- a/devel/meld/DEPENDS
+++ b/devel/meld/DEPENDS
@@ -1,6 +1,7 @@
 depends desktop-file-utils
 depends meson
 depends python-pygobject
+depends python-pycairo
 depends gtksourceview
 depends gsettings-desktop-schemas
 depends itstool

--- a/devel/meld/DETAILS
+++ b/devel/meld/DETAILS
@@ -1,12 +1,11 @@
           MODULE=meld
-         VERSION=3.22.0
+         VERSION=3.22.2
           SOURCE=$MODULE-$VERSION.tar.xz
       SOURCE_URL=$GNOME_URL/sources/$MODULE/${VERSION%.*}
-      SOURCE_VFY=sha256:3fc107c98ef6e75358ffd2b0d14c85ddb48fe14a11e939a94322faaa8e90c40d
+      SOURCE_VFY=sha256:46a0a713fbcd1b153b377a1e0757c8ce255c9822467658eacfbd89b1e92316ef
         WEB_SITE=http://meld.sourceforge.net/
-            TYPE=meson
          ENTERED=20021119
-         UPDATED=20231025
+         UPDATED=20250112
            SHORT="A visual diff and merge tool"
 
 cat << EOF


### PR DESCRIPTION
Checking out https://github.com/lunar-linux/moonbase-other/pull/4954 and doing it locally, still wouldn't find the updated python-pycairo. 