### PR TITLE
frei0r-plugins: Version bumped to 3.1.0

### DIFF
--- a/video/frei0r-plugins/DETAILS
+++ b/video/frei0r-plugins/DETAILS
@@ -1,12 +1,12 @@
           MODULE=frei0r-plugins
-         VERSION=2.3.3
+         VERSION=3.1.0
           SOURCE=$MODULE-$VERSION.tar.gz
  SOURCE_URL_FULL=https://github.com/dyne/frei0r/archive/v$VERSION.tar.gz
-      SOURCE_VFY=sha256:aeeefe3a9b44761b2cf110017d2b1dfa2ceeb873da96d283ba5157380c5d0ce5
+      SOURCE_VFY=sha256:2997a2cdcac26f9ddb7f05f05e3885ae9bc45896b2a2a8eb00d333f2d36a8979
 SOURCE_DIRECTORY=$BUILD_DIRECTORY/${MODULE%-*}-$VERSION
         WEB_SITE=https://github.com/dyne/frei0r
          ENTERED=20100210
-         UPDATED=20250102
+         UPDATED=20260412
            SHORT="Plugin API for video sources and filters"
 
 cat << EOF


### PR DESCRIPTION
Upgrade frei0r-plugins from 2.3.3 to 3.1.0

- Updated VERSION to 3.1.0
- Updated SOURCE_VFY to sha256:2997a2cdcac26f9ddb7f05f05e3885ae9bc45896b2a2a8eb00d333f2d36a8979
- Updated UPDATED date to 20260412

---
*Automated PR created by n8n + Claude AI*