### PR TITLE
libcap-ng: Version bumped to 0.9.3

### DIFF
--- a/libs/libcap-ng/DETAILS
+++ b/libs/libcap-ng/DETAILS
@@ -1,12 +1,12 @@
-          MODULE=libcap-ng
-         VERSION=0.9.2
-          SOURCE=$MODULE-$VERSION.tar.gz
- SOURCE_URL_FULL=https://github.com/stevegrubb/libcap-ng/archive/refs/tags/v$VERSION.tar.gz
-      SOURCE_VFY=sha256:df6910d996818848de92db9c05f96492e008c4e35f96a8673f9b7cc44f5cf813
-        WEB_SITE=https://people.redhat.com/sgrubb/libcap-ng
-         ENTERED=20110205
-         UPDATED=20260325
-           SHORT="Next generation of library capabilities"
+         MODULE=libcap-ng
+        VERSION=0.9.3
+         SOURCE=$MODULE-$VERSION.tar.gz
+SOURCE_URL_FULL=https://github.com/stevegrubb/libcap-ng/archive/refs/tags/v$VERSION.tar.gz
+     SOURCE_VFY=sha256:fe11ebbb55904763b3532f19069f13ec319042634620180a03bd4653d301563e
+       WEB_SITE=https://people.redhat.com/sgrubb/libcap-ng
+        ENTERED=20110205
+        UPDATED=20260410
+          SHORT="Next generation of library capabilities"
 
 cat << EOF
 The libcap-ng library is intended to make programming with posix capabilities


### PR DESCRIPTION
Upgrade libcap-ng from 0.9.2 to 0.9.3

This release updates libcap-ng to version 0.9.3 with the latest upstream improvements.

- Version: 0.9.2 → 0.9.3
- Source: GitHub tag v0.9.3
- SHA256: fe11ebbb55904763b3532f19069f13ec319042634620180a03bd4653d301563e

---
*Automated PR created by n8n + Claude AI*