### PR TITLE
libxml2: git now required

### DIFF
--- a/libs/libxml2/DEPENDS
+++ b/libs/libxml2/DEPENDS
@@ -2,6 +2,7 @@ depends zlib
 depends python
 depends readline
 depends meson
+depends git
 
 optional_depends icu4c "-Dicu=enabled" "-Dicu=disabled" "for ICU support"
 optional_depends python2 "" "" "for Python 2 libxml2 support"


### PR DESCRIPTION
The error message I was getting was:

meson.build:20:4: ERROR: Program or command 'git' not found or not executable