### PR TITLE
brave-bin: Version bumped to 1.89.132

### DIFF
--- a/web/brave-bin/DETAILS
+++ b/web/brave-bin/DETAILS
@@ -1,12 +1,12 @@
           MODULE=brave-bin
-         VERSION=1.88.136
+         VERSION=1.89.132
           SOURCE=brave-browser-$VERSION-linux-amd64.zip
       SOURCE_URL=https://github.com/brave/brave-browser/releases/download/v$VERSION/
-      SOURCE_VFY=sha256:d3053b03b141815e1400dd5e9471ca207902ab276ddd9f9964f4035c9fbea0e9
+      SOURCE_VFY=sha256:a32bb2402c7d5d7a5fc2ba6dd77976841a6d5041857674277f47c4c7e11cb9e6
 SOURCE_DIRECTORY=$BUILD_DIRECTORY/brave-browser-$VERSION-linux-amd64
         WEB_SITE=https://brave.com/
          ENTERED=20210628
-         UPDATED=20260325
+         UPDATED=20260410
            SHORT="brave web browser"
 
 cat << EOF


### PR DESCRIPTION
Upgrade brave-bin from 1.88.136 to 1.89.132

- Updated VERSION to 1.89.132
- Updated SOURCE_VFY to a32bb2402c7d5d7a5fc2ba6dd77976841a6d5041857674277f47c4c7e11cb9e6
- Updated UPDATED date to 20260410

---
*Automated PR created by n8n + Claude AI*