### PR TITLE
ifuse: Version bumped to 1.2.1

### DIFF
--- a/filesys/ifuse/DETAILS
+++ b/filesys/ifuse/DETAILS
@@ -1,12 +1,13 @@
-          MODULE=ifuse
-         VERSION=1.2.0
-          SOURCE=$MODULE-$VERSION.tar.bz2
-      SOURCE_URL=https://github.com/libimobiledevice/ifuse/releases/download/$VERSION/
-      SOURCE_VFY=sha256:5c584ae999ed52b386b0d2d1af8f8dcba451cddf31d7cd24367b18db0a9a5a9e
-        WEB_SITE=http://www.libimobiledevice.org/
-         ENTERED=20141109
-         UPDATED=20260105
-           SHORT="access the contents of iOS devices"
+    MODULE=ifuse
+   VERSION=1.2.1
+    SOURCE=$MODULE-$VERSION.tar.bz2
+SOURCE_URL=https://github.com/libimobiledevice/ifuse/releases/download/$VERSION/
+SOURCE_VFY=sha256:9d490470ba6553f8052b385bb5330462e46fbe82131ebe65be47a1cc1c70e857
+  WEB_SITE=http://www.libimobiledevice.org/
+   ENTERED=20141109
+   UPDATED=20260423
+     SHORT="access the contents of iOS devices"
+
 cat << EOF
 A fuse filesystem implementation to access the contents of iOS devices.
 EOF


### PR DESCRIPTION
Upgrade ifuse from 1.2.0 to 1.2.1

- Updated VERSION to 1.2.1
- Updated SOURCE_VFY to sha256:9d490470ba6553f8052b385bb5330462e46fbe82131ebe65be47a1cc1c70e857
- Updated UPDATED field to 20260423

---
*Automated PR created by n8n + Claude AI*