### PR TITLE
libqalculate: Version bumped to 5.11.0

### DIFF
--- a/science/libqalculate/DETAILS
+++ b/science/libqalculate/DETAILS
@@ -1,14 +1,14 @@
 # If bumping this then check qalculate-qt version, they should be
 # in sync.
-          MODULE=libqalculate
-         VERSION=5.10.0
-          SOURCE=$MODULE-$VERSION.tar.gz
- SOURCE_URL_FULL=https://github.com/Qalculate/libqalculate/archive/refs/tags/v${VERSION}.tar.gz
-      SOURCE_VFY=sha256:0053d1d12361bb07bb8117c2b7fb8df7abc70f73d7346b2fe8731525cb6709fd
-        WEB_SITE=http://qalculate.github.io/
-         ENTERED=20060420
-         UPDATED=20260406
-           SHORT="Multi-purpose desktop calculator"
+         MODULE=libqalculate
+        VERSION=5.11.0
+         SOURCE=$MODULE-$VERSION.tar.gz
+SOURCE_URL_FULL=https://github.com/Qalculate/libqalculate/archive/refs/tags/v${VERSION}.tar.gz
+     SOURCE_VFY=sha256:8fcdcfe234ab34d0307a1dcff661841eb100682fda37a58d24261dc5bc4d581e
+       WEB_SITE=http://qalculate.github.io/
+        ENTERED=20060420
+        UPDATED=20260525
+          SHORT="Multi-purpose desktop calculator"
 
 cat << EOF
 Qalculate! is a multi-purpose desktop calculator for GNU/Linux. It is small


### PR DESCRIPTION
Update libqalculate from 5.10.0 to 5.11.0

- Version: 5.10.0 → 5.11.0
- SHA256: 8fcdcfe234ab34d0307a1dcff661841eb100682fda37a58d24261dc5bc4d581e
- Updated: 20260406 → 20260525

Note: Verify that qalculate-qt is compatible with this version.

---
*Automated PR created by n8n + Claude AI*