### PR TITLE
wcslib: Version bumped to 8.8

### DIFF
--- a/libs/wcslib/DETAILS
+++ b/libs/wcslib/DETAILS
@@ -1,11 +1,11 @@
     MODULE=wcslib
-   VERSION=8.7
+   VERSION=8.8
     SOURCE=$MODULE-$VERSION.tar.bz2
 SOURCE_URL=ftp://ftp.atnf.csiro.au/pub/software/wcslib/
-SOURCE_VFY=sha256:792fe05c09544433a9a4ea5480facdbec2da6d28058275b5e9006a1f28c56465
+SOURCE_VFY=sha256:dcd5b952e68016d0e2459e1f0f9866343e78b939635db64429fcf478e1ea4bfc
   WEB_SITE=https://www.atnf.csiro.au/people/mcalabre/WCS/index.html
    ENTERED=20140715
-   UPDATED=20260511
+   UPDATED=20260522
      SHORT="World Coordinate System standard implemented in FITS"
 
 cat << EOF


### PR DESCRIPTION
Upgrade wcslib from 8.7 to 8.8

- Version: 8.7 → 8.8
- Source: ftp://ftp.atnf.csiro.au/pub/software/wcslib/wcslib-8.8.tar.bz2
- SHA256: dcd5b952e68016d0e2459e1f0f9866343e78b939635db64429fcf478e1ea4bfc
- Updated: 20260522

---
*Automated PR created by n8n + Claude AI*