### PR TITLE
python-zeroconf: Version bumped to 0.149.16

### DIFF
--- a/python/python-zeroconf/DETAILS
+++ b/python/python-zeroconf/DETAILS
@@ -1,12 +1,12 @@
           MODULE=python-zeroconf
-         VERSION=0.148.0
+         VERSION=0.149.16
           SOURCE=$MODULE-$VERSION.tar.gz
  SOURCE_URL_FULL=https://pypi.python.org/packages/source/z/zeroconf/zeroconf-$VERSION.tar.gz
-      SOURCE_VFY=sha256:03fcca123df3652e23d945112d683d2f605f313637611b7d4adf31056f681702
+      SOURCE_VFY=sha256:5e6b5a3b153c2cc2a8d9e6f6f189ec5638f7d9c86fc3e88a6c53eb6863761a5e
 SOURCE_DIRECTORY=$BUILD_DIRECTORY/zeroconf-$VERSION
         WEB_SITE=https://pypi.org/project/zeroconf/
          ENTERED=20210201
-         UPDATED=20251111
+         UPDATED=20260602
            SHORT="fork of pyzeroconf, Multicast DNS Service Discovery for Python"
 
 cat << EOF


### PR DESCRIPTION
Upgrade python-zeroconf from 0.148.0 to 0.149.16

---
*Automated PR created by n8n + Claude AI*