### PR TITLE
shaderc: Version bumped to 2026.2

### DIFF
--- a/graphics/shaderc/DETAILS
+++ b/graphics/shaderc/DETAILS
@@ -1,15 +1,16 @@
-          MODULE=shaderc
-         VERSION=2025.5
-          SOURCE=$MODULE-$VERSION.tar.gz
- SOURCE_URL_FULL=https://github.com/google/shaderc/archive/refs/tags/v$VERSION.tar.gz
-      SOURCE_VFY=sha256:fca5041b1fdea6daba167b63e04e55e5059fab40828342126169336643445447
-        WEB_SITE=https://github.com/google/shaderc
-         ENTERED=20250811
-         UPDATED=20251228
-           SHORT="tools, libraries and tests for shader compilation"
+         MODULE=shaderc
+        VERSION=2026.2
+         SOURCE=$MODULE-$VERSION.tar.gz
+SOURCE_URL_FULL=https://github.com/google/shaderc/archive/refs/tags/v$VERSION.tar.gz
+     SOURCE_VFY=sha256:f924178e75e3293082481b25ed64d5e48a795b479dac3bd3c83d23070855df42
+       WEB_SITE=https://github.com/google/shaderc
+        ENTERED=20250811
+        UPDATED=20260522
+          SHORT="tools, libraries and tests for shader compilation"
 
 cat << EOF
-A collection of tools, libraries and tests for shader compilation. At the moment it includes:
+A collection of tools, libraries and tests for shader compilation. At the moment
+it includes:
 
 glslc, a command line compiler for GLSL/HLSL to SPIR-V, and
 libshaderc, a library API for accessing glslc functionality.


### PR DESCRIPTION
Upgrade shaderc from 2025.5 to 2026.2

---
*Automated PR created by n8n + Claude AI*