### PR TITLE
qemu: add Gentoo patch for glibc 2.41

### DIFF
--- a/virtual/qemu/patch.d/qemu-9.2.0-glibc-2.41.patch
+++ b/virtual/qemu/patch.d/qemu-9.2.0-glibc-2.41.patch
@@ -1,0 +1,46 @@
+https://bugs.gentoo.org/949098
+https://gitlab.com/qemu-project/qemu/-/issues/2799
+https://lists.nongnu.org/archive/html/qemu-devel/2024-10/msg02221.html
+
+glibc 2.41+ has added [1] definitions for sched_setattr and sched_getattr functions
+and struct sched_attr. Therefore, it needs to be checked for here as well before
+defining sched_attr
+
+Define sched_attr conditionally on SCHED_ATTR_SIZE_VER0
+
+Fixes builds with glibc/trunk
+
+[1]
+https://sourceware.org/git/?p=glibc.git;a=commitdiff;h=21571ca0d70302909cf72707b2a7736cf12190a0;hp=298bc488fdc047da37482f4003023cb9adef78f8
+
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+Cc: Laurent Vivier <laurent@vivier.eu>
+Cc: Paolo Bonzini <pbonzini@redhat.com>
+---
+v2: Use SCHED_ATTR_SIZE_VER0 instead of glibc version check
+
+ linux-user/syscall.c | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/linux-user/syscall.c b/linux-user/syscall.c
+index 1ce4c79..a407d4a 100644
+--- a/linux-user/syscall.c
++++ b/linux-user/syscall.c
+@@ -358,7 +358,8 @@ _syscall3(int, sys_sched_getaffinity, pid_t, pid, unsigned int, len,
+ #define __NR_sys_sched_setaffinity __NR_sched_setaffinity
+ _syscall3(int, sys_sched_setaffinity, pid_t, pid, unsigned int, len,
+           unsigned long *, user_mask_ptr);
+-/* sched_attr is not defined in glibc */
++/* sched_attr is not defined in glibc < 2.41 */
++#ifndef SCHED_ATTR_SIZE_VER0
+ struct sched_attr {
+     uint32_t size;
+     uint32_t sched_policy;
+@@ -371,6 +372,7 @@ struct sched_attr {
+     uint32_t sched_util_min;
+     uint32_t sched_util_max;
+ };
++#endif
+ #define __NR_sys_sched_getattr __NR_sched_getattr
+ _syscall4(int, sys_sched_getattr, pid_t, pid, struct sched_attr *, attr,
+           unsigned int, size, unsigned int, flags);


### PR DESCRIPTION
The error I was getting was:

[...]
[2701/4634] Compiling C object libqemu-aarch64_be-linux-user.a.p/linux-user_syscall.c.o
FAILED: libqemu-aarch64_be-linux-user.a.p/linux-user_syscall.c.o 
gcc -m64 -Ilibqemu-aarch64_be-linux-user.a.p -I. -I.. -Itarget/arm -I../target/arm -I../common-user/host/x86_64 -I../linux-user/include/host/x86_64 -I../linux-user/include -Ilinux-user -I../linux-user -Ilinux-user/aarch64 -I../linux-user/aarch64 -Iqapi -Itrace -Iui -Iui/shader -I/usr/include/capstone -I/usr/local/include -I/usr/include/glib-2.0 -I/usr/lib/glib-2.0/include -fdiagnostics-color=auto -Wall -Winvalid-pch -std=gnu11 -O2 -g -fstack-protector-strong -Wempty-body -Wendif-labels -Wexpansion-to-defined -Wformat-security -Wformat-y2k -Wignored-qualifiers -Wimplicit-fallthrough=2 -Winit-self -Wmissing-format-attribute -Wmissing-prototypes -Wnested-externs -Wold-style-declaration -Wold-style-definition -Wredundant-decls -Wshadow=local -Wstrict-prototypes -Wtype-limits -Wundef -Wvla -Wwrite-strings -Wno-missing-include-dirs -Wno-psabi -Wno-shift-negative-value -isystem /usr/src/qemu-9.2.0/linux-headers -isystem linux-headers -iquote . -iquote /usr/src/qemu-9.2.0 -iquote /usr/src/qemu-9.2.0/include -iquote /usr/src/qemu-9.2.0/host/include/x86_64 -iquote /usr/src/qemu-9.2.0/host/include/generic -iquote /usr/src/qemu-9.2.0/tcg/i386 -pthread -mcx16 -msse2 -D_GNU_SOURCE -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -fno-strict-aliasing -fno-common -fwrapv -ftrivial-auto-var-init=zero -fzero-call-used-regs=used-gpr -O2 -march=x86-64 -fno-plt -fexceptions -pipe -fstack-clash-protection -fPIC -fPIE -isystem../linux-headers -isystemlinux-headers -DCOMPILING_PER_TARGET '-DCONFIG_TARGET="aarch64_be-linux-user-config-target.h"' '-DCONFIG_DEVICES="aarch64_be-linux-user-config-devices.h"' -MD -MQ libqemu-aarch64_be-linux-user.a.p/linux-user_syscall.c.o -MF libqemu-aarch64_be-linux-user.a.p/linux-user_syscall.c.o.d -o libqemu-aarch64_be-linux-user.a.p/linux-user_syscall.c.o -c ../linux-user/syscall.c
../linux-user/syscall.c:362:8: error: redefinition of 'struct sched_attr'
  362 | struct sched_attr {
      |        ^~~~~~~~~~
In file included from /usr/include/bits/sched.h:63,
                 from /usr/include/sched.h:43,
                 from /usr/lib/gcc/x86_64-pc-linux-gnu/14.2.0/include-fixed/pthread.h:31,
                 from /usr/include/glib-2.0/glib/deprecated/gthread.h:126,
                 from /usr/include/glib-2.0/glib.h:115,
                 from /usr/src/qemu-9.2.0/include/glib-compat.h:32,
                 from /usr/src/qemu-9.2.0/include/qemu/osdep.h:161,
                 from ../linux-user/syscall.c:20:
/usr/include/linux/sched/types.h:98:8: note: originally defined here
   98 | struct sched_attr {
      |        ^~~~~~~~~~
[2702/4634] Compiling C object libqemu-aarch64_be-linux-user.a.p/linux-user_strace.c.o
[2703/4634] Compiling C object libqemu-aarch64_be-linux-user.a.p/linux-user_uaccess.c.o
[2704/4634] Compiling C object libqemu-aarch64_be-linux-user.a.p/target_arm_tcg_sve_helper.c.o
ninja: build stopped: subcommand failed.
make[1]: *** [Makefile:168: run-ninja] Error 1
make[1]: Leaving directory '/usr/src/qemu-9.2.0/build'
make: *** [GNUmakefile:6: build] Error 2