### PR TITLE
faac: Version bumped to 1.50

### DIFF
--- a/audio/faac/DETAILS
+++ b/audio/faac/DETAILS
@@ -1,13 +1,13 @@
           MODULE=faac
-         VERSION=1.40
+         VERSION=1.50
           SOURCE=$MODULE-$VERSION.tar.gz
       SOURCE_URL=https://github.com/knik0/faac/archive/refs/tags/
-      SOURCE_VFY=sha256:3ef4cc1fa6a750003602adc6eea892ca3815becd9145797b787f0999e8b2b89c
+      SOURCE_VFY=sha256:e6876cba00cbd786a7f984d9aaada4d5bcb08d2582100366c70f6164d5c89214
 SOURCE_DIRECTORY=$BUILD_DIRECTORY/faac-faac-$VERSION
         WEB_SITE=http://www.audiocoding.com/
             TYPE=meson
          ENTERED=20050308
-         UPDATED=20250317
+         UPDATED=20260416
            SHORT="ISO AAC audio encoder"
 
 cat << EOF


### PR DESCRIPTION
Upgrade faac from version 1.40 to 1.50. This release includes updates from the official GitHub repository with improved audio encoding capabilities.

---
*Automated PR created by n8n + Claude AI*