### PR TITLE
toxcore: Version bumped to 0.2.22

### DIFF
--- a/chat/toxcore/DETAILS
+++ b/chat/toxcore/DETAILS
@@ -1,12 +1,12 @@
           MODULE=toxcore
-         VERSION=0.2.21
+         VERSION=0.2.22
           SOURCE=$MODULE-$VERSION.tar.xz
  SOURCE_URL_FULL=https://github.com/TokTok/c-toxcore/releases/download/v$VERSION/v$VERSION.tar.xz
-      SOURCE_VFY=sha256:9eb8288bd4fa2a95622ba55fc1e21df7d3fb09fc1eab9864e5cf7bdbb06fdd34
+      SOURCE_VFY=sha256:21ccec45c85afae03cdad48642756b28d6b7632715cfa5d901cc63fcb0a170c1
 SOURCE_DIRECTORY=$BUILD_DIRECTORY/tox-$VERSION
         WEB_SITE=https://tox.chat/
          ENTERED=20160215
-         UPDATED=20250819
+         UPDATED=20260505
            SHORT="Secure, configuration-free, P2P Skype replacement backend"
 
 cat << EOF


### PR DESCRIPTION
Upgrade toxcore from 0.2.21 to 0.2.22

- Version: 0.2.21 → 0.2.22
- Source: https://github.com/TokTok/c-toxcore/releases/download/v0.2.22/v0.2.22.tar.xz
- SHA256: 21ccec45c85afae03cdad48642756b28d6b7632715cfa5d901cc63fcb0a170c1

---
*Automated PR created by n8n + Claude AI*