### PR TITLE
libindi: Version bumped to 2.2.2

### DIFF
--- a/libs/libindi/DETAILS
+++ b/libs/libindi/DETAILS
@@ -1,12 +1,12 @@
           MODULE=libindi
-         VERSION=2.2.1.1
+         VERSION=2.2.2
           SOURCE=$MODULE-$VERSION.tar.gz
  SOURCE_URL_FULL=https://github.com/indilib/indi/archive/refs/tags/v$VERSION.tar.gz
-      SOURCE_VFY=sha256:270e0767768dcca6879d6a9f410ad6086b067ea492228c48e03ba3803c718271
+      SOURCE_VFY=sha256:e2069555088b70e118e491840180fe0ef85d12912c145f74dbc51e266dc1c8f2
 SOURCE_DIRECTORY=$BUILD_DIRECTORY/indi-$VERSION
         WEB_SITE=http://www.indilib.org/index.php?title=Main_Page
          ENTERED=20071027
-         UPDATED=20260429
+         UPDATED=20260601
            SHORT="instrument neutral distributed interface control protocol"
 
 cat << EOF


### PR DESCRIPTION
Upgrade libindi from 2.2.1.1 to 2.2.2

- Updated VERSION to 2.2.2
- Updated SOURCE_VFY to e2069555088b70e118e491840180fe0ef85d12912c145f74dbc51e266dc1c8f2
- Updated UPDATED timestamp to 20260601

---
*Automated PR created by n8n + Claude AI*