### PR TITLE
libde265: Version bumped to 1.0.19

### DIFF
--- a/video/libde265/DETAILS
+++ b/video/libde265/DETAILS
@@ -1,11 +1,11 @@
           MODULE=libde265
-         VERSION=1.0.18
+         VERSION=1.0.19
           SOURCE=$MODULE-$VERSION.tar.gz
       SOURCE_URL=https://github.com/strukturag/libde265/releases/download/v$VERSION/
-      SOURCE_VFY=sha256:800478f3bf35f0621b14928ceb317579f3e8b23de4bd2aac29b6cb8be962bbd8
+      SOURCE_VFY=sha256:bb19a0b485d2643e0eeb7e91f3ab32d1ad617e7c487dbedc91214ca3dbd8d7eb
         WEB_SITE=https://github.com/strukturag/libde265
          ENTERED=20181108
-         UPDATED=20260317
+         UPDATED=20260520
            SHORT="Open h.265 video codec implementation"
 
 cat << EOF


### PR DESCRIPTION
Upgrade libde265 from 1.0.18 to 1.0.19

- Updated VERSION to 1.0.19
- Updated SOURCE_VFY to bb19a0b485d2643e0eeb7e91f3ab32d1ad617e7c487dbedc91214ca3dbd8d7eb
- Updated UPDATED date to 20260520
- No changes to DEPENDS or BUILD files

---
*Automated PR created by n8n + Claude AI*