### PR TITLE
bazel: Version bumped to 9.0.2

### DIFF
--- a/devel/bazel/DETAILS
+++ b/devel/bazel/DETAILS
@@ -1,12 +1,12 @@
-          MODULE=bazel
-         VERSION=9.0.1
-          SOURCE=$MODULE-$VERSION-dist.zip
-      SOURCE_URL=https://github.com/bazelbuild/bazel/releases/download/$VERSION/
-      SOURCE_VFY=sha256:3f336b4510a8210f954fa3a7d6cfbd271b6f9d639732fdc11c000b6fbfca3fbe
-        WEB_SITE=http://bazel.build
-         ENTERED=20170419
-         UPDATED=20260313
-           SHORT="Google's own build tool"
+    MODULE=bazel
+   VERSION=9.0.2
+    SOURCE=$MODULE-$VERSION-dist.zip
+SOURCE_URL=https://github.com/bazelbuild/bazel/releases/download/$VERSION/
+SOURCE_VFY=sha256:d80b8f708e7a5840fd09b853a4343cace7e4c3504d4e8ac67367d4cb6224436e
+  WEB_SITE=http://bazel.build
+   ENTERED=20170419
+   UPDATED=20260411
+     SHORT="Google's own build tool"
 
 cat << EOF
 Bazel is Google's own build tool. Bazel has built-in support for building


### PR DESCRIPTION
Upgrade bazel from 9.0.1 to 9.0.2

- Updated VERSION to 9.0.2
- Updated SOURCE_VFY hash to d80b8f708e7a5840fd09b853a4343cace7e4c3504d4e8ac67367d4cb6224436e
- Updated UPDATED date to 20260411

---
*Automated PR created by n8n + Claude AI*