### PR TITLE
opencl-icd-loader: Adding, will be a dependency for opencl-clhpp,

### DIFF
--- a/devel/opencl-icd-loader/DEPENDS
+++ b/devel/opencl-icd-loader/DEPENDS
@@ -1,0 +1,1 @@
+depends cmake

--- a/devel/opencl-icd-loader/DETAILS
+++ b/devel/opencl-icd-loader/DETAILS
@@ -1,0 +1,15 @@
+          MODULE=opencl-icd-loader
+         VERSION=2025.07.22
+          SOURCE=$MODULE-$VERSION.tar.gz
+ SOURCE_URL_FULL=https://github.com/KhronosGroup/OpenCL-ICD-Loader/archive/refs/tags/v$VERSION.tar.gz
+      SOURCE_VFY=sha256:dff7a0b11ad5b63a669358e3476e3dc889a4a361674e5b69b267b944d0794142
+SOURCE_DIRECTORY=$BUILD_DIRECTORY/OpenCL-ICD-Loader-$VERSION
+        WEB_SITE=https://github.com/KhronosGroup/OpenCL-ICD-Loader
+            TYPE=cmake
+         ENTERED=20260420
+         UPDATED=20260420
+        REPLACES=ocl-icd
+           SHORT="the Khronos official OpenCL ICD Loader"
+cat << EOF
+Source code and tests for the Khronos official OpenCL ICD Loader.
+EOF

--- a/devel/opencl-icd-loader/DETAILS
+++ b/devel/opencl-icd-loader/DETAILS
@@ -10,6 +10,7 @@ SOURCE_DIRECTORY=$BUILD_DIRECTORY/OpenCL-ICD-Loader-$VERSION
          UPDATED=20260420
         REPLACES=ocl-icd
            SHORT="the Khronos official OpenCL ICD Loader"
+
 cat << EOF
 Source code and tests for the Khronos official OpenCL ICD Loader.
 EOF


### PR DESCRIPTION
which in turn will be a new depends for upcoming qgis bump.