### PR TITLE
ntp: fix build with newer gcc 14

### DIFF
--- a/net/ntp/BUILD
+++ b/net/ntp/BUILD
@@ -6,6 +6,7 @@ OPTS+=" --disable-static   \
         --localstatedir=/var/cache"
 
 CPPFLAGS+=" -fPIC" &&
+CFLAGS+=" -fpermissive" &&
 
 default_build &&
 


### PR DESCRIPTION
The configure script was failing with:

configure: error: could not locate pthread_detach()

I found this in config.log:

```
configure:23116: checking for pthread_detach with <pthread.h>
configure:23139: gcc -o conftest  -O2 -march=x86-64 -fno-plt -fexceptions -pipe -fstack-clash-protection   -s -Wl,-z,relro,-z,now,--sort-common conftest.c    >&5
conftest.c: In function 'main':
conftest.c:166:16: error: passing argument 1 of 'pthread_detach' makes integer from pointer without a cast [-Wint-conversion]
  166 | pthread_detach(NULL);
      |                ^~~~
      |                | 
      |                void *
In file included from conftest.c:158:
/usr/include/pthread.h:269:38: note: expected 'pthread_t' {aka 'long unsigned int'} but argument is of type 'void *'
  269 | extern int pthread_detach (pthread_t __th) __THROW;
      |                            ~~~~~~~~~~^~~~
```