### PR TITLE
wakatime-cli: Version bumped to 2.2.3

### DIFF
--- a/utils/wakatime-cli/DETAILS
+++ b/utils/wakatime-cli/DETAILS
@@ -1,11 +1,11 @@
          MODULE=wakatime-cli
-        VERSION=2.2.0
+        VERSION=2.2.3
          SOURCE=$MODULE-$VERSION.tar.gz
 SOURCE_URL_FULL=https://github.com/wakatime/wakatime-cli/archive/refs/tags/v$VERSION.tar.gz
-     SOURCE_VFY=sha256:6f41af918d8e2416f6ff4743a2c4fae25f0e30ffe77aeb1c11689492487721ed
+     SOURCE_VFY=sha256:c29065fc59e47441ffea763645a3d17844fcd7b8e7f8a35f827e689350e666b5
        WEB_SITE=https://github.com/wakatime/wakatime-cli
         ENTERED=20220710
-        UPDATED=20260408
+        UPDATED=20260412
           SHORT="Command line interface used by all WakaTime text editor plugins"
 
 cat <<EOF


### PR DESCRIPTION
Upgrade wakatime-cli from 2.2.0 to 2.2.3

- Updated VERSION to 2.2.3
- Updated SOURCE_VFY with new checksum
- Updated UPDATED date to 20260412

---
*Automated PR created by n8n + Claude AI*