### PR TITLE
jenkins: Version bumped to 2.559

### DIFF
--- a/devel/jenkins/DETAILS
+++ b/devel/jenkins/DETAILS
@@ -1,11 +1,11 @@
          MODULE=jenkins
-        VERSION=2.558
+        VERSION=2.559
          SOURCE=$MODULE-$VERSION.war
 SOURCE_URL_FULL=http://mirrors.jenkins.io/war/$VERSION/jenkins.war
-     SOURCE_VFY=sha256:90b442043cc8bf3f7766d5950f70fdb7d4896513f73fdd40366628803ed9e896
+     SOURCE_VFY=sha256:507fc03ef62242e9f687a0ddb1cf7ed90d77c35a248734703b0e001a13046ac1
        WEB_SITE=https://www.jenkins.io/
         ENTERED=20141027
-        UPDATED=20260408
+        UPDATED=20260416
           SHORT="Extendable continuous integration server"
 ARCHIVE=off
 LDD_CHECK=off


### PR DESCRIPTION
Upgrade jenkins from 2.558 to 2.559

- Updated VERSION to 2.559
- Updated SOURCE_VFY with new SHA256 checksum
- Updated UPDATED date to 20260416

---
*Automated PR created by n8n + Claude AI*