### PR TITLE
htop: Version bumped to 3.5.0

### DIFF
--- a/utils/htop/DETAILS
+++ b/utils/htop/DETAILS
@@ -1,12 +1,12 @@
-          MODULE=htop
-         VERSION=3.4.1
-          SOURCE=$MODULE-$VERSION.tar.gz
-      SOURCE_URL=https://github.com/htop-dev/htop/archive/${VERSION}/
-      SOURCE_VFY=sha256:af9ec878f831b7c27d33e775c668ec79d569aa781861c995a0fbadc1bdb666cf
-        WEB_SITE=http://hisham.hm/htop/index.php?page=main
-         ENTERED=20040927
-         UPDATED=20251201
-           SHORT="An interactive process viewer"
+    MODULE=htop
+   VERSION=3.5.0
+    SOURCE=$MODULE-$VERSION.tar.gz
+SOURCE_URL=https://github.com/htop-dev/htop/archive/${VERSION}/
+SOURCE_VFY=sha256:cf0e72abf670ff3547d9130e129d2a97a657a5b20c74132c17502c817babbb41
+  WEB_SITE=http://hisham.hm/htop/index.php?page=main
+   ENTERED=20040927
+   UPDATED=20260410
+     SHORT="An interactive process viewer"
 
 cat << EOF
 htop is an interactive, text-mode (ncurses) process viewer. That has many


### PR DESCRIPTION
Upgrade htop from 3.4.1 to 3.5.0

- Updated VERSION to 3.5.0
- Updated SOURCE_VFY to cf0e72abf670ff3547d9130e129d2a97a657a5b20c74132c17502c817babbb41
- Updated UPDATED timestamp to 20260410

---
*Automated PR created by n8n + Claude AI*