### PR TITLE
gh: Version bumped to 2.90.0

### DIFF
--- a/devel/gh/DETAILS
+++ b/devel/gh/DETAILS
@@ -1,12 +1,12 @@
           MODULE=gh
-         VERSION=2.89.0
+         VERSION=2.90.0
           SOURCE=gh-cli-$VERSION.tar.gz
  SOURCE_URL_FULL=https://github.com/cli/cli/archive/refs/tags/v$VERSION.tar.gz
-      SOURCE_VFY=sha256:bc9c11f75e4aeb7e1f0bd5f543a3edabb8958655025f8cdc3d9bbe14435a7441
+      SOURCE_VFY=sha256:87a6a3b3df1155e9d253ec6ae273d9e018773498b7ce7570f896a7cb75b64e39
 SOURCE_DIRECTORY=$BUILD_DIRECTORY/cli-$VERSION
         WEB_SITE=https://cli.github.com/
          ENTERED=20210423
-         UPDATED=20260327
+         UPDATED=20260417
            SHORT="Official command-line wrapper for GitHub"
 
 cat << EOF


### PR DESCRIPTION
Upgrade gh from 2.89.0 to 2.90.0

- Updated VERSION to 2.90.0
- Updated SOURCE_VFY to sha256:87a6a3b3df1155e9d253ec6ae273d9e018773498b7ce7570f896a7cb75b64e39
- Updated UPDATED date to 20260417

---
*Automated PR created by n8n + Claude AI*