### PR TITLE
neon: Version bumped to 0.37.1

### DIFF
--- a/libs/neon/DETAILS
+++ b/libs/neon/DETAILS
@@ -1,12 +1,12 @@
-          MODULE=neon
-         VERSION=0.36.0
-          SOURCE=$MODULE-$VERSION.tar.gz
-      SOURCE_URL=https://notroj.github.io/neon/
-      SOURCE_VFY=sha256:70cc7f2aeebde263906e185b266e04e0de92b38e5f4ecccbf61e8b79177c2f07
-        WEB_SITE=https://notroj.github.io/neon/
-         ENTERED=20020526
-         UPDATED=20251125
-           SHORT="WebDAV client library, with a C interface"
+    MODULE=neon
+   VERSION=0.37.1
+    SOURCE=$MODULE-$VERSION.tar.gz
+SOURCE_URL=https://notroj.github.io/neon/
+SOURCE_VFY=sha256:a99b7262525a454d1065cf76dd17240fd808dfc4ef15636990ff83a5d0d9e740
+  WEB_SITE=https://notroj.github.io/neon/
+   ENTERED=20020526
+   UPDATED=20260425
+     SHORT="WebDAV client library, with a C interface"
 
 cat << EOF
 neon is an HTTP and WebDAV client library, with a C interface. Featuring:


### PR DESCRIPTION
Upgrade neon from 0.36.0 to 0.37.1

- Updated VERSION to 0.37.1
- Updated SOURCE_VFY to a99b7262525a454d1065cf76dd17240fd808dfc4ef15636990ff83a5d0d9e740
- Updated UPDATED timestamp to 20260425

---
*Automated PR created by n8n + Claude AI*