### PR TITLE
jemalloc: Version bumped to 5.3.1

### DIFF
--- a/devel/jemalloc/DETAILS
+++ b/devel/jemalloc/DETAILS
@@ -1,12 +1,12 @@
-          MODULE=jemalloc
-         VERSION=5.3.0
-          SOURCE=$MODULE-$VERSION.tar.bz2
-      SOURCE_URL=http://github.com/jemalloc/jemalloc/releases/download/$VERSION
-      SOURCE_VFY=sha256:git config --global core.editor
-        WEB_SITE=https://jemalloc.net/
-         ENTERED=20020318
-         UPDATED=20220522
-           SHORT="A general purpose malloc(3) implementation"
+    MODULE=jemalloc
+   VERSION=5.3.1
+    SOURCE=$MODULE-$VERSION.tar.bz2
+SOURCE_URL=http://github.com/jemalloc/jemalloc/releases/download/$VERSION
+SOURCE_VFY=sha256:3826bc80232f22ed5c4662f3034f799ca316e819103bdc7bb99018a421706f92
+  WEB_SITE=https://jemalloc.net/
+   ENTERED=20020318
+   UPDATED=20260414
+     SHORT="A general purpose malloc(3) implementation"
 
 cat << EOF
 jemalloc is a general purpose malloc(3) implementation that emphasizes


### PR DESCRIPTION
Upgrade jemalloc from 5.3.0 to 5.3.1

- Updated VERSION to 5.3.1
- Updated SOURCE_VFY with correct SHA256 hash
- Updated UPDATED timestamp to 20260414

---
*Automated PR created by n8n + Claude AI*