### PR TITLE
libmicrohttpd: Version bumped to 1.0.5

### DIFF
--- a/libs/libmicrohttpd/DETAILS
+++ b/libs/libmicrohttpd/DETAILS
@@ -1,12 +1,12 @@
        MODULE=libmicrohttpd
-      VERSION=1.0.4
+      VERSION=1.0.5
        SOURCE=$MODULE-$VERSION.tar.gz
 SOURCE_URL[0]=https://ftp.gnu.org/gnu/$MODULE/
 SOURCE_URL[1]=$GNU_URL/$MODULE/
-   SOURCE_VFY=sha256:d72e5cfccd62bf2f79252edbc3828eeedc088ce71fc47b7c9e3bd7246b3d54de
+   SOURCE_VFY=sha256:b46d00f58efa6f497b97d2e782c4ee66301d412ddd855dd3068518b3a2cd3ea2
      WEB_SITE=https://www.gnu.org/software/libmicrohttpd/
       ENTERED=20100904
-      UPDATED=20260413
+      UPDATED=20260416
         SHORT="Small httpd service library"
 
 cat << EOF


### PR DESCRIPTION
Update libmicrohttpd to version 1.0.5 with new SHA256 checksum b46d00f58efa6f497b97d2e782c4ee66301d412ddd855dd3068518b3a2cd3ea2

---
*Automated PR created by n8n + Claude AI*