### PR TITLE
starship: Version bumped to 1.25.1

### DIFF
--- a/utils/starship/DETAILS
+++ b/utils/starship/DETAILS
@@ -1,12 +1,12 @@
-          MODULE=starship
-         VERSION=1.24.2
-          SOURCE=$MODULE-$VERSION.tar.gz
- SOURCE_URL_FULL=https://github.com/starship/starship/archive/v$VERSION.tar.gz
-      SOURCE_VFY=sha256:b7ab0ef364f527395b46d2fb7f59f9592766b999844325e35f62c8fa4d528795
-        WEB_SITE=https://starship.rs/
-         ENTERED=20190921
-         UPDATED=20251231
-           SHORT="The cross-shell prompt for astronauts"
+         MODULE=starship
+        VERSION=1.25.1
+         SOURCE=$MODULE-$VERSION.tar.gz
+SOURCE_URL_FULL=https://github.com/starship/starship/archive/v$VERSION.tar.gz
+     SOURCE_VFY=sha256:521306b14066ee7e332d998ef5b5b6455fdc6085c52e86b6316a7cdc37bae1d8
+       WEB_SITE=https://starship.rs/
+        ENTERED=20190921
+        UPDATED=20260502
+          SHORT="The cross-shell prompt for astronauts"
 
 cat << EOF
 Starship is the minimal, blazing fast, and extremely customizable prompt for any


### PR DESCRIPTION
Upgrade starship from 1.24.2 to 1.25.1

- Updated VERSION to 1.25.1
- Updated SOURCE_VFY with new checksum: sha256:521306b14066ee7e332d998ef5b5b6455fdc6085c52e86b6316a7cdc37bae1d8
- Updated UPDATED date to 20260502

---
*Automated PR created by n8n + Claude AI*