### PR TITLE
openvpn: Version bumped to 2.7.2

### DIFF
--- a/security/openvpn/DETAILS
+++ b/security/openvpn/DETAILS
@@ -1,11 +1,11 @@
          MODULE=openvpn
-        VERSION=2.7.1
+        VERSION=2.7.2
          SOURCE=$MODULE-$VERSION.tar.gz
 SOURCE_URL_FULL=https://github.com/OpenVPN/openvpn/archive/v$VERSION.tar.gz
-     SOURCE_VFY=sha256:92801c834d8b1193a988f8b6ab52c1e8a92cadaf745a346d2155aea0eb260e6e
+     SOURCE_VFY=sha256:a65cdcb2c4d911fab73daf13a4cf109dc9664e28c094f77aafcd39c7e9d5023e
        WEB_SITE=http://openvpn.net/
         ENTERED=20040127
-        UPDATED=20260401
+        UPDATED=20260423
           SHORT="Highly configurable VPN (Virtual Private Network) daemon"
 
 cat << EOF


### PR DESCRIPTION
Upgrade openvpn from version 2.7.1 to 2.7.2

- Version: 2.7.1 → 2.7.2
- Source: https://github.com/OpenVPN/openvpn/archive/v2.7.2.tar.gz
- SHA256: a65cdcb2c4d911fab73daf13a4cf109dc9664e28c094f77aafcd39c7e9d5023e
- Updated date: 20260423

---
*Automated PR created by n8n + Claude AI*