### PR TITLE
nginx: Version bumped to 1.31.1

### DIFF
--- a/web/nginx/DETAILS
+++ b/web/nginx/DETAILS
@@ -1,11 +1,11 @@
     MODULE=nginx
-   VERSION=1.30.2
+   VERSION=1.31.1
     SOURCE=$MODULE-$VERSION.tar.gz
 SOURCE_URL=http://nginx.org/download
-SOURCE_VFY=sha256:7df3090907fca3cc0e456d6dc00ceb230da74ea88026ceff0affc29dbbd9ac4c
+SOURCE_VFY=sha256:9fcaaeb8f22544b09a19a761f3412c4112215422401634bebdd1296a403cc4bc
   WEB_SITE=http://nginx.org
    ENTERED=20111228
-   UPDATED=20260522
+   UPDATED=20260523
      SHORT="http server and reverse proxy"
 
 cat << EOF


### PR DESCRIPTION
Upgrade nginx from 1.30.2 to 1.31.1

- Updated VERSION to 1.31.1
- Updated SOURCE_VFY to sha256:9fcaaeb8f22544b09a19a761f3412c4112215422401634bebdd1296a403cc4bc
- Updated UPDATED date to 20260523

---
*Automated PR created by n8n + Claude AI*