### PR TITLE
erlang: Version bumped to 29.0.1

### DIFF
--- a/compilers/erlang/DETAILS
+++ b/compilers/erlang/DETAILS
@@ -1,12 +1,12 @@
           MODULE=erlang
-         VERSION=29.0
+         VERSION=29.0.1
           SOURCE=OTP-$VERSION.tar.gz
       SOURCE_URL=http://github.com/erlang/otp/archive/
-      SOURCE_VFY=sha256:032b64b0de42bf66a13086bf18b8e62a5d83dcf32ac0d44d33c4792f0e8f826c
+      SOURCE_VFY=sha256:a3acb3bc1391b451a61252fcc95b9f9cd34be4802aa214d204debdebfa7fd8a0
 SOURCE_DIRECTORY=$BUILD_DIRECTORY/otp-OTP-$VERSION
         WEB_SITE=http://www.erlang.org
          ENTERED=20020112
-         UPDATED=20260524
+         UPDATED=20260530
            SHORT="General-purpose programming language and runtime environment"
 
 cat << EOF


### PR DESCRIPTION
Upgrade erlang from 29.0 to 29.0.1

- Updated VERSION to 29.0.1
- Updated SOURCE_VFY to a3acb3bc1391b451a61252fcc95b9f9cd34be4802aa214d204debdebfa7fd8a0
- Updated UPDATED date to 20260530

---
*Automated PR created by n8n + Claude AI*