### PR TITLE
mold: Version bumped to 2.41.0

### DIFF
--- a/devel/mold/DETAILS
+++ b/devel/mold/DETAILS
@@ -1,13 +1,13 @@
-          MODULE=mold
-         VERSION=2.40.4
-          SOURCE=$MODULE-$VERSION.tar.gz
- SOURCE_URL_FULL=https://github.com/rui314/mold/archive/refs/tags/v$VERSION.tar.gz
-      SOURCE_VFY=sha256:69414c702ec1084e1fa8ca16da24f167f549e5e11e9ecd5d70a8dcda6f08c249
-        WEB_SITE=https://github.com/rui314/mold
-         ENTERED=20240303
-         UPDATED=20251103
-           SHORT="modern linker"
+         MODULE=mold
+        VERSION=2.41.0
+         SOURCE=$MODULE-$VERSION.tar.gz
+SOURCE_URL_FULL=https://github.com/rui314/mold/archive/refs/tags/v$VERSION.tar.gz
+     SOURCE_VFY=sha256:0a61abac85d818437b425df856822e9d6e9982baeae5a93bcb02fe6c0060c61a
+       WEB_SITE=https://github.com/rui314/mold
+        ENTERED=20240303
+        UPDATED=20260414
+          SHORT="modern linker"
 
 cat << EOF
-Mold is a faster drop-in replacement for existing Unix linkers. 
+Mold is a faster drop-in replacement for existing Unix linkers.
 EOF


### PR DESCRIPTION
Update mold from 2.40.4 to 2.41.0. This is a routine version bump for the modern linker that provides faster linking performance as a drop-in replacement for existing Unix linkers.

---
*Automated PR created by n8n + Claude AI*