### PR TITLE
grpc: Version bumped to 1.81.0

### DIFF
--- a/devel/grpc/DETAILS
+++ b/devel/grpc/DETAILS
@@ -1,11 +1,11 @@
          MODULE=grpc
-        VERSION=1.80.0
+        VERSION=1.81.0
          SOURCE=$MODULE-$VERSION.tar.gz
 SOURCE_URL_FULL=https://github.com/grpc/grpc/archive/refs/tags/v$VERSION.tar.gz
-     SOURCE_VFY=sha256:38f58596277fa632064cc0719b9ece4381c8c77461cb51e9b66ca149574b7865
+     SOURCE_VFY=sha256:41b695614b26652ff9e97ce50cfd4a6c7a3d45a9fe598d1454407746499bbf2c
        WEB_SITE=https://grpc.io/
         ENTERED=20240401
-        UPDATED=20260401
+        UPDATED=20260601
           SHORT="high-performance remote procedure call (RPC) framework that can run anywhere"
 
 cat << EOF


### PR DESCRIPTION
Upgrade grpc from 1.80.0 to 1.81.0

- Updated VERSION to 1.81.0
- Updated SOURCE_VFY hash to 41b695614b26652ff9e97ce50cfd4a6c7a3d45a9fe598d1454407746499bbf2c
- Updated UPDATED date to 20260601

---
*Automated PR created by n8n + Claude AI*