### PR TITLE
iperf3: Version bumped to 3.21

### DIFF
--- a/net/iperf3/DETAILS
+++ b/net/iperf3/DETAILS
@@ -1,12 +1,12 @@
           MODULE=iperf3
-         VERSION=3.20
+         VERSION=3.21
           SOURCE=$MODULE-$VERSION.tar.gz
  SOURCE_URL_FULL=https://github.com/esnet/iperf/archive/$VERSION.tar.gz
-      SOURCE_VFY=sha256:84640ea0f43831850434e50134d0554b7a94f97fb02e2488ffbe252c9fb05a56
+      SOURCE_VFY=sha256:dd289b6700d3bc33eda7fa3ce6db217d6ca42239edbcb2e7f152bf7bf5c8a5aa
 SOURCE_DIRECTORY=$BUILD_DIRECTORY/iperf-$VERSION
         WEB_SITE=https://github.com/esnet/iperf/
          ENTERED=20160224
-         UPDATED=20251117
+         UPDATED=20260410
            SHORT="Internet Protocol bandwidth measuring tool"
 
 cat << EOF


### PR DESCRIPTION
Upgrade iperf3 from version 3.20 to 3.21. Updated SOURCE_VFY checksum and UPDATED date.

---
*Automated PR created by n8n + Claude AI*