### PR TITLE
libindi: Version bumped to 2.2.1.1

### DIFF
--- a/libs/libindi/DETAILS
+++ b/libs/libindi/DETAILS
@@ -1,12 +1,12 @@
           MODULE=libindi
-         VERSION=2.2.1
+         VERSION=2.2.1.1
           SOURCE=$MODULE-$VERSION.tar.gz
  SOURCE_URL_FULL=https://github.com/indilib/indi/archive/refs/tags/v$VERSION.tar.gz
-      SOURCE_VFY=sha256:3bd2b8460a592f168af983700f1bedaaf454aca693109b3ac6c5bb3195370b22
+      SOURCE_VFY=sha256:270e0767768dcca6879d6a9f410ad6086b067ea492228c48e03ba3803c718271
 SOURCE_DIRECTORY=$BUILD_DIRECTORY/indi-$VERSION
         WEB_SITE=http://www.indilib.org/index.php?title=Main_Page
          ENTERED=20071027
-         UPDATED=20260423
+         UPDATED=20260429
            SHORT="instrument neutral distributed interface control protocol"
 
 cat << EOF


### PR DESCRIPTION
Upgrade libindi from 2.2.1 to 2.2.1.1

- Version: 2.2.1 → 2.2.1.1
- SHA256: 270e0767768dcca6879d6a9f410ad6086b067ea492228c48e03ba3803c718271
- Source: https://github.com/indilib/indi/archive/refs/tags/v2.2.1.1.tar.gz

---
*Automated PR created by n8n + Claude AI*