### PR TITLE
clifm: Version bumped to 1.28

### DIFF
--- a/filemanagers/clifm/DETAILS
+++ b/filemanagers/clifm/DETAILS
@@ -1,12 +1,12 @@
-          MODULE=clifm
-         VERSION=1.27.1
-          SOURCE=$MODULE-$VERSION.tar.gz
- SOURCE_URL_FULL=https://github.com/leo-arch/clifm/archive/refs/tags/v${VERSION}.tar.gz
-      SOURCE_VFY=sha256:a35cd1ccbb83f1261c3c5b14b5b4733cf0555be68579b3cb19fa8b36076a5339
-        WEB_SITE=https://github.com/leo-arch/clifm/wiki/
-         ENTERED=20210117
-         UPDATED=20260110
-           SHORT="The KISS text-based file manager"
+         MODULE=clifm
+        VERSION=1.28
+         SOURCE=$MODULE-$VERSION.tar.gz
+SOURCE_URL_FULL=https://github.com/leo-arch/clifm/archive/refs/tags/v${VERSION}.tar.gz
+     SOURCE_VFY=sha256:65ac33825fb55d6388c1044572e464a50ad367b607448774fb396d850b7c4420
+       WEB_SITE=https://github.com/leo-arch/clifm/wiki/
+        ENTERED=20210117
+        UPDATED=20260528
+          SHORT="The KISS text-based file manager"
 
 cat << EOF
 The KISS file manager: text-based, ultra-lightweight, lightning fast, and


### PR DESCRIPTION
Upgrade clifm from 1.27.1 to 1.28

---
*Automated PR created by n8n + Claude AI*