### PR TITLE
sox: Version bumped to 14.8.0

### DIFF
--- a/audio/sox/DETAILS
+++ b/audio/sox/DETAILS
@@ -1,12 +1,12 @@
           MODULE=sox
-         VERSION=14.7.1.1
+         VERSION=14.8.0
           SOURCE=${MODULE}_ng-${VERSION}.tar.gz
       SOURCE_URL=https://codeberg.org/sox_ng/sox_ng/releases/download/sox_ng-$VERSION/
-      SOURCE_VFY=sha256:88720ce6c7701cb2c4e55f5437d6a5a2b2670a628240b0aeea63597a20ee92a0
+      SOURCE_VFY=sha256:341777dda6fd13376418d788c2e20e8c362b95c4a896ea42700d8b4566879d73
 SOURCE_DIRECTORY=$BUILD_DIRECTORY/sox_ng-$VERSION
         WEB_SITE=https://sox.sourceforge.net
          ENTERED=20010922
-         UPDATED=20260313
+         UPDATED=20260519
            SHORT="Swiss Army knife of sound processing tools"
 
 cat << EOF


### PR DESCRIPTION
Upgrade sox from 14.7.1.1 to 14.8.0

- Updated VERSION to 14.8.0
- Updated SOURCE_VFY checksum
- Updated UPDATED date to 20260519
- Source URL pattern remains consistent with sox_ng releases

---
*Automated PR created by n8n + Claude AI*