### PR TITLE
mxml: Version bumped to 4.0.4

### DIFF
--- a/libs/mxml/DETAILS
+++ b/libs/mxml/DETAILS
@@ -1,12 +1,12 @@
-          MODULE=mxml
-         VERSION=3.3.1
-          SOURCE=$MODULE-$VERSION.tar.gz
- SOURCE_URL_FULL=https://github.com/michaelrsweet/mxml/archive/v$VERSION.tar.gz
-      SOURCE_VFY=sha256:59eba16ce43765f2e2a6cf4873a58d317be801f1e929647d85da9f171e41e9ac
-        WEB_SITE=https://github.com/michaelrsweet/mxml
-         ENTERED=20150617
-         UPDATED=20230511
-           SHORT="a small XML library"
+         MODULE=mxml
+        VERSION=4.0.4
+         SOURCE=$MODULE-$VERSION.tar.gz
+SOURCE_URL_FULL=https://github.com/michaelrsweet/mxml/archive/v$VERSION.tar.gz
+     SOURCE_VFY=sha256:2d865d1f8e30ab3d3e170f8b96136b650f217068c7ce99a8447b3f6b3c1ab4ee
+       WEB_SITE=https://github.com/michaelrsweet/mxml
+        ENTERED=20150617
+        UPDATED=20260531
+          SHORT="a small XML library"
 
 cat << EOF
 Mini-XML is a small XML library that you can use to read


### PR DESCRIPTION
Upgrade mxml from version 3.3.1 to 4.0.4

- Updated VERSION to 4.0.4
- Updated SOURCE_VFY to match new release
- Updated UPDATED timestamp to 20260531
- All other module properties preserved

---
*Automated PR created by n8n + Claude AI*