### PR TITLE
cython: Version bumped to 3.2.5

### DIFF
--- a/compilers/cython/DETAILS
+++ b/compilers/cython/DETAILS
@@ -1,11 +1,11 @@
           MODULE=cython
-         VERSION=3.2.4
+         VERSION=3.2.5
           SOURCE=$MODULE-$VERSION.tar.gz
       SOURCE_URL=https://github.com/cython/cython/releases/download/$VERSION
-      SOURCE_VFY=sha256:84226ecd313b233da27dc2eb3601b4f222b8209c3a7216d8733b031da1dc64e6
+      SOURCE_VFY=sha256:3dd42e4cf36ad15f265bdfec2337cc00c688c8eb6d374ffd13bb19437c27bba1
         WEB_SITE=http://cython.org/
          ENTERED=20120724
-         UPDATED=20260105
+         UPDATED=20260524
         REPLACES=Cython
            SHORT="C extensions for Python"
 


### PR DESCRIPTION
Upgrade cython from 3.2.4 to 3.2.5

- Updated VERSION to 3.2.5
- Updated SOURCE_VFY to sha256:3dd42e4cf36ad15f265bdfec2337cc00c688c8eb6d374ffd13bb19437c27bba1
- Updated UPDATED timestamp to 20260524

---
*Automated PR created by n8n + Claude AI*