### PR TITLE
xmlsec1: Version bumped to 1.3.11

### DIFF
--- a/doc-tools/xmlsec1/DETAILS
+++ b/doc-tools/xmlsec1/DETAILS
@@ -1,12 +1,12 @@
-          MODULE=xmlsec1
-         VERSION=1.3.10
-          SOURCE=$MODULE-$VERSION.tar.gz
-      SOURCE_URL=https://github.com/lsh123/xmlsec/releases/download/$VERSION/
-      SOURCE_VFY=sha256:5915590780566dae4b5d13d51a42fc0e34b30b26fda6f2c5f744ec31b363ee1a
-        WEB_SITE=https://www.aleksey.com/xmlsec/
-         ENTERED=20201101
-         UPDATED=20260403
-           SHORT="XML Security Library"
+    MODULE=xmlsec1
+   VERSION=1.3.11
+    SOURCE=$MODULE-$VERSION.tar.gz
+SOURCE_URL=https://github.com/lsh123/xmlsec/releases/download/$VERSION/
+SOURCE_VFY=sha256:53675e98fa83b48201d24f7bfbcaeaa1b51496b8b19ff969785856bdeb196af3
+  WEB_SITE=https://www.aleksey.com/xmlsec/
+   ENTERED=20201101
+   UPDATED=20260422
+     SHORT="XML Security Library"
 
 cat << EOF
 XML Security Library is a C library based on LibXML2.


### PR DESCRIPTION
Upgrade xmlsec1 from 1.3.10 to 1.3.11

- Updated VERSION to 1.3.11
- Updated SOURCE_VFY to sha256:53675e98fa83b48201d24f7bfbcaeaa1b51496b8b19ff969785856bdeb196af3
- Updated UPDATED date to 20260422
- Preserved all existing module dependencies and build configuration

---
*Automated PR created by n8n + Claude AI*