### PR TITLE
isolate: Version bumped to 2.5

### DIFF
--- a/security/isolate/DETAILS
+++ b/security/isolate/DETAILS
@@ -1,11 +1,11 @@
           MODULE=isolate
-         VERSION=2.2.1
+         VERSION=2.5
           SOURCE=$MODULE-$VERSION.tar.gz
  SOURCE_URL_FULL=https://github.com/ioi/isolate/archive/v${VERSION}.tar.gz
-      SOURCE_VFY=sha256:2fa57deb5269f80ba794653a2dab77cd08771a15d1e57796767026d7eac5bd43
+      SOURCE_VFY=sha256:20481ca0d776a045fb081f5d9bc128d03621c5894cc2ee04a3de024586a8906b
         WEB_SITE=http://github.com/ioi/isolate/
          ENTERED=20160201
-         UPDATED=20260103
+         UPDATED=20260521
            SHORT="Sandbox for securely executing untrusted programs"
 
 cat << EOF


### PR DESCRIPTION
Upgrade isolate from 2.2.1 to 2.5

- Version: 2.2.1 → 2.5
- Updated: 20260103 → 20260521
- Source: https://github.com/ioi/isolate/archive/v2.5.tar.gz
- SHA256: 20481ca0d776a045fb081f5d9bc128d03621c5894cc2ee04a3de024586a8906b

---
*Automated PR created by n8n + Claude AI*