### PR TITLE
sqlite: Version bumped to 3530000

### DIFF
--- a/sql/sqlite/DETAILS
+++ b/sql/sqlite/DETAILS
@@ -1,12 +1,12 @@
           MODULE=sqlite
-         VERSION=3520000
+         VERSION=3530000
           SOURCE=$MODULE-src-$VERSION.zip
       SOURCE_URL=https://sqlite.org/2026
-      SOURCE_VFY=sha256:652a98ca833ed638809a52bec225a7f37799f71a995778f9ccb68ad03bd1fc11
+      SOURCE_VFY=sha256:fbc30cdbfcfa42c78fe7bddd3fd37ab8995369a31d39097a5d0633296c0b6e65
 SOURCE_DIRECTORY=$BUILD_DIRECTORY/sqlite-src-$VERSION/
         WEB_SITE=https://sqlite.org
          ENTERED=20011016
-         UPDATED=20260308
+         UPDATED=20260410
            SHORT="A SQL engine in a C library"
 
 cat << EOF


### PR DESCRIPTION
Upgrade sqlite from version 3520000 to 3530000. Updated SOURCE_VFY checksum and UPDATED date.

---
*Automated PR created by n8n + Claude AI*