### PR TITLE
libical: Version bumped to 4.0.1

### DIFF
--- a/libs/libical/DETAILS
+++ b/libs/libical/DETAILS
@@ -1,12 +1,12 @@
-          MODULE=libical
-         VERSION=4.0.0
-          SOURCE=$MODULE-$VERSION.tar.gz
- SOURCE_URL_FULL=http://github.com/$MODULE/$MODULE/archive/v$VERSION.tar.gz
-      SOURCE_VFY=sha256:caa74119c5a83d19e7466f20344ea6ffe4b779198ee33f46d5fab9d574dac207
-        WEB_SITE=https://github.com/libical/libical/
-         ENTERED=20021128
-         UPDATED=20260510
-           SHORT="An implementation of the IETF's Calendar protocol"
+         MODULE=libical
+        VERSION=4.0.1
+         SOURCE=$MODULE-$VERSION.tar.gz
+SOURCE_URL_FULL=http://github.com/$MODULE/$MODULE/archive/v$VERSION.tar.gz
+     SOURCE_VFY=sha256:7c1d8b780ce305a8823e5824ec4d7eb05d85ae8f808836b495aa37b0c3d08337
+       WEB_SITE=https://github.com/libical/libical/
+        ENTERED=20021128
+        UPDATED=20260514
+          SHORT="An implementation of the IETF's Calendar protocol"
 
 cat << EOF
 Libical is an Open Source implementation of the iCalendar protocols and protocol


### PR DESCRIPTION
Upgrade libical from version 4.0.0 to 4.0.1

---
*Automated PR created by n8n + Claude AI*