### PR TITLE
capstone: Version bumped to 5.0.8

### DIFF
--- a/utils/capstone/DETAILS
+++ b/utils/capstone/DETAILS
@@ -1,13 +1,14 @@
-          MODULE=capstone
-         VERSION=5.0.6
-          SOURCE=$MODULE-$VERSION.tar.gz
- SOURCE_URL_FULL=https://github.com/capstone-engine/capstone/archive/refs/tags/$VERSION.tar.gz
-      SOURCE_VFY=sha256:240ebc834c51aae41ca9215d3190cc372fd132b9c5c8aa2d5f19ca0c325e28f9
-        WEB_SITE=https://www.capstone-engine.org/index.html
-         ENTERED=20240801
-         UPDATED=20250404
-           SHORT="lightweight multi-platform multi-architecture disassembly framework"
+         MODULE=capstone
+        VERSION=5.0.8
+         SOURCE=$MODULE-$VERSION.tar.gz
+SOURCE_URL_FULL=https://github.com/capstone-engine/capstone/archive/refs/tags/$VERSION.tar.gz
+     SOURCE_VFY=sha256:467e128736227a12a2066c562cfe69a2b7c45353fab3f02a0522d9cd62ccf0f6
+       WEB_SITE=https://www.capstone-engine.org/index.html
+        ENTERED=20240801
+        UPDATED=20260524
+          SHORT="lightweight multi-platform multi-architecture disassembly framework"
 
 cat << EOF
-Capstone is a lightweight multi-platform, multi-architecture disassembly framework.
+Capstone is a lightweight multi-platform, multi-architecture disassembly
+framework.
 EOF


### PR DESCRIPTION
Upgrade capstone from 5.0.6 to 5.0.8

- Version: 5.0.6 → 5.0.8
- SHA256: 467e128736227a12a2066c562cfe69a2b7c45353fab3f02a0522d9cd62ccf0f6
- Updated: 20260524

---
*Automated PR created by n8n + Claude AI*