### PR TITLE
android-udev-rules: Version bumped to 20260423

### DIFF
--- a/system/android-udev-rules/DETAILS
+++ b/system/android-udev-rules/DETAILS
@@ -1,11 +1,11 @@
           MODULE=android-udev-rules
-         VERSION=20250525
+         VERSION=20260423
           SOURCE=$MODULE-$VERSION.tar.gz
  SOURCE_URL_FULL=https://github.com/M0Rf30/android-udev-rules/archive/$VERSION.tar.gz
-      SOURCE_VFY=sha256:582bf8daa23f318047e77ece4c101c8696fd9151c459f695dca56cf4a40a72a2
+      SOURCE_VFY=sha256:d5cfdbd2bc19dc560424c807298c6822daf4ed1cf8389373dfe029b5dfc7b1a2
         WEB_SITE=https://github.com/M0Rf30/android-udev-rules
          ENTERED=20180812
-         UPDATED=20250528
+         UPDATED=20260521
            SHORT="Android udev rules"
 
 cat << EOF


### PR DESCRIPTION
Upgrade android-udev-rules from version 20250525 to 20260423. This update includes the latest Android device udev rules from the upstream repository.

---
*Automated PR created by n8n + Claude AI*