### PR TITLE
gdal: version bumped to 3.10.2

### DIFF
--- a/libs/gdal/BUILD
+++ b/libs/gdal/BUILD
@@ -1,6 +1,3 @@
-# Deal with poppler 24.12.0
-sedit '21i #include <sstream>' frmts/pdf/pdfsdk_headers_poppler.h
-
 export PYTHONDONTWRITEBYTECODE=1 &&
 
 OPTS+=" -DBUILD_PYTHON_BINDINGS=ON \

--- a/libs/gdal/DETAILS
+++ b/libs/gdal/DETAILS
@@ -1,11 +1,11 @@
           MODULE=gdal
-         VERSION=3.10.1
+         VERSION=3.10.2
           SOURCE=$MODULE-$VERSION.tar.gz
       SOURCE_URL=https://github.com/OSGeo/gdal/releases/download/v$VERSION/
-      SOURCE_VFY=sha256:b1c739256d074be42d67c6c3d33eee94c90a490ebb02fcb7fc21c569a6fc78bd
+      SOURCE_VFY=sha256:ca710aab81eb4d638f5dbd4f03d4d4b902aeb6ee73a3d4a8c5e966b6b648b0da
         WEB_SITE=http://gdal.org/
          ENTERED=20050915
-         UPDATED=20250113
+         UPDATED=20250217
            SHORT="Geospatial Data Abstraction Library"
 
 cat << EOF


### PR DESCRIPTION
The #include has been added upstream, so remove the fix.