### PR TITLE
qtermwidget: Version bumped to 2.4.0

### DIFF
--- a/terminal/qtermwidget/DETAILS
+++ b/terminal/qtermwidget/DETAILS
@@ -1,12 +1,12 @@
-          MODULE=qtermwidget
-         VERSION=2.3.0
-          SOURCE=$MODULE-$VERSION.tar.xz
-      SOURCE_URL=https://github.com/lxqt/qtermwidget/releases/download/$VERSION
-      SOURCE_VFY=sha256:77366c9b45fb3986c63e0ef6ff51cd894b44c363b50a12fa92c0308c94022c32
-        WEB_SITE=https://github.com/lxqt/qtermwidget
-         ENTERED=20200313
-         UPDATED=20251105
-           SHORT="The terminal widget for QTerminal"
+    MODULE=qtermwidget
+   VERSION=2.4.0
+    SOURCE=$MODULE-$VERSION.tar.xz
+SOURCE_URL=https://github.com/lxqt/qtermwidget/releases/download/$VERSION
+SOURCE_VFY=sha256:ceb7d1991ecc0e75b751b6b7786c4962598d367c6e9a0b55f78fc12a49f25304
+  WEB_SITE=https://github.com/lxqt/qtermwidget
+   ENTERED=20200313
+   UPDATED=20260504
+     SHORT="The terminal widget for QTerminal"
 
 cat << EOF
 QTermWidget aims to provide a unicode-enabled, embeddable Qt widget


### PR DESCRIPTION
Upgrade qtermwidget from 2.3.0 to 2.4.0

- Updated VERSION to 2.4.0
- Updated SOURCE_VFY to ceb7d1991ecc0e75b751b6b7786c4962598d367c6e9a0b55f78fc12a49f25304
- Updated UPDATED date to 20260504

---
*Automated PR created by n8n + Claude AI*