### PR TITLE
gmic-qt: Version bumped to 3.7.5

### DIFF
--- a/graphics/gmic-qt/DETAILS
+++ b/graphics/gmic-qt/DETAILS
@@ -1,21 +1,23 @@
 # This uses the same tarball as gmic so if you update gmic 
 # YOU HAVE to update this one.
           MODULE=gmic-qt
-         VERSION=3.7.3
+         VERSION=3.7.5
           SOURCE=gmic\_${VERSION}.tar.gz
       SOURCE_URL=https://gmic.eu/files/source/
-      SOURCE_VFY=sha256:64d5e46077fc203d3e617076ae580f6699da16d7ee2ac63e5bbce0026c4350ba
+      SOURCE_VFY=sha256:159d15a5b6fcd6cf1da676ef971a3fd4ebeadc8d1c009c0f9275c2af4034e5e4
 SOURCE_DIRECTORY=$BUILD_DIRECTORY/gmic-$VERSION
         WEB_SITE=https://gmic.eu
          ENTERED=20201208
-         UPDATED=20260316
+         UPDATED=20260502
            SHORT="GUI components for GMIC"
 
 cat << EOF
- GMIC is a full-featured open-source framework for digital image processing, distributed under the
- CeCILL free software licenses (LGPL-like and/or GPL-compatible). It provides several user interfaces
- to convert / process / visualize generic image datasets, ranging from 1D scalar signals to 3D+t
- sequences of multi-spectral volumetric images, hence including 2D color images. 
+ GMIC is a full-featured open-source framework for digital image processing,
+ distributed under the CeCILL free software licenses (LGPL-like and/or
+ GPL-compatible). It provides several user interfaces to convert / process /
+ visualize generic image datasets, ranging from 1D scalar signals to 3D+t
+ sequences of multi-spectral volumetric images, hence including 2D color images.
  
- This module contains GUIs for GMIC - a QT5 standalone app, and plugins for GIMP, Krita, and DigiKam.
+ This module contains GUIs for GMIC - a QT5 standalone app, and plugins for
+ GIMP, Krita, and DigiKam.
 EOF


### PR DESCRIPTION
Upgrade gmic-qt from version 3.7.3 to 3.7.5. This uses the same tarball as gmic, so ensure gmic is updated to the same version.

---
*Automated PR created by n8n + Claude AI*