### PR TITLE
openexr: version bumped to 3.2.14

### DIFF
--- a/graphics/openexr/DETAILS
+++ b/graphics/openexr/DETAILS
@@ -1,11 +1,11 @@
          MODULE=openexr
-        VERSION=3.4.10
+        VERSION=3.4.12
          SOURCE=$MODULE-$VERSION.tar.gz
 SOURCE_URL_FULL=git+https://github.com/openexr/openexr:$VERSION
 #     SOURCE_VFY=sha256:0c3a1668d80dc34b3385b948e3d1339db5bfdd69e59071f654d59b074d42126c
        WEB_SITE=https://openexr.com/en/latest/
         ENTERED=20050601
-        UPDATED=20260418
+        UPDATED=20260525
           SHORT="A high dynamic-range (HDR) image file format"
 
 cat << EOF


### PR DESCRIPTION
Fixes those CVEs:

[CVE-2026-45696](https://www.cve.org/CVERecord?id=CVE-2026-45696) OpenEXR ht_undo_impl heap-buffer-overflow READ via codestream/channel width mismatch in HTJ2K decode
[CVE-2026-44663](https://www.cve.org/CVERecord?id=CVE-2026-44663) Integer overflow in HTJ2K decoder ( ht_undo_impl ) leading to heap-buffer-overflow
[OSS-Fuzz 512895184](https://issues.oss-fuzz.com/issues/512895184) Null-dereference WRITE in Imf_4_0::TileProcess::run_decode
[OSS-fuzz 512314697](https://issues.oss-fuzz.com/issues/512314697) Direct-leak in internal_exr_add_part
[OSS-fuzz 508362159](https://issues.oss-fuzz.com/issues/508362159) Heap-buffer-overflow in DwaCompressor_uncompress
[OSS-fuzz 507413960](https://issues.oss-fuzz.com/issues/507413960) Heap-buffer-overflow in generic_unpack