### PR TITLE
python-matplotlib: Version bumped to 3.10.9

### DIFF
--- a/python/python-matplotlib/DETAILS
+++ b/python/python-matplotlib/DETAILS
@@ -1,14 +1,14 @@
           MODULE=python-matplotlib
-         VERSION=3.10.8
+         VERSION=3.10.9
           SOURCE=matplotlib-$VERSION.tar.gz
       SOURCE_URL=https://pypi.python.org/packages/source/m/matplotlib/
-      SOURCE_VFY=sha256:2299372c19d56bcd35cf05a2738308758d32b9eaed2371898d8f5bd33f084aa3
+      SOURCE_VFY=sha256:fd66508e8c6877d98e586654b608a0456db8d7e8a546eb1e2600efd957302358
 SOURCE_DIRECTORY=$BUILD_DIRECTORY/matplotlib-$VERSION
         WEB_SITE=http://matplotlib.org/
             TYPE=meson
         REPLACES=matplotlib
          ENTERED=20120729
-         UPDATED=20260109
+         UPDATED=20260505
            SHORT="Python 2D plotting library"
 
 cat << EOF


### PR DESCRIPTION
Upgrade python-matplotlib from 3.10.8 to 3.10.9

---
*Automated PR created by n8n + Claude AI*