### PR TITLE
monkey: Version bumped to 1.8.7

### DIFF
--- a/web/monkey/DETAILS
+++ b/web/monkey/DETAILS
@@ -1,11 +1,11 @@
           MODULE=monkey
-         VERSION=1.8.4
+         VERSION=1.8.7
           SOURCE=$MODULE-$VERSION.tar.gz
  SOURCE_URL_FULL=https://github.com/monkey/monkey/archive/refs/tags/v$VERSION.tar.gz
-      SOURCE_VFY=sha256:52b7d75a22180babfe93fe40ad61b9e63ff717b68fb3feaf3e2e5a589ffb1624
+      SOURCE_VFY=sha256:929cbe9732eb7d14c57afc0218d8f97582a44965e2d5c41ef5748ff14ef3957e
         WEB_SITE=https://github.com/monkey/monkey
          ENTERED=20080315
-         UPDATED=20250906
+         UPDATED=20260430
            SHORT="A fast and light web server for Linux."
 
 cat << EOF


### PR DESCRIPTION
Upgrade monkey web server from version 1.8.4 to 1.8.7. Updated SOURCE_VFY hash and UPDATED date.

---
*Automated PR created by n8n + Claude AI*