### PR TITLE
lxqt-build-tools: Version bumped to 2.4.0

### DIFF
--- a/utils/lxqt-build-tools/DETAILS
+++ b/utils/lxqt-build-tools/DETAILS
@@ -1,12 +1,12 @@
-          MODULE=lxqt-build-tools
-         VERSION=2.3.0
-          SOURCE=$MODULE-$VERSION.tar.xz
-      SOURCE_URL=https://github.com/lxqt/lxqt-build-tools/releases/download/$VERSION
-      SOURCE_VFY=sha256:f979142ceee22993da6f5d43a7eea9b0d8ef1ff9812ea9210f514e9a52407f42
-        WEB_SITE=https://github.com/lxqt/lxqt-build-tools
-         ENTERED=20200313
-         UPDATED=20251105
-           SHORT="Various packaging tools and scripts for LXQt applications"
+    MODULE=lxqt-build-tools
+   VERSION=2.4.0
+    SOURCE=$MODULE-$VERSION.tar.xz
+SOURCE_URL=https://github.com/lxqt/lxqt-build-tools/releases/download/$VERSION
+SOURCE_VFY=sha256:14999ff954e820a23af44389b9f7c65f9e58b2f1c0a559f0badd38f9b459aee6
+  WEB_SITE=https://github.com/lxqt/lxqt-build-tools
+   ENTERED=20200313
+   UPDATED=20260504
+     SHORT="Various packaging tools and scripts for LXQt applications"
 
 cat << EOF
 Various packaging tools and scripts for LXQt applications.


### PR DESCRIPTION
Upgrade lxqt-build-tools from 2.3.0 to 2.4.0

- Updated VERSION to 2.4.0
- Updated SOURCE_VFY to sha256:14999ff954e820a23af44389b9f7c65f9e58b2f1c0a559f0badd38f9b459aee6
- Updated UPDATED date to 20260504

---
*Automated PR created by n8n + Claude AI*