### PR TITLE
gpgmepp: Version bumped to 2.1.0

### DIFF
--- a/crypto/gpgmepp/DETAILS
+++ b/crypto/gpgmepp/DETAILS
@@ -1,13 +1,13 @@
-          MODULE=gpgmepp
-         VERSION=2.0.0
-          SOURCE=$MODULE-$VERSION.tar.xz
-      SOURCE_URL=https://www.mirrorservice.org/sites/ftp.gnupg.org/gcrypt/gpgmepp/
-      SOURCE_VFY=sha256:d4796049c06708a26f3096f748ef095347e1a3c1e570561701fe952c3f565382
-        WEB_SITE=http://www.gnupg.org/gpgme.html
-            TYPE=cmake
-         ENTERED=20251001
-         UPDATED=20251004
-           SHORT="C++ bindings for GPGME"
+    MODULE=gpgmepp
+   VERSION=2.1.0
+    SOURCE=$MODULE-$VERSION.tar.xz
+SOURCE_URL=https://www.mirrorservice.org/sites/ftp.gnupg.org/gcrypt/gpgmepp/
+SOURCE_VFY=sha256:57f804468f0204504b172c6b139cb05124b4263be7ad514932c7c4c5062a16e2
+  WEB_SITE=http://www.gnupg.org/gpgme.html
+      TYPE=cmake
+   ENTERED=20251001
+   UPDATED=20260519
+     SHORT="C++ bindings for GPGME"
 
 cat << EOF
 C++ bindings for GPGME.


### PR DESCRIPTION
Upgrade gpgmepp from 2.0.0 to 2.1.0

- Updated VERSION to 2.1.0
- Updated SOURCE_VFY with new sha256 checksum
- Updated UPDATED date to 20260519

---
*Automated PR created by n8n + Claude AI*