### PR TITLE
transmission: add a Gentoo patch for newer miniupnpc

### DIFF
--- a/distributed/transmission/DEPENDS
+++ b/distributed/transmission/DEPENDS
@@ -5,6 +5,7 @@ depends npm
 depends ninja
 depends cmake
 depends intltool
+depends miniupnpc
 
 optional_depends gtk      "-DENABLE_GTK=ON"                   "-DENABLE_GTK=OFF"    "for the GTK+ GUI interface,${PROBLEM_COLOR}Not merged to moonbase, say no for now${DEFAULT_COLOR}" n
 optional_depends qt6-tools "-DENABLE_QT=ON -DUSE_QT_VERSION=6" "-DENABLE_QT=OFF"    "for the Qt GUI interface"

--- a/distributed/transmission/patch.d/transmission-4.0.6-miniupnpc-2.2.8.patch
+++ b/distributed/transmission/patch.d/transmission-4.0.6-miniupnpc-2.2.8.patch
@@ -1,0 +1,24 @@
+https://bugs.gentoo.org/934016
+https://github.com/transmission/transmission/pull/6907
+
+From 3523b928c8c968d0b7bca2c6c3a84a939e908f8c Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?C=C5=93ur?= <coeur@gmx.fr>
+Date: Mon, 10 Jun 2024 22:16:06 +0800
+Subject: [PATCH] bump miniupnpc to 2.2.8
+
+diff --git a/libtransmission/port-forwarding-upnp.cc b/libtransmission/port-forwarding-upnp.cc
+index 6d7bbc7f7c2..d805bc18218 100644
+--- a/libtransmission/port-forwarding-upnp.cc
++++ b/libtransmission/port-forwarding-upnp.cc
+@@ -261,7 +261,11 @@ tr_port_forwarding_state tr_upnpPulse(
+ 
+         FreeUPNPUrls(&handle->urls);
+         auto lanaddr = std::array<char, TR_ADDRSTRLEN>{};
++#if (MINIUPNPC_API_VERSION >= 18)
++        if (UPNP_GetValidIGD(devlist, &handle->urls, &handle->data, std::data(lanaddr), std::size(lanaddr) - 1, NULL, 0) ==
++#else
+         if (UPNP_GetValidIGD(devlist, &handle->urls, &handle->data, std::data(lanaddr), std::size(lanaddr) - 1) ==
++#endif
+             UPNP_IGD_VALID_CONNECTED)
+         {
+             tr_logAddInfo(fmt::format(_("Found Internet Gateway Device '{url}'"), fmt::arg("url", handle->urls.controlURL)));


### PR DESCRIPTION
The error I was getting was:

/usr/src/transmission-4.0.6/libtransmission/port-forwarding-upnp.cc:278:29: error: too few arguments to function 'int UPNP_GetValidIGD(UPNPDev*, UPNPUrls*, IGDdatas*, char*, int, char*, int)'
