### PR TITLE
libgit2: Version bumped to 1.9.4

### DIFF
--- a/libs/libgit2/DETAILS
+++ b/libs/libgit2/DETAILS
@@ -1,11 +1,11 @@
          MODULE=libgit2
-        VERSION=1.9.3
+        VERSION=1.9.4
          SOURCE=$MODULE-$VERSION.tar.gz
 SOURCE_URL_FULL=https://github.com/libgit2/libgit2/archive/v$VERSION.tar.gz
-     SOURCE_VFY=sha256:d532172d7ab24d2a25944e2434212d63ee85f3650e97b5f7579e7f201a78ad64
+     SOURCE_VFY=sha256:824b73bd13647800fe4b566a1008ae77fea0e3e3424edab632fcfd8c0b14ba8b
        WEB_SITE=https://libgit2.org/
         ENTERED=20150205
-        UPDATED=20260505
+        UPDATED=20260522
           SHORT="Pure C implementation of the Git core methods"
 
 cat << EOF


### PR DESCRIPTION
libgit2: Version bumped to 1.9.4

Upgrade libgit2 from 1.9.3 to 1.9.4

- VERSION: 1.9.4
- SOURCE_VFY: sha256:824b73bd13647800fe4b566a1008ae77fea0e3e3424edab632fcfd8c0b14ba8b
- UPDATED: 20260522

---
*Automated PR created by n8n + Claude AI*