### PR TITLE
linux-lts: Version bumped to 6.18.25

### DIFF
--- a/kernel/linux-lts/DETAILS
+++ b/kernel/linux-lts/DETAILS
@@ -1,5 +1,5 @@
         MODULE=linux-lts
-       VERSION=6.18.24
+       VERSION=6.18.25
           BASE=$(echo $VERSION | cut -d. -f1,2)
         SOURCE=linux-$BASE.tar.xz
 if [ -n "$(echo $VERSION | cut -d. -f3)" ] ; then
@@ -10,10 +10,10 @@ fi
 SOURCE2_URL[0]=$KERNEL_URL/pub/linux/kernel/v6.x
 SOURCE2_URL[1]=https://www.kernel.org/pub/linux/kernel/v6.x
     SOURCE_VFY=sha256:9106a4605da9e31ff17659d958782b815f9591ab308d03b0ee21aad6c7dced4b
-   SOURCE2_VFY=sha256:fd37b41e4a971c3fb43394bb0d4808710b002cdd948dce3c975767f9b2d99725
+   SOURCE2_VFY=sha256:b8c024f8bf2a2936d788038a92cba406772e9c4ba803668feb962662d3c4d000
       WEB_SITE=https://www.kernel.org/
        ENTERED=20111121
-       UPDATED=20260422
+       UPDATED=20260428
          SHORT="The core of a Linux GNU Operating System"
 TMPFS=off
 KEEP_SOURCE=on


### PR DESCRIPTION
Upgrade linux-lts kernel to version 6.18.25 with updated source checksums

---
*Automated PR created by n8n + Claude AI*