### PR TITLE
libsodium: Version bumped to 1.0.22

### DIFF
--- a/crypto/libsodium/DETAILS
+++ b/crypto/libsodium/DETAILS
@@ -1,12 +1,12 @@
-          MODULE=libsodium
-         VERSION=1.0.20
-          SOURCE=$MODULE-$VERSION.tar.gz
-      SOURCE_URL=https://download.libsodium.org/libsodium/releases/
-      SOURCE_VFY=sha256:ebb65ef6ca439333c2bb41a0c1990587288da07f6c7fd07cb3a18cc18d30ce19
-        WEB_SITE=https://github.com/jedisct1/libsodium/
-         ENTERED=20150427
-         UPDATED=20190922
-           SHORT="A higher-level cryptographic library"
+    MODULE=libsodium
+   VERSION=1.0.22
+    SOURCE=$MODULE-$VERSION.tar.gz
+SOURCE_URL=https://download.libsodium.org/libsodium/releases/
+SOURCE_VFY=sha256:adbdd8f16149e81ac6078a03aca6fc03b592b89ef7b5ed83841c086191be3349
+  WEB_SITE=https://github.com/jedisct1/libsodium/
+   ENTERED=20150427
+   UPDATED=20260411
+     SHORT="A higher-level cryptographic library"
 
 cat << EOF
 Sodium is a new, easy-to-use software library for encryption, decryption,


### PR DESCRIPTION
Upgrade libsodium from 1.0.20 to 1.0.22. This update maintains backward compatibility and follows the existing module structure.

---
*Automated PR created by n8n + Claude AI*