### PR TITLE
libwebsockets: Version bumped to 4.5.8

### DIFF
--- a/libs/libwebsockets/DETAILS
+++ b/libs/libwebsockets/DETAILS
@@ -1,12 +1,12 @@
-          MODULE=libwebsockets
-         VERSION=4.5.4
-          SOURCE=$MODULE-$VERSION.tar.gz
- SOURCE_URL_FULL=https://github.com/warmcat/libwebsockets/archive/v${VERSION}.tar.gz
-      SOURCE_VFY=sha256:f2aa31a0be16d45470360b868f3b5b114990da038ba5e49569f0732c58b2d9fc
-        WEB_SITE=https://github.com/warmcat/libwebsockets
-         ENTERED=20210130
-         UPDATED=20260313
-           SHORT="A library for websocket clients and servers"
+         MODULE=libwebsockets
+        VERSION=4.5.8
+         SOURCE=$MODULE-$VERSION.tar.gz
+SOURCE_URL_FULL=https://github.com/warmcat/libwebsockets/archive/v${VERSION}.tar.gz
+     SOURCE_VFY=sha256:b6ade658f4af3a823d0dc806ae5ef0623f0f4f5e2aeb895a0f77c4783840c30e
+       WEB_SITE=https://github.com/warmcat/libwebsockets
+        ENTERED=20210130
+        UPDATED=20260526
+          SHORT="A library for websocket clients and servers"
 
 cat << EOF
 Libwebsockets is a simple-to-use, pure C library providing client and server for


### PR DESCRIPTION
Upgrade libwebsockets from 4.5.4 to 4.5.8

- Updated VERSION to 4.5.8
- Updated SOURCE_VFY to b6ade658f4af3a823d0dc806ae5ef0623f0f4f5e2aeb895a0f77c4783840c30e
- Updated UPDATED timestamp to 20260526

---
*Automated PR created by n8n + Claude AI*