### PR TITLE
libslirp: Version bumped to 4.9.3

### DIFF
--- a/net/libslirp/DETAILS
+++ b/net/libslirp/DETAILS
@@ -1,13 +1,13 @@
           MODULE=libslirp
-         VERSION=4.9.1
+         VERSION=4.9.3
           SOURCE=$MODULE-$VERSION.tar.bz2
       SOURCE_URL=https://gitlab.freedesktop.org/slirp/libslirp/-/archive/v$VERSION/
-      SOURCE_VFY=sha256:1bed745adf70f0a903c8101d6a3cd8beccbdf44ca05db1d60f290520b18e1fa4
+      SOURCE_VFY=sha256:56f784b3cd9df59efde8c886ce50b1b398c4f5eae5d19f82d53046660e11e8c6
 SOURCE_DIRECTORY=$BUILD_DIRECTORY/$MODULE-$VERSION-9c744e1e52aa0d9646ed91d789d588696292c21e
         WEB_SITE=https://gitlab.freedesktop.org/slirp/libslirp/
             TYPE=meson
          ENTERED=20200402
-         UPDATED=20260523
+         UPDATED=20260526
            SHORT="General purpose TCP-IP emulator"
 
 cat << EOF


### PR DESCRIPTION
Upgrade libslirp from 4.9.1 to 4.9.3

- Updated VERSION to 4.9.3
- Updated SOURCE_VFY to sha256:56f784b3cd9df59efde8c886ce50b1b398c4f5eae5d19f82d53046660e11e8c6
- Updated UPDATED date to 20260526

---
*Automated PR created by n8n + Claude AI*