### PR TITLE
netdata: Version bumped to 2.10.0

### DIFF
--- a/web/netdata/DETAILS
+++ b/web/netdata/DETAILS
@@ -1,12 +1,12 @@
           MODULE=netdata
-         VERSION=2.9.0
+         VERSION=2.10.0
           SOURCE=$MODULE-v$VERSION.tar.gz
 SOURCE_DIRECTORY=$BUILD_DIRECTORY/$MODULE-v$VERSION
       SOURCE_URL=https://github.com/netdata/netdata/releases/download/v$VERSION/
-      SOURCE_VFY=sha256:e3f2933aabf46970c31186a85078b5aff437bbb84fa8985d801575d40b1ad5e5
+      SOURCE_VFY=sha256:200091fcaf0c6abea7c8906870e2877b034f07a2354b435703b8c7f35e19ce6f
         WEB_SITE=http://github.com/firehol/netdata/
          ENTERED=20160620
-         UPDATED=20260219
+         UPDATED=20260410
            SHORT="Detailed real-time performance monitoring over the web"
 
 cat << EOF


### PR DESCRIPTION
Upgrade netdata from version 2.9.0 to 2.10.0. Updated VERSION, SOURCE_VFY, and UPDATED date.

---
*Automated PR created by n8n + Claude AI*