### PR TITLE
freetds: Version bumped to 1.5.18

### DIFF
--- a/sql/freetds/DETAILS
+++ b/sql/freetds/DETAILS
@@ -1,11 +1,11 @@
     MODULE=freetds
-   VERSION=1.5.17
+   VERSION=1.5.18
     SOURCE=$MODULE-$VERSION.tar.bz2
 SOURCE_URL=http://www.freetds.org/files/stable/
-SOURCE_VFY=sha256:6dee48026b7e3e2393d3ea3ce18f8f81a74d6a0f300e9951981ed7bf4de6bbc3
+SOURCE_VFY=sha256:6b2c8b93b9ee7c83855daf745de5878790032f14dbaee553d83a9d211b84dd4b
   WEB_SITE=http://www.freetds.org/
    ENTERED=20030101
-   UPDATED=20260418
+   UPDATED=20260517
      SHORT="OpenSource libraries for Sybase connections"
 
 cat << EOF


### PR DESCRIPTION
Upgrade freetds from version 1.5.17 to 1.5.18. Updated SOURCE_VFY checksum and UPDATED date.

---
*Automated PR created by n8n + Claude AI*