### PR TITLE
shfmt: Version bumped to 3.13.1

### DIFF
--- a/devel/shfmt/DETAILS
+++ b/devel/shfmt/DETAILS
@@ -1,12 +1,12 @@
           MODULE=shfmt
-         VERSION=3.13.0
+         VERSION=3.13.1
           SOURCE=$MODULE-$VERSION.tar.gz
  SOURCE_URL_FULL=https://github.com/mvdan/sh/archive/v${VERSION}.tar.gz
-      SOURCE_VFY=sha256:efef583999befd358fae57858affa4eb9dc8a415f39f69d0ebab3a9f473d7dd3
+      SOURCE_VFY=sha256:b31aad2d4c26b0c6e8ebe894d59022520bbebce33e082d7d29e4325eee35d308
 SOURCE_DIRECTORY=$BUILD_DIRECTORY/sh-$VERSION
         WEB_SITE=https://github.com/mvdan/sh/
          ENTERED=20200512
-         UPDATED=20260314
+         UPDATED=20260410
            SHORT="A formatter for shell programs"
 
 cat << EOF


### PR DESCRIPTION
Upgrade shfmt from 3.13.0 to 3.13.1

- Version: 3.13.0 → 3.13.1
- SHA256: b31aad2d4c26b0c6e8ebe894d59022520bbebce33e082d7d29e4325eee35d308
- Updated: 20260314 → 20260410

---
*Automated PR created by n8n + Claude AI*