### PR TITLE
tagparser: build shared library instead of static

### DIFF
--- a/audio/tagparser/PRE_BUILD
+++ b/audio/tagparser/PRE_BUILD
@@ -1,0 +1,3 @@
+default_pre_build &&
+
+OPTS+=" -DBUILD_SHARED_LIBS=ON"


### PR DESCRIPTION
Forgot to add PRE_BUILD in previous PR :P