### PR TITLE
aom: Version bumped to 3.13.3

### DIFF
--- a/video/aom/DETAILS
+++ b/video/aom/DETAILS
@@ -1,13 +1,13 @@
           MODULE=aom
-         VERSION=3.13.2
+         VERSION=3.13.3
           SOURCE=libaom-$VERSION.tar.gz
       SOURCE_URL=https://storage.googleapis.com/aom-releases/
-      SOURCE_VFY=sha256:634039cc79c3a3307206b6c25ea759abc0e734c6f4ac14f6dbea5694e46af837
+      SOURCE_VFY=sha256:446a4ae9741cb8f3eeb98c949d25f91b48cb2b8569cae975c4b737392e9024fc
 SOURCE_DIRECTORY=$BUILD_DIRECTORY/libaom-$VERSION
         WEB_SITE=https://aomedia.org/
             TYPE=cmake
          ENTERED=20210117
-         UPDATED=20260328
+         UPDATED=20260428
            SHORT="Alliance for Open Media video codec"
 
 cat << EOF


### PR DESCRIPTION
Upgrade aom from 3.13.2 to 3.13.3

Updates the AV1 Codec Library to the latest release.

- Version: 3.13.2 → 3.13.3
- SHA256: 446a4ae9741cb8f3eeb98c949d25f91b48cb2b8569cae975c4b737392e9024fc

---
*Automated PR created by n8n + Claude AI*