### PR TITLE
wcslib: Version bumped to 8.7

### DIFF
--- a/libs/wcslib/DETAILS
+++ b/libs/wcslib/DETAILS
@@ -1,12 +1,12 @@
-          MODULE=wcslib
-         VERSION=8.5
-          SOURCE=$MODULE-$VERSION.tar.bz2
-      SOURCE_URL=ftp://ftp.atnf.csiro.au/pub/software/wcslib/
-      SOURCE_VFY=sha256:f1fd1b78fbfdbabda363f8045e0c59e32735eca45482a5302191e56fe062eace
-        WEB_SITE=https://www.atnf.csiro.au/people/mcalabre/WCS/index.html
-         ENTERED=20140715
-         UPDATED=20251206
-           SHORT="World Coordinate System standard implemented in FITS"
+    MODULE=wcslib
+   VERSION=8.7
+    SOURCE=$MODULE-$VERSION.tar.bz2
+SOURCE_URL=ftp://ftp.atnf.csiro.au/pub/software/wcslib/
+SOURCE_VFY=sha256:792fe05c09544433a9a4ea5480facdbec2da6d28058275b5e9006a1f28c56465
+  WEB_SITE=https://www.atnf.csiro.au/people/mcalabre/WCS/index.html
+   ENTERED=20140715
+   UPDATED=20260511
+     SHORT="World Coordinate System standard implemented in FITS"
 
 cat << EOF
 WCSLIB is a C library, supplied with a full set of Fortran wrappers, that 


### PR DESCRIPTION
Upgrade wcslib from 8.5 to 8.7

- Updated VERSION to 8.7
- Updated SOURCE_VFY to sha256:792fe05c09544433a9a4ea5480facdbec2da6d28058275b5e9006a1f28c56465
- Updated UPDATED timestamp to 20260511
- All other fields preserved from existing module

---
*Automated PR created by n8n + Claude AI*