### PR TITLE
libgit2: Version bumped to 1.9.3

### DIFF
--- a/libs/libgit2/DETAILS
+++ b/libs/libgit2/DETAILS
@@ -1,12 +1,12 @@
-          MODULE=libgit2
-         VERSION=1.9.2
-          SOURCE=$MODULE-$VERSION.tar.gz
- SOURCE_URL_FULL=https://github.com/libgit2/libgit2/archive/v$VERSION.tar.gz
-      SOURCE_VFY=sha256:6f097c82fc06ece4f40539fb17e9d41baf1a5a2fc26b1b8562d21b89bc355fe6
-        WEB_SITE=https://libgit2.org/
-         ENTERED=20150205
-         UPDATED=20251206
-           SHORT="Pure C implementation of the Git core methods"
+         MODULE=libgit2
+        VERSION=1.9.3
+         SOURCE=$MODULE-$VERSION.tar.gz
+SOURCE_URL_FULL=https://github.com/libgit2/libgit2/archive/v$VERSION.tar.gz
+     SOURCE_VFY=sha256:d532172d7ab24d2a25944e2434212d63ee85f3650e97b5f7579e7f201a78ad64
+       WEB_SITE=https://libgit2.org/
+        ENTERED=20150205
+        UPDATED=20260505
+          SHORT="Pure C implementation of the Git core methods"
 
 cat << EOF
 libgit2 is a portable, pure C implementation of the Git core methods provided


### PR DESCRIPTION
Upgrade libgit2 from 1.9.2 to 1.9.3

This is a minor version bump that updates libgit2 to the latest stable release.

**Changes:**
- Version: 1.9.2 → 1.9.3
- SHA256: 6f097c82fc06ece4f40539fb17e9d41baf1a5a2fc26b1b8562d21b89bc355fe6 → d532172d7ab24d2a25944e2434212d63ee85f3650e97b5f7579e7f201a78ad64
- Updated: 20251206 → 20260505

No changes to dependencies or build configuration needed for this version.

---
*Automated PR created by n8n + Claude AI*