### PR TITLE
swaptop: Version bumped to 1.0.6

### DIFF
--- a/utils/swaptop/DETAILS
+++ b/utils/swaptop/DETAILS
@@ -1,12 +1,12 @@
-          MODULE=swaptop
-         VERSION=1.0.5
-          SOURCE=$MODULE-$VERSION.tar.gz
- SOURCE_URL_FULL=https://github.com/luis-ota/$MODULE/archive/refs/tags/v${VERSION}.tar.gz
-      SOURCE_VFY=sha256:20bcd3b83e7fe29100771d4adc932cec9c8c14e1361be7c7608d70ba515af80f
-        WEB_SITE=https://github.com/luis-ota/swaptop
-         ENTERED=20251202
-         UPDATED=20251213
-           SHORT="A swap usage monitor"
+         MODULE=swaptop
+        VERSION=1.0.6
+         SOURCE=$MODULE-$VERSION.tar.gz
+SOURCE_URL_FULL=https://github.com/luis-ota/$MODULE/archive/refs/tags/v${VERSION}.tar.gz
+     SOURCE_VFY=sha256:9197ec8821c5705a972d763d9c5f715624f0a31a1dd72a88804306654b3a2c22
+       WEB_SITE=https://github.com/luis-ota/swaptop
+        ENTERED=20251202
+        UPDATED=20260517
+          SHORT="A swap usage monitor"
 
 cat << EOF
 swaptop is a real-time swap usage monitor for Linux and Windows systems with


### PR DESCRIPTION
Upgrade swaptop from 1.0.5 to 1.0.6. Updated VERSION, SOURCE_VFY, and UPDATED date. All other module files remain unchanged.

---
*Automated PR created by n8n + Claude AI*