### PR TITLE
libnetfilter_conntrack: Version bumped to 1.1.1

### DIFF
--- a/net/libnetfilter_conntrack/DETAILS
+++ b/net/libnetfilter_conntrack/DETAILS
@@ -1,11 +1,11 @@
           MODULE=libnetfilter_conntrack
-         VERSION=1.1.0
+         VERSION=1.1.1
           SOURCE=$MODULE-$VERSION.tar.xz
       SOURCE_URL=https://www.netfilter.org/projects/$MODULE/files/
-      SOURCE_VFY=sha256:67edcb4eb826c2f8dc98af08dabff68f3b3d0fe6fb7d9d0ac1ee7ecce0fe694e
+      SOURCE_VFY=sha256:769d3eaf57fa4fbdb05dd12873b6cb9a5be7844d8937e222b647381d44284820
         WEB_SITE=https://www.netfilter.org/projects/libnetfilter_conntrack/
          ENTERED=20181107
-         UPDATED=20241208
+         UPDATED=20260421
            SHORT="An API to the in-kernel connection tracking state table"
 
 cat << EOF


### PR DESCRIPTION
Upgrade libnetfilter_conntrack from 1.1.0 to 1.1.1

---
*Automated PR created by n8n + Claude AI*