### PR TITLE
go-bootstrap: switch to prebuilt bootstrap (1.22.12)

### DIFF
--- a/compilers/go-bootstrap/BUILD
+++ b/compilers/go-bootstrap/BUILD
@@ -1,25 +1,9 @@
-BOOT_VER=$(lvu version go-bootstrap|cut -d"." -f2)
-export GOOS=linux
-export GOROOT=$SOURCE_DIRECTORY
-export GOBIN=$GOROOT/bin
-export GOPATH=$BUILD_DIRECTORY
-export GOROOT_FINAL=/usr/lib/go1.$BOOT_VER
-
-case "$(arch)" in
-   x86_64) export GOARCH=amd64 ;;
-   i686)   export GOARCH=386 ;;
-esac &&
-
-# Disable compressed sections or go 1.4 will fail to build with binutils >= 2.26
-export CGO_CFLAGS+=" -Wa,--compress-debug-sections=none"
-
-cd src &&
-bash --verbose make.bash &&
+export GOROOT_FINAL=/usr/lib/go$(lvu version go-bootstrap|cut -d"." -f1,2)
 
 prepare_install &&
 
-cd $SOURCE_DIRECTORY &&
-mkdir -p /usr/lib/go1.$BOOT_VER/bin &&
-cp -a bin/* /usr/lib/go1.$BOOT_VER/bin/ &&
-cp -a {src,lib,pkg} /usr/lib/go1.$BOOT_VER/ &&
-chmod -R +x /usr/lib/go1.$BOOT_VER/pkg/tool
+mkdir -p $GOROOT_FINAL/bin &&
+cp -a go.env $GOROOT_FINAL/ &&
+cp -a bin/* $GOROOT_FINAL/bin/ &&
+cp -a {src,lib,pkg} $GOROOT_FINAL/ &&
+chmod -R +x $GOROOT_FINAL/pkg/tool

--- a/compilers/go-bootstrap/DETAILS
+++ b/compilers/go-bootstrap/DETAILS
@@ -1,17 +1,14 @@
           MODULE=go-bootstrap
-         VERSION=1.4.3
-          SOURCE=go${VERSION}.src.tar.gz
-         SOURCE2=go-1.4.3-support_new_relocation.patch
+         VERSION=1.22.12
+          SOURCE=go$VERSION.linux-amd64.tar.gz
 SOURCE_DIRECTORY=$BUILD_DIRECTORY/go
-      SOURCE_URL=http://storage.googleapis.com/golang
-     SOURCE2_URL=$PATCH_URL
-      SOURCE_VFY=sha256:9947fc705b0b841b5938c48b22dc33e9647ec0752bae66e50278df4f23f64959
-     SOURCE2_VFU=sha256:3bd901d920e53fed95b495a6daf012854826855993187a6d07970a7ef108ef28
-        WEB_SITE=http://golang.org/
+      SOURCE_URL=https://go.dev/dl
+      SOURCE_VFY=sha256:4fa4f869b0f7fc6bb1eb2660e74657fbf04cdd290b5aef905585c86051b34d43
+        WEB_SITE=https://golang.org/
          ENTERED=20140606
-         UPDATED=20210828
-           SHORT="A bootstrap Go compiler and tools"
+         UPDATED=20250214
+           SHORT="A prebuilt Go compiler and tools"
 
 cat << EOF
-Compiler and tools for the Go programming language from Google.
+Prebuilt compiler and tools for bootstrapping the Go compiler from Google.
 EOF

--- a/compilers/go-bootstrap/POST_INSTALL
+++ b/compilers/go-bootstrap/POST_INSTALL
@@ -1,7 +1,4 @@
-# Fix timestamps to avoid go tools to rebuild its files
-find /usr/lib/go1.4 -type f -exec touch -r /usr/lib/go1.4/pkg/*/runtime.a {} \;
-
 # add the symlinks to /usr/bin
-for f in /usr/lib/go1.4/bin/*; do
+for f in /usr/lib/go1.22/bin/*; do
    ln -sf $f /usr/bin/
 done

--- a/compilers/go-bootstrap/PRE_BUILD
+++ b/compilers/go-bootstrap/PRE_BUILD
@@ -1,2 +1,0 @@
-default_pre_build &&
-patch_it $SOURCE2 1


### PR DESCRIPTION
Ratler suggested we stop introducing additional bootstraps. With Go 1.24.0, a 4th one was needed. So use the minimum required prebuilt version instead.