### PR TITLE
fzf: Version bumped to 0.73.0

### DIFF
--- a/utils/fzf/DETAILS
+++ b/utils/fzf/DETAILS
@@ -1,11 +1,11 @@
          MODULE=fzf
-        VERSION=0.72.0
+        VERSION=0.73.0
          SOURCE=$MODULE-$VERSION.tar.gz
 SOURCE_URL_FULL=https://github.com/junegunn/fzf/archive/refs/tags/v$VERSION.tar.gz
-     SOURCE_VFY=sha256:ca5ce083cec5187503ceb96d837c20d8efde85f03e62bba3a8890f8da526f2fc
+     SOURCE_VFY=sha256:393a79e3d504af3c5032508d2f33f1517a472bcad5c5081babf2b930f4fce74f
        WEB_SITE=https://github.com/junegunn/fzf/
         ENTERED=20181112
-        UPDATED=20260426
+        UPDATED=20260524
           SHORT="Command-line fuzzy finder"
 
 cat << EOF


### PR DESCRIPTION
Upgrade fzf from 0.72.0 to 0.73.0

- Updated VERSION to 0.73.0
- Updated SOURCE_VFY to sha256:393a79e3d504af3c5032508d2f33f1517a472bcad5c5081babf2b930f4fce74f
- Updated UPDATED timestamp to 20260524

---
*Automated PR created by n8n + Claude AI*