### PR TITLE
pdfjs: Version bumped to 6.0.227

### DIFF
--- a/web/pdfjs/DETAILS
+++ b/web/pdfjs/DETAILS
@@ -1,12 +1,12 @@
           MODULE=pdfjs
-         VERSION=5.7.284
+         VERSION=6.0.227
           SOURCE=$MODULE-$VERSION.tar.gz
  SOURCE_URL_FULL=https://github.com/mozilla/pdf.js/archive/v$VERSION.tar.gz
-      SOURCE_VFY=sha256:3cd36e9c7878dc6ab23d1f64879b03d696f2ffe364d071c8dba396e4d0c1e0ee
+      SOURCE_VFY=sha256:d2894d77c111b603c05a673cfb39ca71d70909d77f0a6377097c496ce98dcc60
 SOURCE_DIRECTORY=$BUILD_DIRECTORY/pdf.js-$VERSION
         WEB_SITE=https://github.com/mozilla/pdf.js/
          ENTERED=20181003
-         UPDATED=20260428
+         UPDATED=20260601
            SHORT="PDF reader in JavaScript"
 
 cat << EOF


### PR DESCRIPTION
Upgrade pdfjs from 5.7.284 to 6.0.227

- Updated VERSION to 6.0.227
- Updated SOURCE_VFY to d2894d77c111b603c05a673cfb39ca71d70909d77f0a6377097c496ce98dcc60
- Updated UPDATED date to 20260601

---
*Automated PR created by n8n + Claude AI*