### PR TITLE
msgpack-c: Version bumped to 7.0.0

### DIFF
--- a/libs/msgpack-c/DETAILS
+++ b/libs/msgpack-c/DETAILS
@@ -1,12 +1,12 @@
-          MODULE=msgpack-c
-         VERSION=6.0.0
-          SOURCE=$MODULE-$VERSION.tar.gz
-      SOURCE_URL=https://github.com/msgpack/msgpack-c/releases/download/c-$VERSION/
-      SOURCE_VFY=sha256:3654f5e2c652dc52e0a993e270bb57d5702b262703f03771c152bba51602aeba
-        WEB_SITE=http://msgpack.org/
-         ENTERED=20180419
-         UPDATED=20230501
-           SHORT="An efficient object serialization library"
+    MODULE=msgpack-c
+   VERSION=7.0.0
+    SOURCE=$MODULE-$VERSION.tar.gz
+SOURCE_URL=https://github.com/msgpack/msgpack-c/releases/download/c-$VERSION/
+SOURCE_VFY=sha256:0f1b34a42ea20b35350ad774e56666f64e860ce22d787626f2b3d2ab67061639
+  WEB_SITE=http://msgpack.org/
+   ENTERED=20180419
+   UPDATED=20260601
+     SHORT="An efficient object serialization library"
 
 cat << EOF
 MessagePack is an efficient binary serialization format. It lets you exchange


### PR DESCRIPTION
Upgrade msgpack-c from 6.0.0 to 7.0.0

Updates the msgpack-c library to the latest upstream release 7.0.0. This upgrade includes the latest features and bug fixes from the MessagePack C implementation.

- Version: 6.0.0 → 7.0.0
- SHA256: 0f1b34a42ea20b35350ad774e56666f64e860ce22d787626f2b3d2ab67061639

---
*Automated PR created by n8n + Claude AI*