### PR TITLE
dune: Version bumped to 3.22.0

### DIFF
--- a/compilers/dune/DETAILS
+++ b/compilers/dune/DETAILS
@@ -1,12 +1,12 @@
-          MODULE=dune
-         VERSION=3.17.2
-          SOURCE=$MODULE-$VERSION.tar.gz
- SOURCE_URL_FULL=https://github.com/ocaml/dune/archive/refs/tags/$VERSION.tar.gz
-      SOURCE_VFY=sha256:1b45e34d1eacf40be569e4d7ad055508a3242637b098327c91f7ce67772a1889
-        WEB_SITE=https://github.com/ocaml/dune
-         ENTERED=20181003
-         UPDATED=20250427
-           SHORT="A composable build system for OCaml"
+         MODULE=dune
+        VERSION=3.22.0
+         SOURCE=$MODULE-$VERSION.tar.gz
+SOURCE_URL_FULL=https://github.com/ocaml/dune/archive/refs/tags/$VERSION.tar.gz
+     SOURCE_VFY=sha256:a91f88417398d07406181793e7edcd845fc6b7f3e9f53cd362bdcba3bbaa0aef
+       WEB_SITE=https://github.com/ocaml/dune
+        ENTERED=20181003
+        UPDATED=20260320
+          SHORT="A composable build system for OCaml"
 
 cat << EOF
 A composable build system for OCaml, formerly jbuilder.


### PR DESCRIPTION
Upgrade dune from 3.17.2 to 3.22.0. This update includes the latest improvements and bug fixes for the OCaml build system.

---
*Automated PR created by n8n + Claude AI*