### PR TITLE
simdjson: Version bumped to 4.6.4

### DIFF
--- a/libs/simdjson/DETAILS
+++ b/libs/simdjson/DETAILS
@@ -1,11 +1,11 @@
          MODULE=simdjson
-        VERSION=4.6.2
+        VERSION=4.6.4
          SOURCE=$MODULE-$VERSION.tar.gz
 SOURCE_URL_FULL=https://github.com/simdjson/simdjson/archive/refs/tags/v$VERSION.tar.gz
-     SOURCE_VFY=sha256:c240d4bffcccda4fe3a2bba2872718d96fc92e56d2615bfac4f9b2bad89a6386
+     SOURCE_VFY=sha256:b091107844fe928158c5c2265c20360fff312889ddf7ebc4528a0f0f8f2ff9cd
        WEB_SITE=https://github.com/simdjson/simdjson
         ENTERED=20240916
-        UPDATED=20260418
+        UPDATED=20260510
           SHORT="parsing gigabytes of JSON per second"
 
 cat << EOF


### PR DESCRIPTION
Upgrade simdjson from 4.6.2 to 4.6.4

- Updated VERSION to 4.6.4
- Updated SOURCE_VFY to sha256:b091107844fe928158c5c2265c20360fff312889ddf7ebc4528a0f0f8f2ff9cd
- Updated UPDATED date to 20260510
- All other fields preserved from existing module

---
*Automated PR created by n8n + Claude AI*