### PR TITLE
lcms2: Version bumped to 2.19

### DIFF
--- a/libs/lcms2/DETAILS
+++ b/libs/lcms2/DETAILS
@@ -1,12 +1,12 @@
-          MODULE=lcms2
-         VERSION=2.18
-          SOURCE=$MODULE-$VERSION.tar.gz
-      SOURCE_URL=https://github.com/mm2/Little-CMS/releases/download/lcms${VERSION}/
-      SOURCE_VFY=sha256:ee67be3566f459362c1ee094fde2c159d33fa0390aa4ed5f5af676f9e5004347
-        WEB_SITE=http://www.littlecms.com
-         ENTERED=20100510
-         UPDATED=20260109
-           SHORT="A small, free color management system"
+    MODULE=lcms2
+   VERSION=2.19
+    SOURCE=$MODULE-$VERSION.tar.gz
+SOURCE_URL=https://github.com/mm2/Little-CMS/releases/download/lcms${VERSION}/
+SOURCE_VFY=sha256:49e7e134e4299733dd0eda434fa468997a28ab3d33fa397c642b03644f552216
+  WEB_SITE=http://www.littlecms.com
+   ENTERED=20100510
+   UPDATED=20260424
+     SHORT="A small, free color management system"
 
 cat << EOF
 Little cms intends to be a small-footprint, speed optimized color management


### PR DESCRIPTION
Upgrade lcms2 from version 2.18 to 2.19. Updated SOURCE_VFY checksum and UPDATED date.

---
*Automated PR created by n8n + Claude AI*