### PR TITLE
links: fix build with recent gcc 14

### DIFF
--- a/web/links/BUILD
+++ b/web/links/BUILD
@@ -1,3 +1,5 @@
+export CFLAGS+=" -fpermissive"
+
 default_build &&
 
 if in_depends $MODULE libX11; then


### PR DESCRIPTION
I was getting "C compiler cannot create executables" in configure... I found this in config.log:

configure:993: checking whether the C compiler (gcc  -O2 -march=x86-64 -fno-plt -fexceptions -pipe -fstack-clash-protection  -s -Wl,-z,relro,-z,now,--sort-common) works
configure:1009: gcc -o conftest  -O2 -march=x86-64 -fno-plt -fexceptions -pipe -fstack-clash-protection   -s -Wl,-z,relro,-z,now,--sort-common conftest.c  1>&5
configure:1006:1: error: return type defaults to 'int' [-Wimplicit-int]