### PR TITLE
atuin: Version bumped to 18.15.2

### DIFF
--- a/utils/atuin/DETAILS
+++ b/utils/atuin/DETAILS
@@ -1,11 +1,11 @@
          MODULE=atuin
-        VERSION=18.15.1
+        VERSION=18.15.2
          SOURCE=$MODULE-$VERSION.tar.gz
 SOURCE_URL_FULL=https://github.com/atuinsh/atuin/archive/v$VERSION.tar.gz
-     SOURCE_VFY=sha256:5afbcd5a654604ab3118dbacb91d2202cba51500d92a4f2a3d1e43d023fb4b32
+     SOURCE_VFY=sha256:9f0c9f1b52e42a805da6b448375c7cf38978510bd421e1f3e042c12652a12e54
        WEB_SITE=https://atuin.sh
         ENTERED=20251026
-        UPDATED=20260416
+        UPDATED=20260417
           SHORT="Magical shell history"
 
 cat << EOF


### PR DESCRIPTION
Upgrade atuin from 18.15.1 to 18.15.2

- Updated VERSION to 18.15.2
- Updated SOURCE_VFY checksum
- Updated UPDATED timestamp to 20260417

---
*Automated PR created by n8n + Claude AI*