### PR TITLE
harfbuzz: Version bumped to 14.2.0

### DIFF
--- a/graphics/harfbuzz/DETAILS
+++ b/graphics/harfbuzz/DETAILS
@@ -1,11 +1,11 @@
     MODULE=harfbuzz
-   VERSION=14.1.0
+   VERSION=14.2.0
     SOURCE=$MODULE-$VERSION.tar.xz
 SOURCE_URL=https://github.com/harfbuzz/harfbuzz/releases/download/$VERSION/
-SOURCE_VFY=sha256:ee0eb3a1da2c5a28147f12dff55f6c7d60aeeeb29ac7ef334eabe84c8476c105
+SOURCE_VFY=sha256:94017020f96d025bb66ae91574e4cf334bcad23e8175a8a40565b3721bc2eaff
   WEB_SITE=https://freedesktop.org/wiki/Software/HarfBuzz
    ENTERED=20130511
-   UPDATED=20260406
+   UPDATED=20260420
      SHORT="OpenType text shaping engine"
 
 cat << EOF


### PR DESCRIPTION
Upgrade harfbuzz from 14.1.0 to 14.2.0

- Version: 14.1.0 → 14.2.0
- SHA256: 94017020f96d025bb66ae91574e4cf334bcad23e8175a8a40565b3721bc2eaff
- Source: https://github.com/harfbuzz/harfbuzz/releases/download/14.2.0/harfbuzz-14.2.0.tar.xz

---
*Automated PR created by n8n + Claude AI*