### PR TITLE
stress-ng: Version bumped to 0.21.01

### DIFF
--- a/utils/stress-ng/DETAILS
+++ b/utils/stress-ng/DETAILS
@@ -1,11 +1,11 @@
          MODULE=stress-ng
-        VERSION=0.21.00
+        VERSION=0.21.01
          SOURCE=$MODULE-$VERSION.tar.gz
 SOURCE_URL_FULL=https://github.com/ColinIanKing/$MODULE/archive/refs/tags/V${VERSION}.tar.gz
-     SOURCE_VFY=sha256:1339cbc6ccbff7e2ee2177bf0fd67e7b94e8ff7b07fe89bcfaec0280d800cf34
+     SOURCE_VFY=sha256:4c898d9b1911124f43f1fb6a18a725badbe795f5b628531afd4b631127ad8073
        WEB_SITE=https://github.com/ColinIanKing/stress-ng
         ENTERED=20250106
-        UPDATED=20260402
+        UPDATED=20260502
           SHORT="stress test a computer system in various selectable ways"
 
 cat << EOF


### PR DESCRIPTION
Upgrade stress-ng from 0.21.00 to 0.21.01

---
*Automated PR created by n8n + Claude AI*