### PR TITLE
libical: Version bumped to 4.0.0

### DIFF
--- a/libs/libical/DETAILS
+++ b/libs/libical/DETAILS
@@ -1,12 +1,12 @@
-          MODULE=libical
-         VERSION=3.0.20
-          SOURCE=$MODULE-$VERSION.tar.gz
- SOURCE_URL_FULL=http://github.com/$MODULE/$MODULE/archive/v$VERSION.tar.gz
-      SOURCE_VFY=sha256:e73de92f5a6ce84c1b00306446b290a2b08cdf0a80988eca0a2c9d5c3510b4c2
-        WEB_SITE=https://github.com/libical/libical/
-         ENTERED=20021128
-         UPDATED=20250310
-           SHORT="An implementation of the IETF's Calendar protocol"
+         MODULE=libical
+        VERSION=4.0.0
+         SOURCE=$MODULE-$VERSION.tar.gz
+SOURCE_URL_FULL=http://github.com/$MODULE/$MODULE/archive/v$VERSION.tar.gz
+     SOURCE_VFY=sha256:caa74119c5a83d19e7466f20344ea6ffe4b779198ee33f46d5fab9d574dac207
+       WEB_SITE=https://github.com/libical/libical/
+        ENTERED=20021128
+        UPDATED=20260510
+          SHORT="An implementation of the IETF's Calendar protocol"
 
 cat << EOF
 Libical is an Open Source implementation of the iCalendar protocols and protocol


### PR DESCRIPTION
Upgrade libical from version 3.0.20 to 4.0.0. Updated SOURCE_VFY and UPDATED date.

---
*Automated PR created by n8n + Claude AI*