### PR TITLE
hplip: Version bumped to 3.26.4

### DIFF
--- a/printer/hplip/DETAILS
+++ b/printer/hplip/DETAILS
@@ -1,13 +1,14 @@
-          MODULE=hplip
-         VERSION=3.25.8
-          SOURCE=$MODULE-$VERSION.tar.gz
-      SOURCE_URL=https://downloads.sourceforge.net/$MODULE/
-      SOURCE_VFY=sha256:1cf6d6c28735435c8eb6646e83bcfb721e51c4b1f0e8cf9105a6faf96dc9ad25
-        WEB_SITE=https://developers.hp.com/hp-linux-imaging-and-printing
-         ENTERED=20061216
-         UPDATED=20251117
-           SHORT="Hewlett Packard's drivers for HP printers"
+    MODULE=hplip
+   VERSION=3.26.4
+    SOURCE=$MODULE-$VERSION.tar.gz
+SOURCE_URL=https://downloads.sourceforge.net/$MODULE/
+SOURCE_VFY=sha256:b9c61252754f35b4a237396ca8961e7b3e0c56db76d66a6712b7bf3e30e69463
+  WEB_SITE=https://developers.hp.com/hp-linux-imaging-and-printing
+   ENTERED=20061216
+   UPDATED=20260520
+     SHORT="Hewlett Packard's drivers for HP printers"
 PSAFE=no
+
 cat << EOF
 HPLIP is an HP developed solution for printing, scanning, and faxing with HP
 inkjet and laser based printers in Linux.


### PR DESCRIPTION
Upgrade hplip from 3.25.8 to 3.26.4

- Version: 3.25.8 → 3.26.4
- SHA256: b9c61252754f35b4a237396ca8961e7b3e0c56db76d66a6712b7bf3e30e69463
- Source: https://downloads.sourceforge.net/hplip/hplip-3.26.4.tar.gz

---
*Automated PR created by n8n + Claude AI*