### PR TITLE
libpaper: Version bumped to 2.2.8

### DIFF
--- a/libs/libpaper/DETAILS
+++ b/libs/libpaper/DETAILS
@@ -1,12 +1,12 @@
-          MODULE=libpaper
-         VERSION=2.2.7
-          SOURCE=$MODULE-$VERSION.tar.gz
-      SOURCE_URL=https://github.com/rrthomas/libpaper/releases/download/v$VERSION/
-      SOURCE_VFY=sha256:3925401edf1eda596277bc2485e050b704fd7f364f257c874b0c40ac5aa627c0
-        WEB_SITE=http://packages.debian.org/unstable/source/libpaper
-         ENTERED=20070315
-         UPDATED=20251204
-           SHORT="A paper size library"
+    MODULE=libpaper
+   VERSION=2.2.8
+    SOURCE=$MODULE-$VERSION.tar.gz
+SOURCE_URL=https://github.com/rrthomas/libpaper/releases/download/v$VERSION/
+SOURCE_VFY=sha256:1e330571690191874eca415ec76889dd11bab9887a2302d6a3665cd081c4d77b
+  WEB_SITE=http://packages.debian.org/unstable/source/libpaper
+   ENTERED=20070315
+   UPDATED=20260516
+     SHORT="A paper size library"
 
 cat << EOF
 A paper size library.


### PR DESCRIPTION
Upgrade libpaper from 2.2.7 to 2.2.8

---
*Automated PR created by n8n + Claude AI*