### PR TITLE
conky: Version bumped to 1.23.0

### DIFF
--- a/x11-utils/conky/DETAILS
+++ b/x11-utils/conky/DETAILS
@@ -1,11 +1,11 @@
           MODULE=conky
-         VERSION=1.22.3
+         VERSION=1.23.0
           SOURCE=$MODULE-$VERSION.tar.gz
  SOURCE_URL_FULL=https://github.com/brndnmtthws/conky/archive/v$VERSION.tar.gz
-      SOURCE_VFY=sha256:645af6bbd3b1f8ad44cb427b3e3d6a97db05687aeee33021d4348c39215ab28f
+      SOURCE_VFY=sha256:039bdc6d14a355586b462cb0a6ffdeb3e2f9b354a5348dd88f8ad22d4538b783
         WEB_SITE=https://conky.sourceforge.net
          ENTERED=20060221
-         UPDATED=20260323
+         UPDATED=20260518
            SHORT="A light-weight system monitor"
 
 cat << EOF


### PR DESCRIPTION
Upgrade conky to version 1.23.0. Updated SOURCE_VFY checksum and UPDATED date. No dependency or build changes required.

---
*Automated PR created by n8n + Claude AI*