### PR TITLE
mbedtls: Version bumped to 3.6.6

### DIFF
--- a/crypto/mbedtls/DETAILS
+++ b/crypto/mbedtls/DETAILS
@@ -1,12 +1,12 @@
-          MODULE=mbedtls
-         VERSION=3.6.5
-          SOURCE=$MODULE-$VERSION.tar.bz2
-      SOURCE_URL=https://github.com/Mbed-TLS/mbedtls/releases/download/mbedtls-$VERSION/
-      SOURCE_VFY=sha256:4a11f1777bb95bf4ad96721cac945a26e04bf19f57d905f241fe77ebeddf46d8
-        WEB_SITE=https://github.com/Mbed-TLS/mbedtls
-         ENTERED=20180104
-         UPDATED=20251206
-           SHORT="Portable cryptographic and SSL/TLS library"
+    MODULE=mbedtls
+   VERSION=3.6.6
+    SOURCE=$MODULE-$VERSION.tar.bz2
+SOURCE_URL=https://github.com/Mbed-TLS/mbedtls/releases/download/mbedtls-$VERSION/
+SOURCE_VFY=sha256:8fb65fae8dcae5840f793c0a334860a411f884cc537ea290ce1c52bb64ca007a
+  WEB_SITE=https://github.com/Mbed-TLS/mbedtls
+   ENTERED=20180104
+   UPDATED=20260525
+     SHORT="Portable cryptographic and SSL/TLS library"
 
 cat << EOF
 Portable cryptographic and SSL/TLS library, aka polarssl.


### PR DESCRIPTION
Update mbedtls from 3.6.5 to 3.6.6

Upgrades the mbedtls cryptographic library to version 3.6.6 with updated SHA256 checksum.

- Version: 3.6.5 → 3.6.6
- Source: https://github.com/Mbed-TLS/mbedtls/releases/download/mbedtls-3.6.6/mbedtls-3.6.6.tar.bz2
- SHA256: 8fb65fae8dcae5840f793c0a334860a411f884cc537ea290ce1c52bb64ca007a

---
*Automated PR created by n8n + Claude AI*