### PR TITLE
sway: Version bumped to 1.12

### DIFF
--- a/wayland/sway/DETAILS
+++ b/wayland/sway/DETAILS
@@ -1,12 +1,12 @@
-          MODULE=sway
-         VERSION=1.11
-          SOURCE=$MODULE-$VERSION.tar.gz
- SOURCE_URL_FULL=https://github.com/swaywm/sway/archive/$VERSION.tar.gz
-      SOURCE_VFY=sha256:034ec4519326d6af5275814700dde46e852c5174614109affe4c86b2fbee062a
-        WEB_SITE=https://swaywm.org/
-         ENTERED=20190329
-         UPDATED=20250731
-           SHORT="Tiling Wayland compositor"
+         MODULE=sway
+        VERSION=1.12
+         SOURCE=$MODULE-$VERSION.tar.gz
+SOURCE_URL_FULL=https://github.com/swaywm/sway/archive/$VERSION.tar.gz
+     SOURCE_VFY=sha256:29ca7caac960d13e02d8213418d91a5422c7c23102a283ceab944c57c5e1efcf
+       WEB_SITE=https://swaywm.org/
+        ENTERED=20190329
+        UPDATED=20260526
+          SHORT="Tiling Wayland compositor"
 
 cat << EOF
 Sway is a tiling Wayland compositor and a drop-in replacement for the i3 window


### PR DESCRIPTION
Upgrade sway from 1.11 to 1.12

- Version: 1.11 → 1.12
- SHA256: 29ca7caac960d13e02d8213418d91a5422c7c23102a283ceab944c57c5e1efcf
- Updated: 20260526

---
*Automated PR created by n8n + Claude AI*