### PR TITLE
radare2: Version bumped to 6.1.4

### DIFF
--- a/editors/radare2/DETAILS
+++ b/editors/radare2/DETAILS
@@ -1,12 +1,12 @@
          MODULE=radare2
-        VERSION=6.1.2
+        VERSION=6.1.4
          SOURCE=$MODULE-$VERSION.tar.gz
 SOURCE_URL_FULL=https://github.com/radareorg/radare2/archive/refs/tags/$VERSION.tar.gz
-     SOURCE_VFY=sha256:f0677266eeb505bec4df12961cbb2adb92cf8202ff3dab05690bcb24c4bf5c52
+     SOURCE_VFY=sha256:e025d623aa253e20b050164e65f140e437c110812a7b4c8b1b1342f692dfb452
        WEB_SITE=https://www.radare.org/n/
            TYPE=meson
         ENTERED=20210429
-        UPDATED=20260320
+        UPDATED=20260413
           SHORT="reverse engineering framework"
 
 cat << EOF


### PR DESCRIPTION
Upgrade radare2 from 6.1.2 to 6.1.4

- Updated VERSION to 6.1.4
- Updated SOURCE_VFY to e025d623aa253e20b050164e65f140e437c110812a7b4c8b1b1342f692dfb452
- Updated UPDATED date to 20260413

---
*Automated PR created by n8n + Claude AI*