### PR TITLE
python-apsw: Version bumped to 3.53.1.0

### DIFF
--- a/python/python-apsw/DETAILS
+++ b/python/python-apsw/DETAILS
@@ -1,12 +1,12 @@
           MODULE=python-apsw
-         VERSION=3.51.2.0
+         VERSION=3.53.1.0
           SOURCE=apsw-$VERSION.tar.gz
       SOURCE_URL=https://pypi.python.org/packages/source/a/apsw
-      SOURCE_VFY=sha256:916271dcf55fc3fd150354b6dbbf76d75a1a5e77cbefca3c3603a8b9c51f9529
+      SOURCE_VFY=sha256:4f8978ae8c7c405d0133a6ea590f3342f839143bdf39e46029cb36e2fa418692
 SOURCE_DIRECTORY=$BUILD_DIRECTORY/apsw-$VERSION
         WEB_SITE=http://github.com/rogerbinns/apsw/
          ENTERED=20131005
-         UPDATED=20260303
+         UPDATED=20260511
            SHORT="Another Python SQLite Wrapper"
 
 cat << EOF


### PR DESCRIPTION
Upgrade python-apsw from 3.51.2.0 to 3.53.1.0

---
*Automated PR created by n8n + Claude AI*