### PR TITLE
libraqm: Version bumped to 0.10.5

### DIFF
--- a/graphics/libraqm/DETAILS
+++ b/graphics/libraqm/DETAILS
@@ -1,13 +1,13 @@
           MODULE=libraqm
-         VERSION=0.10.4
+         VERSION=0.10.5
           SOURCE=raqm-$VERSION.tar.xz
       SOURCE_URL=https://github.com/HOST-Oman/libraqm/releases/download/v${VERSION}/
-      SOURCE_VFY=sha256:6e7106a92cd2c21f622ccdfd9f6b698271225810b67023911120f2b0a4724ff3
+      SOURCE_VFY=sha256:563053e724892a7b037913110ea2daef50ad575d4fa9f7c368ae1e4515f5e856
 SOURCE_DIRECTORY=$BUILD_DIRECTORY/raqm-$VERSION/
         WEB_SITE=https://github.com/HOST-Oman/libraqm/
             TYPE=meson
          ENTERED=20160610
-         UPDATED=20260409
+         UPDATED=20260411
            SHORT="library and API for text layout"
 
 cat << EOF


### PR DESCRIPTION
Upgrade libraqm from 0.10.4 to 0.10.5. This is a minor version update of the text layout library with FriBiDi, HarfBuzz, and script itemization support.

---
*Automated PR created by n8n + Claude AI*