### PR TITLE
libheif: Version bumped to 1.23.0

### DIFF
--- a/libs/libheif/DETAILS
+++ b/libs/libheif/DETAILS
@@ -1,11 +1,11 @@
     MODULE=libheif
-   VERSION=1.22.2
+   VERSION=1.23.0
     SOURCE=$MODULE-$VERSION.tar.gz
 SOURCE_URL=https://github.com/strukturag/libheif/releases/download/v$VERSION/
-SOURCE_VFY=sha256:eea48e4841f83fbe51d029337ffd2d14512d0203015dad40b90213d872958af3
+SOURCE_VFY=sha256:4c9182b18897617182eed12ab5eb9f9d855b3aa3a736d6bdb31abc034ec7d393
   WEB_SITE=https://github.com/strukturag/libheif/
    ENTERED=20181108
-   UPDATED=20260526
+   UPDATED=20260529
      SHORT="HEIF file format decoder and encoder"
 
 cat << EOF


### PR DESCRIPTION
Upgrade libheif from 1.22.2 to 1.23.0. Updated source verification hash and build date.

---
*Automated PR created by n8n + Claude AI*