### PR TITLE
srt: Version bumped to 1.5.5

### DIFF
--- a/security/srt/DETAILS
+++ b/security/srt/DETAILS
@@ -1,13 +1,13 @@
-          MODULE=srt
-         VERSION=1.5.4
-          SOURCE=$MODULE-$VERSION.tar.gz
- SOURCE_URL_FULL=https://github.com/Haivision/srt/archive/v$VERSION.tar.gz
-      SOURCE_VFY=sha256:d0a8b600fe1b4eaaf6277530e3cfc8f15b8ce4035f16af4a5eb5d4b123640cdd
-        WEB_SITE=https://www.srtalliance.org/
-            TYPE=cmake
-         ENTERED=20180326
-         UPDATED=20241214
-           SHORT="Secure Reliable Transport"
+         MODULE=srt
+        VERSION=1.5.5
+         SOURCE=$MODULE-$VERSION.tar.gz
+SOURCE_URL_FULL=https://github.com/Haivision/srt/archive/v$VERSION.tar.gz
+     SOURCE_VFY=sha256:c3518bc43a71b5289032395b2db4c3e09e73d78b54247d56c14553a503b491cf
+       WEB_SITE=https://www.srtalliance.org/
+           TYPE=cmake
+        ENTERED=20180326
+        UPDATED=20260602
+          SHORT="Secure Reliable Transport"
 
 cat << EOF
 Secure Reliable Transport (SRT) is a proprietary transport technology that


### PR DESCRIPTION
Upgrade srt from 1.5.4 to 1.5.5

- Version: 1.5.4 → 1.5.5
- Source: https://github.com/Haivision/srt/archive/v1.5.5.tar.gz
- SHA256: c3518bc43a71b5289032395b2db4c3e09e73d78b54247d56c14553a503b491cf

---
*Automated PR created by n8n + Claude AI*