### PR TITLE
fzf: Version bumped to 0.72.0

### DIFF
--- a/utils/fzf/DETAILS
+++ b/utils/fzf/DETAILS
@@ -1,11 +1,11 @@
          MODULE=fzf
-        VERSION=0.71.0
+        VERSION=0.72.0
          SOURCE=$MODULE-$VERSION.tar.gz
 SOURCE_URL_FULL=https://github.com/junegunn/fzf/archive/refs/tags/v$VERSION.tar.gz
-     SOURCE_VFY=sha256:2420f4df1e7c3207a5a74b30c32ff3f3fa88ab6e2eb9e0da92cb27905271a525
+     SOURCE_VFY=sha256:ca5ce083cec5187503ceb96d837c20d8efde85f03e62bba3a8890f8da526f2fc
        WEB_SITE=https://github.com/junegunn/fzf/
         ENTERED=20181112
-        UPDATED=20260404
+        UPDATED=20260426
           SHORT="Command-line fuzzy finder"
 
 cat << EOF


### PR DESCRIPTION
Upgrade fzf from 0.71.0 to 0.72.0. Updated SOURCE_VFY hash and UPDATED date.

---
*Automated PR created by n8n + Claude AI*