### PR TITLE
xwayland: version bumped to 24.1.8 + CVE fix

### DIFF
--- a/wayland/xwayland/DETAILS
+++ b/wayland/xwayland/DETAILS
@@ -1,11 +1,11 @@
           MODULE=xwayland
-         VERSION=24.1.7
+         VERSION=24.1.8
           SOURCE=$MODULE-$VERSION.tar.xz
       SOURCE_URL=$XORG_URL/individual/xserver
-     SOURCE_VFY=sha256:f7d97e248092878a3f7d3c68b25dab652bf970d9e6a17d30fbf457aaea139ccb
+     SOURCE_VFY=sha256:c8908d57c8ed9ceb8293c16ba7ad5af522efaf1ba7e51f9e4cf3c0774d199907
         WEB_SITE=https://xorg.freedesktop.org/
          ENTERED=20230329
-         UPDATED=20250617
+         UPDATED=20250706
            SHORT="run X clients under wayland"
 
 cat << EOF


### PR DESCRIPTION
Just like xorg-server, this release fixes [CVE-2025-49176](https://www.cvedetails.com/cve/CVE-2025-49176) (See https://lists.x.org/archives/xorg/2025-June/062055.html)