### PR TITLE
libslirp: Version bumped to 4.9.2

### DIFF
--- a/net/libslirp/DETAILS
+++ b/net/libslirp/DETAILS
@@ -1,13 +1,13 @@
-          MODULE=libslirp
-         VERSION=4.9.1
-          SOURCE=$MODULE-$VERSION.tar.bz2
-      SOURCE_URL=https://gitlab.freedesktop.org/slirp/libslirp/-/archive/v$VERSION
-      SOURCE_VFY=sha256:1bed745adf70f0a903c8101d6a3cd8beccbdf44ca05db1d60f290520b18e1fa4
-        WEB_SITE=https://gitlab.freedesktop.org/slirp/libslirp/
-            TYPE=meson
-         ENTERED=20200402
-         UPDATED=20251113
-           SHORT="General purpose TCP-IP emulator"
+    MODULE=libslirp
+   VERSION=4.9.2
+    SOURCE=$MODULE-$VERSION.tar.bz2
+SOURCE_URL=https://gitlab.freedesktop.org/slirp/libslirp/-/archive/v$VERSION
+SOURCE_VFY=sha256:83f2157dafb087518d0c306f503b735b6d4f30dcaf3c77ec6a06a51625d94c3a
+  WEB_SITE=https://gitlab.freedesktop.org/slirp/libslirp/
+      TYPE=meson
+   ENTERED=20200402
+   UPDATED=20260524
+     SHORT="General purpose TCP-IP emulator"
 
 cat << EOF
 A general purpose TCP-IP emulator used by virtual machine hypervisors to


### PR DESCRIPTION
Upgrade libslirp from version 4.9.1 to 4.9.2. Updated SOURCE_VFY hash and UPDATED date.

---
*Automated PR created by n8n + Claude AI*