### PR TITLE
fluxbox-git: bumped to the latest commit

### DIFF
--- a/x11-wm/fluxbox-git/DETAILS
+++ b/x11-wm/fluxbox-git/DETAILS
@@ -1,10 +1,10 @@
           MODULE=fluxbox-git
          VERSION=1.3.7
           SOURCE=$MODULE-$VERSION.tar.bz2
-      SOURCE_URL=git+https://github.com/fluxbox/fluxbox:06993a4ac8261f1ea6876d7593b14cf43103214b
+      SOURCE_URL=git+https://github.com/fluxbox/fluxbox:c7ff3696d256c45d27ed3ad37d67821f6293916b
         WEB_SITE=http://fluxbox.org
          ENTERED=20030325
-         UPDATED=20240816
+         UPDATED=20250821
            SHORT="Yet another windowmanager"
     USE_WRAPPERS=no
 


### PR DESCRIPTION
No more auto_ptr C++ warnings! (The output was filled with those before.)