### PR TITLE
libde265: Version bumped to 1.1.0

### DIFF
--- a/video/libde265/DETAILS
+++ b/video/libde265/DETAILS
@@ -1,11 +1,11 @@
           MODULE=libde265
-         VERSION=1.0.19
+         VERSION=1.1.0
           SOURCE=$MODULE-$VERSION.tar.gz
       SOURCE_URL=https://github.com/strukturag/libde265/releases/download/v$VERSION/
-      SOURCE_VFY=sha256:bb19a0b485d2643e0eeb7e91f3ab32d1ad617e7c487dbedc91214ca3dbd8d7eb
+      SOURCE_VFY=sha256:afc19dd28e2fc523de5952bba5224ee1d28e286c72436d2843df126cca1181fd
         WEB_SITE=https://github.com/strukturag/libde265
          ENTERED=20181108
-         UPDATED=20260520
+         UPDATED=20260526
            SHORT="Open h.265 video codec implementation"
 
 cat << EOF


### PR DESCRIPTION
Upgrade libde265 from 1.0.19 to 1.1.0

- Updates version to 1.1.0
- Updates SOURCE_VFY to afc19dd28e2fc523de5952bba5224ee1d28e286c72436d2843df126cca1181fd
- Updates UPDATED date to 20260526

---
*Automated PR created by n8n + Claude AI*