### PR TITLE
python-build: Version bumped to 1.4.3

### DIFF
--- a/python/python-build/DETAILS
+++ b/python/python-build/DETAILS
@@ -1,12 +1,12 @@
           MODULE=python-build
-         VERSION=1.4.2
+         VERSION=1.4.3
           SOURCE=build-$VERSION.tar.gz
       SOURCE_URL=https://files.pythonhosted.org/packages/source/b/build/
-      SOURCE_VFY=sha256:35b14e1ee329c186d3f08466003521ed7685ec15ecffc07e68d706090bf161d1
+      SOURCE_VFY=sha256:5aa4231ae0e807efdf1fd0623e07366eca2ab215921345a2e38acdd5d0fa0a74
 SOURCE_DIRECTORY=$BUILD_DIRECTORY/build-$VERSION
         WEB_SITE=https://pypi.org/project/build/
          ENTERED=20221025
-         UPDATED=20260401
+         UPDATED=20260413
            SHORT="correct PEP 517 build frontend"
 
 cat << EOF


### PR DESCRIPTION
Upgrade python-build from 1.4.2 to 1.4.3

- Updated VERSION to 1.4.3
- Updated SOURCE_VFY to sha256:5aa4231ae0e807efdf1fd0623e07366eca2ab215921345a2e38acdd5d0fa0a74
- Updated UPDATED date to 20260413

---
*Automated PR created by n8n + Claude AI*