### PR TITLE
python-lxml: Version bumped to 6.0.4

### DIFF
--- a/python/python-lxml/DETAILS
+++ b/python/python-lxml/DETAILS
@@ -1,14 +1,14 @@
           MODULE=python-lxml
-         VERSION=6.0.3
+         VERSION=6.0.4
           SOURCE=lxml-$VERSION.tar.gz
       SOURCE_URL=https://pypi.io/packages/source/l/lxml/
-      SOURCE_VFY=sha256:a1664c5139755df44cab3834f4400b331b02205d62d3fdcb1554f63439bf3372
+      SOURCE_VFY=sha256:4137516be2a90775f99d8ef80ec0283f8d78b5d8bd4630ff20163b72e7e9abf2
 SOURCE_DIRECTORY=$BUILD_DIRECTORY/lxml-$VERSION
         WEB_SITE=https://pypi.org/project/lxml/
             TYPE=python3
         REPLACES=lxml
          ENTERED=20021223
-         UPDATED=20260409
+         UPDATED=20260412
            SHORT="Python wrappers for libxml2 and libxslt"
 
 cat << EOF


### PR DESCRIPTION
Upgrade python-lxml from 6.0.3 to 6.0.4

- Version: 6.0.3 → 6.0.4
- Updated: 20260409 → 20260412
- SHA256: a1664c5139755df44cab3834f4400b331b02205d62d3fdcb1554f63439bf3372 → 4137516be2a90775f99d8ef80ec0283f8d78b5d8bd4630ff20163b72e7e9abf2

---
*Automated PR created by n8n + Claude AI*