### PR TITLE
firefox: Version bumped to 151.0.2

### DIFF
--- a/web/firefox/DETAILS
+++ b/web/firefox/DETAILS
@@ -1,11 +1,11 @@
     MODULE=firefox
-   VERSION=151.0.1
+   VERSION=151.0.2
     SOURCE=$MODULE-$VERSION.source.tar.xz
 SOURCE_URL=https://archive.mozilla.org/pub/firefox/releases/$VERSION/source
-SOURCE_VFY=sha256:a80ae34238cbf83a507274bc25d215ccac00934ddf26190b02a34fdce60584c0
+SOURCE_VFY=sha256:63c4267799f2618dd7ac5997d0306bbcf2a5306caaca0056795bc6c61d00f8c8
   WEB_SITE=https://www.mozilla.org/en-US/firefox
    ENTERED=20110814
-   UPDATED=20260521
+   UPDATED=20260526
      SHORT="A web browser from mozilla.org"
 
 cat << EOF


### PR DESCRIPTION
Upgrade firefox from 151.0.1 to 151.0.2

- Updated VERSION to 151.0.2
- Updated SOURCE_VFY to sha256:63c4267799f2618dd7ac5997d0306bbcf2a5306caaca0056795bc6c61d00f8c8
- Updated UPDATED timestamp to 20260526

---
*Automated PR created by n8n + Claude AI*