### PR TITLE
libblockdev: Version bumped to 3.5.0

### DIFF
--- a/libs/libblockdev/DETAILS
+++ b/libs/libblockdev/DETAILS
@@ -1,12 +1,12 @@
           MODULE=libblockdev
-         VERSION=3.4.0
+         VERSION=3.5.0
           SOURCE=$MODULE-${VERSION%-*}.tar.gz
       SOURCE_URL=https://github.com/storaged-project/libblockdev/releases/download/$VERSION/
-      SOURCE_VFY=sha256:65ef9a37babd44b85b8ff9b273f90f9f7d5f8ff7b0c76a8edb69240325fd83f4
+      SOURCE_VFY=sha256:bccd30e6b5d11504de60d9889ff6a2a25b07a4ec8f04070f2387e168301b3e3a
 SOURCE_DIRECTORY=$BUILD_DIRECTORY/$MODULE-${VERSION%-*}
         WEB_SITE=https://github.com/storaged-project/libblockdev
          ENTERED=20170811
-         UPDATED=20251003
+         UPDATED=20260427
            SHORT="A library for manipulating block devices"
 
 cat << EOF


### PR DESCRIPTION
Upgrade libblockdev from version 3.4.0 to 3.5.0

---
*Automated PR created by n8n + Claude AI*