### PR TITLE
liburing: version bumped to 2.8

### DIFF
--- a/libs/liburing/BUILD
+++ b/libs/liburing/BUILD
@@ -2,4 +2,7 @@ OPTS+=" --mandir=/usr/share/man"
 
 ./configure $OPTS &&
 
-default_make
+default_make &&
+
+# Remove static libraries
+rm /usr/lib/liburing*.a

--- a/libs/liburing/DETAILS
+++ b/libs/liburing/DETAILS
@@ -1,11 +1,12 @@
           MODULE=liburing
-         VERSION=2.7
+         VERSION=2.8
           SOURCE=$MODULE-$VERSION.tar.gz
-      SOURCE_URL=https://git.kernel.dk/cgit/liburing/snapshot/
-      SOURCE_VFY=sha256:29c0897868cb612b71728e680fa5fac4c5c9fc51166d8c42a0261f061f4658ae
+SOURCE_DIRECTORY=$BUILD_DIRECTORY/$MODULE-$MODULE-$VERSION
+      SOURCE_URL=https://github.com/axboe/liburing/archive/refs/tags
+      SOURCE_VFY=sha256:3ed7891d1b2bbe743ef3fb6d0a4970e630aa02d7c7bd3b0212791fb7be815984
         WEB_SITE=https://git.kernel.dk/cgit/liburing/
          ENTERED=20200723
-         UPDATED=20240821
+         UPDATED=20250125
            SHORT="Linux-native io_uring I/O access library"
 
 cat << EOF


### PR DESCRIPTION
I was getting HTTP error code 400, bad request, when using 'lget -w 2.8 liburing', so update the source URL to the repo hosted on Github.