### PR TITLE
linux-lts: Version bumped to 6.18.27

### DIFF
--- a/kernel/linux-lts/DETAILS
+++ b/kernel/linux-lts/DETAILS
@@ -1,5 +1,5 @@
         MODULE=linux-lts
-       VERSION=6.18.26
+       VERSION=6.18.27
           BASE=$(echo $VERSION | cut -d. -f1,2)
         SOURCE=linux-$BASE.tar.xz
 if [ -n "$(echo $VERSION | cut -d. -f3)" ] ; then
@@ -10,10 +10,10 @@ fi
 SOURCE2_URL[0]=$KERNEL_URL/pub/linux/kernel/v6.x
 SOURCE2_URL[1]=https://www.kernel.org/pub/linux/kernel/v6.x
     SOURCE_VFY=sha256:9106a4605da9e31ff17659d958782b815f9591ab308d03b0ee21aad6c7dced4b
-   SOURCE2_VFY=sha256:4851813df8b58abaa5a68f61bcd31f5b9dc043d8505b230296cd1b5ac1dab9ae
+   SOURCE2_VFY=sha256:1d74406decf73fd0fb365b0e807fec8bc1e1d464e17f59438779f49da189cfae
       WEB_SITE=https://www.kernel.org/
        ENTERED=20111121
-       UPDATED=20260430
+       UPDATED=20260507
          SHORT="The core of a Linux GNU Operating System"
 TMPFS=off
 KEEP_SOURCE=on


### PR DESCRIPTION
Upgrade linux-lts from 6.18.26 to 6.18.27

- VERSION: 6.18.27
- SOURCE_VFY: sha256:9106a4605da9e31ff17659d958782b815f9591ab308d03b0ee21aad6c7dced4b
- SOURCE2_VFY: sha256:1d74406decf73fd0fb365b0e807fec8bc1e1d464e17f59438779f49da189cfae
- UPDATED: 20260507

---
*Automated PR created by n8n + Claude AI*