### PR TITLE
m17n-db: Version bumped to 1.8.12

### DIFF
--- a/i18n/m17n-db/DETAILS
+++ b/i18n/m17n-db/DETAILS
@@ -1,12 +1,12 @@
-          MODULE=m17n-db
-         VERSION=1.8.5
-          SOURCE=$MODULE-$VERSION.tar.gz
-      SOURCE_URL=http://download.savannah.gnu.org/releases/m17n/
-      SOURCE_VFY=sha256:b68fff422c0a2864ee56e2c4517382133b981bb4ba39b53f47895cd8b1c0a736
-        WEB_SITE=http://www.nongnu.org/m17n/
-         ENTERED=20170422
-         UPDATED=20231202
-           SHORT="Multilingual text processing library database"
+    MODULE=m17n-db
+   VERSION=1.8.12
+    SOURCE=$MODULE-$VERSION.tar.gz
+SOURCE_URL=http://download.savannah.gnu.org/releases/m17n/
+SOURCE_VFY=sha256:d11ab5820989609d0df303e4211c1f008b665f9b0992a1077bc9f4bd020a29eb
+  WEB_SITE=http://www.nongnu.org/m17n/
+   ENTERED=20170422
+   UPDATED=20260527
+     SHORT="Multilingual text processing library database"
 
 cat << EOF
 Multilingual text processing library database.


### PR DESCRIPTION
Upgrade m17n-db from version 1.8.5 to 1.8.12. This update includes bug fixes and improvements to the multilingual text processing library database.

---
*Automated PR created by n8n + Claude AI*