### PR TITLE
libheif: Version bumped to 1.22.2

### DIFF
--- a/libs/libheif/DETAILS
+++ b/libs/libheif/DETAILS
@@ -1,11 +1,11 @@
     MODULE=libheif
-   VERSION=1.22.1
+   VERSION=1.22.2
     SOURCE=$MODULE-$VERSION.tar.gz
 SOURCE_URL=https://github.com/strukturag/libheif/releases/download/v$VERSION/
-SOURCE_VFY=sha256:379b6abde094ba8f93620b91c230af2d7102945ad641231876074f3b113865fa
+SOURCE_VFY=sha256:eea48e4841f83fbe51d029337ffd2d14512d0203015dad40b90213d872958af3
   WEB_SITE=https://github.com/strukturag/libheif/
    ENTERED=20181108
-   UPDATED=20260525
+   UPDATED=20260526
      SHORT="HEIF file format decoder and encoder"
 
 cat << EOF


### PR DESCRIPTION
Upgrade libheif from 1.22.1 to 1.22.2

---
*Automated PR created by n8n + Claude AI*