### PR TITLE
libheif: Version bumped to 1.22.0

### DIFF
--- a/libs/libheif/DETAILS
+++ b/libs/libheif/DETAILS
@@ -1,12 +1,12 @@
-          MODULE=libheif
-         VERSION=1.21.2
-          SOURCE=$MODULE-$VERSION.tar.gz
-      SOURCE_URL=https://github.com/strukturag/libheif/releases/download/v$VERSION/
-      SOURCE_VFY=sha256:75f530b7154bc93e7ecf846edfc0416bf5f490612de8c45983c36385aa742b42
-        WEB_SITE=https://github.com/strukturag/libheif/
-         ENTERED=20181108
-         UPDATED=20260116
-           SHORT="HEIF file format decoder and encoder"
+    MODULE=libheif
+   VERSION=1.22.0
+    SOURCE=$MODULE-$VERSION.tar.gz
+SOURCE_URL=https://github.com/strukturag/libheif/releases/download/v$VERSION/
+SOURCE_VFY=sha256:8bd20cfa3201997b8f63266cddfabea2e1481467d7f992e6a2595e0bec691fc2
+  WEB_SITE=https://github.com/strukturag/libheif/
+   ENTERED=20181108
+   UPDATED=20260520
+     SHORT="HEIF file format decoder and encoder"
 
 cat << EOF
 libheif is a ISO/IEC 23008-12:2017 HEIF file format decoder and encoder.


### PR DESCRIPTION
Upgrade libheif from 1.21.2 to 1.22.0. Updates VERSION, SOURCE_VFY, and UPDATED date.

---
*Automated PR created by n8n + Claude AI*