### PR TITLE
rrdtool: Version bumped to 1.10.3

### DIFF
--- a/utils/rrdtool/DETAILS
+++ b/utils/rrdtool/DETAILS
@@ -1,11 +1,11 @@
           MODULE=rrdtool
-         VERSION=1.10.1
+         VERSION=1.10.3
           SOURCE=$MODULE-$VERSION.tar.gz
       SOURCE_URL=https://github.com/oetiker/rrdtool-1.x/releases/download/v$VERSION/
-      SOURCE_VFY=sha256:79a0a4caaa278d42b4208048b2c5b28fced0dd8d4498bbcabac42e5641cc1b20
+      SOURCE_VFY=sha256:843b7caa2a80a815d44ac5c65daa42920cb64586fe804e36d0bc0783554e0635
         WEB_SITE=http://oss.oetiker.ch/rrdtool
          ENTERED=20040217
-         UPDATED=20260520
+         UPDATED=20260526
            SHORT="A graphing library"
 
 cat << EOF


### PR DESCRIPTION
Upgrade rrdtool from 1.10.1 to 1.10.3

- Updated version to 1.10.3
- Updated source checksum: sha256:843b7caa2a80a815d44ac5c65daa42920cb64586fe804e36d0bc0783554e0635
- Updated UPDATED date to 20260526

---
*Automated PR created by n8n + Claude AI*