### PR TITLE
wakatime-cli: Version bumped to 2.2.5

### DIFF
--- a/utils/wakatime-cli/DETAILS
+++ b/utils/wakatime-cli/DETAILS
@@ -1,11 +1,11 @@
          MODULE=wakatime-cli
-        VERSION=2.2.3
+        VERSION=2.2.5
          SOURCE=$MODULE-$VERSION.tar.gz
 SOURCE_URL_FULL=https://github.com/wakatime/wakatime-cli/archive/refs/tags/v$VERSION.tar.gz
-     SOURCE_VFY=sha256:c29065fc59e47441ffea763645a3d17844fcd7b8e7f8a35f827e689350e666b5
+     SOURCE_VFY=sha256:ddbe8a293c4cb53f689fd6b32c34cd52b7fd2d0f3230f5a0a9d1d87b080f4c0d
        WEB_SITE=https://github.com/wakatime/wakatime-cli
         ENTERED=20220710
-        UPDATED=20260412
+        UPDATED=20260414
           SHORT="Command line interface used by all WakaTime text editor plugins"
 
 cat <<EOF


### PR DESCRIPTION
Upgrade wakatime-cli from 2.2.3 to 2.2.5. Updates SOURCE_VFY to match the new release tarball and bumps UPDATED date to 20260414.

---
*Automated PR created by n8n + Claude AI*