### PR TITLE
GraphicsMagick: Version bumped to 1.3.47

### DIFF
--- a/graphics/GraphicsMagick/DETAILS
+++ b/graphics/GraphicsMagick/DETAILS
@@ -1,12 +1,12 @@
-          MODULE=GraphicsMagick
-         VERSION=1.3.46
-          SOURCE=$MODULE-$VERSION.tar.xz
-      SOURCE_URL=$SFORGE_URL/graphicsmagick
-      SOURCE_VFY=sha256:c7c706a505e9c6c3764156bb94a0c9644d79131785df15a89c9f8721d1abd061
-        WEB_SITE=http://www.graphicsmagick.org/
-         ENTERED=20061117
-         UPDATED=20251117
-           SHORT="A swiss army knife of image processing"
+    MODULE=GraphicsMagick
+   VERSION=1.3.47
+    SOURCE=$MODULE-$VERSION.tar.xz
+SOURCE_URL=$SFORGE_URL/graphicsmagick
+SOURCE_VFY=sha256:95fb682dab0206a9db168d065963f4ffdf5a60b0b2a375aca1f4492fb18d0627
+  WEB_SITE=http://www.graphicsmagick.org/
+   ENTERED=20061117
+   UPDATED=20260601
+     SHORT="A swiss army knife of image processing"
 
 cat << EOF
 GraphicsMagick is the swiss army knife of image processing. It provides a robust


### PR DESCRIPTION
Upgrade GraphicsMagick from 1.3.46 to 1.3.47

- Updated VERSION to 1.3.47
- Updated SOURCE_VFY to sha256:95fb682dab0206a9db168d065963f4ffdf5a60b0b2a375aca1f4492fb18d0627
- Updated UPDATED field to 20260601

---
*Automated PR created by n8n + Claude AI*