### PR TITLE
libphonenumber: Version bumped to 9.0.31

### DIFF
--- a/libs/libphonenumber/DETAILS
+++ b/libs/libphonenumber/DETAILS
@@ -1,11 +1,11 @@
          MODULE=libphonenumber
-        VERSION=9.0.30
+        VERSION=9.0.31
          SOURCE=$MODULE-$VERSION.tar.gz
 SOURCE_URL_FULL=https://github.com/google/libphonenumber/archive/refs/tags/v$VERSION.tar.gz
-     SOURCE_VFY=sha256:677dd2a555e467073e5c6ef7eaa75ecd7d0d6b2c0e71a231d0a70b730bd0f0c6
+     SOURCE_VFY=sha256:dcb2f38bea286c74500c20efdd83300829f2990adeb94dde863c6b12e8670d68
        WEB_SITE=https://github.com/googlei18n/libphonenumber
         ENTERED=20230824
-        UPDATED=20260518
+        UPDATED=20260523
           SHORT="common library to parse, format and validate international phone numbers"
 
 cat << EOF


### PR DESCRIPTION
Upgrade libphonenumber to 9.0.31

Update libphonenumber from 9.0.30 to 9.0.31.

- Version: 9.0.31
- Source: https://github.com/google/libphonenumber/archive/refs/tags/v9.0.31.tar.gz
- SHA256: dcb2f38bea286c74500c20efdd83300829f2990adeb94dde863c6b12e8670d68

---
*Automated PR created by n8n + Claude AI*