### PR TITLE
openjph: Version bumped to 0.27.2

### DIFF
--- a/graphics/openjph/DETAILS
+++ b/graphics/openjph/DETAILS
@@ -1,13 +1,13 @@
           MODULE=openjph
-         VERSION=0.27.0
+         VERSION=0.27.2
           SOURCE=$MODULE-$VERSION.tar.gz
  SOURCE_URL_FULL=https://github.com/aous72/OpenJPH/archive/refs/tags/$VERSION.tar.gz
 SOURCE_DIRECTORY=$BUILD_DIRECTORY/OpenJPH-$VERSION
-      SOURCE_VFY=sha256:f6768e927d8e4e4884a2efcf500a88d1b6714a48d69516332a9256803a3c8343
+      SOURCE_VFY=sha256:0aee36d16cc7a93aca031bfec7beb7e272c8ea9cfa8773536187f96476d22565
         WEB_SITE=https://github.com/aous72/OpenJPH
             TYPE=cmake
          ENTERED=20251105
-         UPDATED=20260414
+         UPDATED=20260510
            SHORT="implementation of High-throughput JPEG2000"
 
 cat << EOF


### PR DESCRIPTION
Upgrade openjph from 0.27.0 to 0.27.2

---
*Automated PR created by n8n + Claude AI*