### PR TITLE
libical: Version bumped to 4.0.2

### DIFF
--- a/libs/libical/DETAILS
+++ b/libs/libical/DETAILS
@@ -1,11 +1,11 @@
          MODULE=libical
-        VERSION=4.0.1
+        VERSION=4.0.2
          SOURCE=$MODULE-$VERSION.tar.gz
 SOURCE_URL_FULL=http://github.com/$MODULE/$MODULE/archive/v$VERSION.tar.gz
-     SOURCE_VFY=sha256:7c1d8b780ce305a8823e5824ec4d7eb05d85ae8f808836b495aa37b0c3d08337
+     SOURCE_VFY=sha256:39a979bb5474af3c4601c83dc71512c1121dee56722b3d8d8668ed75bd78ccdd
        WEB_SITE=https://github.com/libical/libical/
         ENTERED=20021128
-        UPDATED=20260514
+        UPDATED=20260530
           SHORT="An implementation of the IETF's Calendar protocol"
 
 cat << EOF


### PR DESCRIPTION
Upgrade libical from version 4.0.1 to 4.0.2. Updated SOURCE_VFY checksum and UPDATED date. No changes to dependencies or build configuration.

---
*Automated PR created by n8n + Claude AI*