### PR TITLE
ghostscript: Version bumped to 10.07.1

### DIFF
--- a/printer/ghostscript/DETAILS
+++ b/printer/ghostscript/DETAILS
@@ -1,12 +1,12 @@
           MODULE=ghostscript
-         VERSION=10.07.0
+         VERSION=10.07.1
           SOURCE=ghostpdl-$VERSION.tar.xz
       SOURCE_URL=https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/download/gs${VERSION//./}/
-      SOURCE_VFY=sha256:ba1366006a93b91e615f74aad9c0905fae503d3f5b04078ce2ddbe360bd2f9df
+      SOURCE_VFY=sha256:56f6a82907c3a73bba95de1319e029adf16477e34df2dea180d390e71e7c4053
 SOURCE_DIRECTORY=$BUILD_DIRECTORY/ghostpdl-$VERSION
         WEB_SITE=https://www.ghostscript.com
          ENTERED=20041116
-         UPDATED=20260316
+         UPDATED=20260521
            SHORT="GPL ghostscript"
 PSAFE=no
 


### PR DESCRIPTION
Upgrade ghostscript from 10.07.0 to 10.07.1

- Updated VERSION to 10.07.1
- Updated SOURCE_VFY to sha256:56f6a82907c3a73bba95de1319e029adf16477e34df2dea180d390e71e7c4053
- Updated UPDATED field to 20260521

---
*Automated PR created by n8n + Claude AI*