### PR TITLE
libmicrohttpd: Version bumped to 1.0.4

### DIFF
--- a/libs/libmicrohttpd/DETAILS
+++ b/libs/libmicrohttpd/DETAILS
@@ -1,12 +1,12 @@
        MODULE=libmicrohttpd
-      VERSION=1.0.3
+      VERSION=1.0.4
        SOURCE=$MODULE-$VERSION.tar.gz
 SOURCE_URL[0]=https://ftp.gnu.org/gnu/$MODULE/
 SOURCE_URL[1]=$GNU_URL/$MODULE/
-   SOURCE_VFY=sha256:7816b57aae199cf5c3645e8770e1be5f0a4dfafbcb24b3772173dc4ee634126a
+   SOURCE_VFY=sha256:d72e5cfccd62bf2f79252edbc3828eeedc088ce71fc47b7c9e3bd7246b3d54de
      WEB_SITE=https://www.gnu.org/software/libmicrohttpd/
       ENTERED=20100904
-      UPDATED=20260402
+      UPDATED=20260413
         SHORT="Small httpd service library"
 
 cat << EOF


### PR DESCRIPTION
Upgrade libmicrohttpd from 1.0.3 to 1.0.4

- Updated VERSION to 1.0.4
- Updated SOURCE_VFY to sha256:d72e5cfccd62bf2f79252edbc3828eeedc088ce71fc47b7c9e3bd7246b3d54de
- Updated UPDATED date to 20260413

---
*Automated PR created by n8n + Claude AI*