### PR TITLE
cups: Version bumped to 2.4.19

### DIFF
--- a/printer/cups/DETAILS
+++ b/printer/cups/DETAILS
@@ -1,11 +1,11 @@
     MODULE=cups
-   VERSION=2.4.18
+   VERSION=2.4.19
     SOURCE=$MODULE-$VERSION-source.tar.gz
 SOURCE_URL=https://github.com/OpenPrinting/cups/releases/download/v${VERSION}/
-SOURCE_VFY=sha256:8fe23bf4905f8889f4bd5ebf375e81916e84754bfc59eccc88cfd7b1e97a741b
+SOURCE_VFY=sha256:820984b12a67f98705785aae2dd1347fe0ac097828001d4583ff64574aed6389
   WEB_SITE=https://www.cups.org/
    ENTERED=20020218
-   UPDATED=20260422
+   UPDATED=20260427
      SHORT="A portable printing layer"
 
 cat << EOF


### PR DESCRIPTION
Upgrade cups from 2.4.18 to 2.4.19. This update includes the latest changes and improvements from the OpenPrinting project. The module retains all existing dependencies and build configuration.

---
*Automated PR created by n8n + Claude AI*