### PR TITLE
nginx: Version bumped to 1.30.0

### DIFF
--- a/web/nginx/DETAILS
+++ b/web/nginx/DETAILS
@@ -1,12 +1,12 @@
-          MODULE=nginx
-         VERSION=1.29.8
-          SOURCE=$MODULE-$VERSION.tar.gz
-      SOURCE_URL=http://nginx.org/download
-      SOURCE_VFY=sha256:7f1b985dace8fe706dfc288b83927c928f0ae60bcb7507c2d4e0025eca7280c3
-        WEB_SITE=http://nginx.org
-         ENTERED=20111228
-         UPDATED=20260408
-           SHORT="http server and reverse proxy"
+    MODULE=nginx
+   VERSION=1.30.0
+    SOURCE=$MODULE-$VERSION.tar.gz
+SOURCE_URL=http://nginx.org/download
+SOURCE_VFY=sha256:058188c64bf22baecaa72b809a6318a4f9ba623889c554feab03f7cb853ab31b
+  WEB_SITE=http://nginx.org
+   ENTERED=20111228
+   UPDATED=20260416
+     SHORT="http server and reverse proxy"
 
 cat << EOF
 nginx [engine x] is an HTTP and reverse proxy server, as well as a mail proxy


### PR DESCRIPTION
Upgrade nginx to version 1.30.0

- Version: 1.29.8 → 1.30.0
- SHA256: 058188c64bf22baecaa72b809a6318a4f9ba623889c554feab03f7cb853ab31b
- Updated: 20260416

---
*Automated PR created by n8n + Claude AI*