### PR TITLE
ppp: Version bumped to 2.5.3

### DIFF
--- a/net/ppp/DETAILS
+++ b/net/ppp/DETAILS
@@ -1,11 +1,11 @@
           MODULE=ppp
-         VERSION=2.5.2
+         VERSION=2.5.3
           SOURCE=$MODULE-$VERSION.tar.gz
  SOURCE_URL_FULL=https://github.com/ppp-project/ppp/archive/refs/tags/v${VERSION}.tar.gz
-      SOURCE_VFY=sha256:d7457f0ff409cb2d7a0d8382ef6302520d664895ac5568cb3dce727d71a2a1f5
+      SOURCE_VFY=sha256:8aaed5be77a7582f7850318f326adc67fda04d8307b13773d0c6ba9b0bb0b694
         WEB_SITE=https://ppp.samba.org/
          ENTERED=20010922
-         UPDATED=20250101
+         UPDATED=20260526
            SHORT="A server/client for for point to point protocol"
 
 cat << EOF


### PR DESCRIPTION
Upgrade ppp from 2.5.2 to 2.5.3. This updates the PPP daemon to the latest stable release from the ppp-project GitHub repository.

---
*Automated PR created by n8n + Claude AI*