### PR TITLE
jitterentropy: Version bumped to 3.7.0

### DIFF
--- a/system/jitterentropy/DETAILS
+++ b/system/jitterentropy/DETAILS
@@ -1,16 +1,17 @@
           MODULE=jitterentropy
-         VERSION=3.6.2
+         VERSION=3.7.0
           SOURCE=$MODULE-library-$VERSION.tar.gz
  SOURCE_URL_FULL=https://github.com/smuellerDD/jitterentropy-library/archive/refs/tags/v$VERSION.tar.gz
-      SOURCE_VFY=sha256:33825562f62e599d402e9106a5626090572fcb2cb41d157736f236455d1c3fdb
+      SOURCE_VFY=sha256:f5eaccc9d2977c83308651be9379f09f34348398f419e8f8b5bbd95928c777ed
 SOURCE_DIRECTORY=$BUILD_DIRECTORY/$MODULE-library-$VERSION
         WEB_SITE=https://www.chronox.de/jent/
          ENTERED=20200505
-         UPDATED=20250322
+         UPDATED=20260504
            SHORT="CPU Jitter Random Number Generator"
 
 cat << EOF
-The CPU Jitter Random Number Generator provides a non-physical true random number generator
-that works equally in kernel and user land. The only prerequisite is the availability of a
-high-resolution timer that is available in modern CPUs.
+The CPU Jitter Random Number Generator provides a non-physical true random
+number generator that works equally in kernel and user land. The only
+prerequisite is the availability of a high-resolution timer that is available in
+modern CPUs.
 EOF


### PR DESCRIPTION
Upgrade jitterentropy from 3.6.2 to 3.7.0

- Updated VERSION to 3.7.0
- Updated SOURCE_VFY to f5eaccc9d2977c83308651be9379f09f34348398f419e8f8b5bbd95928c777ed
- Updated UPDATED timestamp to 20260504

---
*Automated PR created by n8n + Claude AI*