### PR TITLE
openvpn: Version bumped to 2.7.3

### DIFF
--- a/security/openvpn/DETAILS
+++ b/security/openvpn/DETAILS
@@ -1,11 +1,11 @@
          MODULE=openvpn
-        VERSION=2.7.2
+        VERSION=2.7.3
          SOURCE=$MODULE-$VERSION.tar.gz
 SOURCE_URL_FULL=https://github.com/OpenVPN/openvpn/archive/v$VERSION.tar.gz
-     SOURCE_VFY=sha256:a65cdcb2c4d911fab73daf13a4cf109dc9664e28c094f77aafcd39c7e9d5023e
+     SOURCE_VFY=sha256:33531ac2cc24c27b0a920cc16ad8694f4634a2d46af57f52412919884ea813ad
        WEB_SITE=http://openvpn.net/
         ENTERED=20040127
-        UPDATED=20260423
+        UPDATED=20260427
           SHORT="Highly configurable VPN (Virtual Private Network) daemon"
 
 cat << EOF


### PR DESCRIPTION
Upgrade openvpn from 2.7.2 to 2.7.3

- Updated VERSION to 2.7.3
- Updated SOURCE_VFY to sha256:33531ac2cc24c27b0a920cc16ad8694f4634a2d46af57f52412919884ea813ad
- Updated UPDATED timestamp to 20260427

No changes to DEPENDS or BUILD files required for this version.

---
*Automated PR created by n8n + Claude AI*