### PR TITLE
skim: Version bumped to 4.6.3

### DIFF
--- a/utils/skim/DETAILS
+++ b/utils/skim/DETAILS
@@ -1,11 +1,11 @@
          MODULE=skim
-        VERSION=4.6.1
+        VERSION=4.6.3
          SOURCE=$MODULE-$VERSION.tar.gz
 SOURCE_URL_FULL=https://github.com/skim-rs/skim/archive/v${VERSION}.tar.gz
-     SOURCE_VFY=sha256:76e6f1b968352ea3f13add7ac7e0548cb7c9b5d2beb880c890808d9be0a6b1d3
+     SOURCE_VFY=sha256:ce5bd17c0440760607ff403cf8363437e30b95100840a4704ccbf86c3b0709c2
        WEB_SITE=https://github.com/skim-rs/skim/
         ENTERED=20200627
-        UPDATED=20260426
+        UPDATED=20260523
           SHORT="Fuzzy Finder in rust"
 
 cat << EOF


### PR DESCRIPTION
Upgrade skim from 4.6.1 to 4.6.3. This is a routine version bump with updated checksum and build date.

---
*Automated PR created by n8n + Claude AI*