### PR TITLE
wine: Version bumped to 11.9

### DIFF
--- a/virtual/wine/DETAILS
+++ b/virtual/wine/DETAILS
@@ -1,12 +1,12 @@
-          MODULE=wine
-         VERSION=11.8
-          SOURCE=$MODULE-$VERSION.tar.xz
-      SOURCE_URL=https://dl.winehq.org/wine/source/${VERSION:0:2}.x/
-      SOURCE_VFY=sha256:53aa85995d4b97f0116a1c56b8a6a1417730ef59a277819d2d3d31364ea556b0
-        WEB_SITE=https://www.winehq.org/
-         ENTERED=20010925
-         UPDATED=20260503
-           SHORT="Runs Microsoft Windows programs"
+    MODULE=wine
+   VERSION=11.9
+    SOURCE=$MODULE-$VERSION.tar.xz
+SOURCE_URL=https://dl.winehq.org/wine/source/${VERSION:0:2}.x/
+SOURCE_VFY=sha256:e39cc18db287358a2436f8af498bedc7e444d55eb99ef545b60e778bb4ea0f6f
+  WEB_SITE=https://www.winehq.org/
+   ENTERED=20010925
+   UPDATED=20260516
+     SHORT="Runs Microsoft Windows programs"
 
 cat << EOF
 Wine Is Not an Emulator. It is an alternative implementation of the Windows and


### PR DESCRIPTION
Upgrade wine from 11.8 to 11.9

- Version: 11.8 → 11.9
- Source URL: https://dl.winehq.org/wine/source/11.x/wine-11.9.tar.xz
- SHA256: e39cc18db287358a2436f8af498bedc7e444d55eb99ef545b60e778bb4ea0f6f
- Updated: 20260516

---
*Automated PR created by n8n + Claude AI*