### PR TITLE
hwdata: Version bumped to 0.407

### DIFF
--- a/system/hwdata/DETAILS
+++ b/system/hwdata/DETAILS
@@ -1,11 +1,11 @@
          MODULE=hwdata
-        VERSION=0.406
+        VERSION=0.407
          SOURCE=$MODULE-$VERSION.tar.gz
 SOURCE_URL_FULL=https://github.com/vcrhonek/hwdata/archive/refs/tags/v$VERSION.tar.gz
-     SOURCE_VFY=sha256:1ccfd1ca723595b1fe8794f4157ec5635be1ebedb5d13769b4be75d0b75bc199
+     SOURCE_VFY=sha256:6a88f6f5cb510fbfaa9c49488348b7fcd7aa209b0a331f24dfebb1c8c339568b
        WEB_SITE=https://github.com/vcrhonek/hwdata
         ENTERED=20220214
-        UPDATED=20260402
+        UPDATED=20260518
           SHORT="hardware identification database"
 
 cat << EOF


### PR DESCRIPTION
Upgrade hwdata from 0.406 to 0.407

- Version: 0.406 → 0.407
- SHA256: 6a88f6f5cb510fbfaa9c49488348b7fcd7aa209b0a331f24dfebb1c8c339568b
- Updated: 20260518

---
*Automated PR created by n8n + Claude AI*