### PR TITLE
Sqlite debloat: remove tcl mandatory dependency, forced Python rebuild

### DIFF
--- a/sql/sqlite/BUILD
+++ b/sql/sqlite/BUILD
@@ -28,13 +28,15 @@ OPTS+="	--disable-static \
         --enable-fts5 \
         --enable-rtree \
         --enable-geopoly \
-        --enable-threadsafe \
-        --enable-readline"
+        --enable-threadsafe"
 
 default_config &&
 
-# fix the tcl related directrory name
-sedit 's|/zipfs:|usr|' Makefile &&
+# fix the tcl related directory name
+if in_depends sqlite tcl
+then
+    sedit 's|/zipfs:|usr|' Makefile
+fi &&
 
 default_make &&
 

--- a/sql/sqlite/CONFIGURE
+++ b/sql/sqlite/CONFIGURE
@@ -1,0 +1,3 @@
+if module_installed python || module_installed python2; then
+  mquery REBUILD_PYTHON "Rebuild Python afterwards to add sqlite support?" n "" ""
+fi

--- a/sql/sqlite/DEPENDS
+++ b/sql/sqlite/DEPENDS
@@ -1,3 +1,4 @@
 depends zlib
-depends tcl
-depends readline
+
+optional_depends readline "--enable-readline" "--disable-readline" "for readline command-line editing" n
+optional_depends tcl "--enable-tcl" "--disable-tcl" "for sqlite3_analyzer and tests" n

--- a/sql/sqlite/POST_INSTALL
+++ b/sql/sqlite/POST_INSTALL
@@ -1,7 +1,10 @@
-if module_installed python; then
-  lin -c python
-fi
+if [[ ${REBUILD_PYTHON:-n} == y ]]
+then
+  if module_installed python; then
+    lin -c python
+  fi
 
-if module_installed python2; then
-  lin -c python2
+  if module_installed python2; then
+    lin -c python2
+  fi
 fi


### PR DESCRIPTION
sqlite seems to have picked up some bloat along the way.

First of all, tcl is an OPTIONAL dependency, and should have never been made mandatory.

Second, rebuilding Python with sqlite support is also OPTIONAL and that should also be a choice.