### PR TITLE
python-sqlalchemy: Version bumped to 2.0.49

### DIFF
--- a/python/python-sqlalchemy/DETAILS
+++ b/python/python-sqlalchemy/DETAILS
@@ -1,14 +1,14 @@
           MODULE=python-sqlalchemy
-         VERSION=2.0.48
+         VERSION=2.0.49
           SOURCE=sqlalchemy-$VERSION.tar.gz
       SOURCE_URL=https://pypi.io/packages/source/S/SQLAlchemy/
-      SOURCE_VFY=sha256:5ca74f37f3369b45e1f6b7b06afb182af1fd5dde009e4ffd831830d98cbe5fe7
+      SOURCE_VFY=sha256:d15950a57a210e36dd4cec1aac22787e2a4d57ba9318233e2ef8b2daf9ff2d5f
 SOURCE_DIRECTORY=$BUILD_DIRECTORY/sqlalchemy-$VERSION
         WEB_SITE=http://www.sqlalchemy.org/
             TYPE=python3
         REPLACES=SQLAlchemy
          ENTERED=20100102
-         UPDATED=20260303
+         UPDATED=20260410
            SHORT="A Python SQL Toolkit and Object Relational Mapper"
 
 cat << EOF


### PR DESCRIPTION
Upgrade python-sqlalchemy from 2.0.48 to 2.0.49

---
*Automated PR created by n8n + Claude AI*