### PR TITLE
vifm: Version bumped to 0.14.4

### DIFF
--- a/filemanagers/vifm/DETAILS
+++ b/filemanagers/vifm/DETAILS
@@ -1,12 +1,12 @@
-          MODULE=vifm
-         VERSION=0.14.3
-          SOURCE=$MODULE-$VERSION.tar.bz2
-        SOURCE_URL=http://github.com/vifm/vifm/releases/download/v${VERSION}/
-      SOURCE_VFY=sha256:16a9be1108d6a5a09e9f947f7256375e519ba41ebe9473659b20739fdbf3440e
-        WEB_SITE=http://github.com/vifm/vifm/
-         ENTERED=20170507
-         UPDATED=20250609
-           SHORT="Ncurses based file manager with vi like keybindings"
+    MODULE=vifm
+   VERSION=0.14.4
+    SOURCE=$MODULE-$VERSION.tar.bz2
+SOURCE_URL=http://github.com/vifm/vifm/releases/download/v${VERSION}/
+SOURCE_VFY=sha256:40bc32ec10d829ada3d0297d33cd4f302c520bb431287d544fc0a05ae45fdb1b
+  WEB_SITE=http://github.com/vifm/vifm/
+   ENTERED=20170507
+   UPDATED=20260601
+     SHORT="Ncurses based file manager with vi like keybindings"
 
 cat << EOF
 Vifm is an ncurses based file manager with vi like keybindings/modes/options/


### PR DESCRIPTION
Upgrade vifm from 0.14.3 to 0.14.4

- Version: 0.14.4
- Source: http://github.com/vifm/vifm/releases/download/v0.14.4/vifm-0.14.4.tar.bz2
- SHA256: 40bc32ec10d829ada3d0297d33cd4f302c520bb431287d544fc0a05ae45fdb1b

---
*Automated PR created by n8n + Claude AI*