### PR TITLE
aom: Version bumped to 3.14.1

### DIFF
--- a/video/aom/DETAILS
+++ b/video/aom/DETAILS
@@ -1,13 +1,13 @@
           MODULE=aom
-         VERSION=3.13.3
+         VERSION=3.14.1
           SOURCE=libaom-$VERSION.tar.gz
       SOURCE_URL=https://storage.googleapis.com/aom-releases/
-      SOURCE_VFY=sha256:446a4ae9741cb8f3eeb98c949d25f91b48cb2b8569cae975c4b737392e9024fc
+      SOURCE_VFY=sha256:44bf90dbd23e734d50e70a8c41c285193922938bd0d3bc2ee56764d181d55ef5
 SOURCE_DIRECTORY=$BUILD_DIRECTORY/libaom-$VERSION
         WEB_SITE=https://aomedia.org/
             TYPE=cmake
          ENTERED=20210117
-         UPDATED=20260428
+         UPDATED=20260528
            SHORT="Alliance for Open Media video codec"
 
 cat << EOF


### PR DESCRIPTION
Upgrade aom from 3.13.3 to 3.14.1

- Updated VERSION to 3.14.1
- Updated SOURCE_VFY to sha256:44bf90dbd23e734d50e70a8c41c285193922938bd0d3bc2ee56764d181d55ef5
- Updated UPDATED date to 20260528

---
*Automated PR created by n8n + Claude AI*