### PR TITLE
highway: Version bumped to 1.4.0

### DIFF
--- a/libs/highway/DETAILS
+++ b/libs/highway/DETAILS
@@ -1,12 +1,12 @@
-          MODULE=highway
-         VERSION=1.2.0
-          SOURCE=$MODULE-$VERSION.tar.gz
- SOURCE_URL_FULL=https://github.com/google/highway/archive/refs/tags/$VERSION.tar.gz
-      SOURCE_VFY=sha256:7e0be78b8318e8bdbf6fa545d2ecb4c90f947df03f7aadc42c1967f019e63343
-        WEB_SITE=https://github.com/google/highway/
-         ENTERED=20221214
-         UPDATED=20240601
-           SHORT="provides portable SIMD/vector intrinsics"
+         MODULE=highway
+        VERSION=1.4.0
+         SOURCE=$MODULE-$VERSION.tar.gz
+SOURCE_URL_FULL=https://github.com/google/highway/archive/refs/tags/$VERSION.tar.gz
+     SOURCE_VFY=sha256:e72241ac9524bb653ae52ced768b508045d4438726a303f10181a38f764a453c
+       WEB_SITE=https://github.com/google/highway/
+        ENTERED=20221214
+        UPDATED=20260427
+          SHORT="provides portable SIMD/vector intrinsics"
 
 cat << EOF
 Highway is a C++ library that provides portable SIMD/vector intrinsics.


### PR DESCRIPTION
Upgrade highway from 1.2.0 to 1.4.0. This update includes performance improvements and new SIMD capabilities in the portable vector intrinsics library.

---
*Automated PR created by n8n + Claude AI*