### PR TITLE
cbindgen: Version bumped to 0.29.3

### DIFF
--- a/devel/cbindgen/DETAILS
+++ b/devel/cbindgen/DETAILS
@@ -1,12 +1,13 @@
-          MODULE=cbindgen
-         VERSION=0.29.2
-          SOURCE=$MODULE-$VERSION.tar.gz
- SOURCE_URL_FULL=https://github.com/mozilla/cbindgen/archive/v$VERSION.tar.gz
-      SOURCE_VFY=sha256:c7d4d610482390c70e471a5682de714967e187ed2f92f2237c317a484a8c7e3a
-        WEB_SITE=https://github.com/eqrion/cbindgen
-         ENTERED=20181023
-         UPDATED=20251120
-           SHORT="generate C bindings for Rust code"
+         MODULE=cbindgen
+        VERSION=0.29.3
+         SOURCE=$MODULE-$VERSION.tar.gz
+SOURCE_URL_FULL=https://github.com/mozilla/cbindgen/archive/v$VERSION.tar.gz
+     SOURCE_VFY=sha256:f3589ce10fd6a61b32d1ac1a1043112838e44b401432f4db9838c2a9ec4322f8
+       WEB_SITE=https://github.com/eqrion/cbindgen
+        ENTERED=20181023
+        UPDATED=20260529
+          SHORT="generate C bindings for Rust code"
+
 cat << EOF
 This project can be used to generate C bindings for Rust code. It is currently
 being developed to support creating bindings for WebRender, but has been


### PR DESCRIPTION
Upgrade cbindgen from 0.29.2 to 0.29.3

- Updated VERSION to 0.29.3
- Updated SOURCE_VFY to sha256:f3589ce10fd6a61b32d1ac1a1043112838e44b401432f4db9838c2a9ec4322f8
- Updated UPDATED date to 20260529

---
*Automated PR created by n8n + Claude AI*