### PR TITLE
opensc: Version bumped to 0.27.1

### DIFF
--- a/devel/opensc/DETAILS
+++ b/devel/opensc/DETAILS
@@ -1,12 +1,13 @@
-          MODULE=opensc
-         VERSION=0.26.1
-          SOURCE=${MODULE}-${VERSION}.tar.gz
-      SOURCE_URL=https://github.com/OpenSC/OpenSC/releases/download/$VERSION
-      SOURCE_VFY=sha256:f16291a031d86e570394762e9f35eaf2fcbc2337a49910f3feae42d54e1688cb
-        WEB_SITE=https://github.com/OpenSC/OpenSC/wiki
-         ENTERED=20131012
-         UPDATED=20250114
-           SHORT="Libraries and applications to access smartcards"
+    MODULE=opensc
+   VERSION=0.27.1
+    SOURCE=${MODULE}-${VERSION}.tar.gz
+SOURCE_URL=https://github.com/OpenSC/OpenSC/releases/download/$VERSION
+SOURCE_VFY=sha256:976f4a23eaf3397a1a2c3a7aac80bf971a8c3d829c9a79f06145bfaeeae5eca7
+  WEB_SITE=https://github.com/OpenSC/OpenSC/wiki
+   ENTERED=20131012
+   UPDATED=20260602
+     SHORT="Libraries and applications to access smartcards"
+
 cat << EOF
 OpenSC provides a set of libraries and utilities to work with
 smart cards. Its main focus is on cards that support cryptographic


### PR DESCRIPTION
Upgrade opensc from 0.26.1 to 0.27.1

- Updated VERSION to 0.27.1
- Updated SOURCE_VFY to sha256:976f4a23eaf3397a1a2c3a7aac80bf971a8c3d829c9a79f06145bfaeeae5eca7
- Updated UPDATED date to 20260602

---
*Automated PR created by n8n + Claude AI*