### PR TITLE
netcdf: Version bumped to 4.10.0

### DIFF
--- a/science/netcdf/DETAILS
+++ b/science/netcdf/DETAILS
@@ -1,13 +1,13 @@
           MODULE=netcdf
-         VERSION=4.9.3
+         VERSION=4.10.0
           SOURCE=$MODULE-$VERSION.tar.gz
  SOURCE_URL_FULL=https://github.com/Unidata/netcdf-c/archive/v$VERSION.tar.gz
-      SOURCE_VFY=sha256:990f46d49525d6ab5dc4249f8684c6deeaf54de6fec63a187e9fb382cc0ffdff
+      SOURCE_VFY=sha256:ce160f9c1483b32d1ba8b7633d7984510259e4e439c48a218b95a023dc02fd4c
 SOURCE_DIRECTORY=$BUILD_DIRECTORY/$MODULE-c-$VERSION
         WEB_SITE=http://www.unidata.ucar.edu/software/netcdf/
             TYPE=cmake
          ENTERED=20090212
-         UPDATED=20250818
+         UPDATED=20260525
            SHORT="network Common Data Form"
 
 cat << EOF


### PR DESCRIPTION
Upgrade netcdf from 4.9.3 to 4.10.0

- Updated VERSION to 4.10.0
- Updated SOURCE_VFY to ce160f9c1483b32d1ba8b7633d7984510259e4e439c48a218b95a023dc02fd4c
- Updated UPDATED date to 20260525

---
*Automated PR created by n8n + Claude AI*