### PR TITLE
python-pillow: Version bumped to 12.2.0

### DIFF
--- a/python/python-pillow/DETAILS
+++ b/python/python-pillow/DETAILS
@@ -1,12 +1,12 @@
           MODULE=python-pillow
-         VERSION=12.1.1
+         VERSION=12.2.0
           SOURCE=pillow-$VERSION.tar.gz
       SOURCE_URL=https://files.pythonhosted.org/packages/source/p/pillow/
-      SOURCE_VFY=sha256:9ad8fa5937ab05218e2b6a4cff30295ad35afd2f83ac592e68c0d871bb0fdbc4
+      SOURCE_VFY=sha256:a830b1a40919539d07806aa58e1b114df53ddd43213d9c8b75847eee6c0182b5
 SOURCE_DIRECTORY=$BUILD_DIRECTORY/pillow-$VERSION
         WEB_SITE=https://pypi.org/project/pillow/
          ENTERED=20151226
-         UPDATED=20260211
+         UPDATED=20260602
         REPLACES=Pillow
            SHORT="Python Imaging Library (PIL) fork"
 


### PR DESCRIPTION
Upgrade python-pillow from 12.1.1 to 12.2.0

- Version: 12.1.1 → 12.2.0
- SHA256: a830b1a40919539d07806aa58e1b114df53ddd43213d9c8b75847eee6c0182b5
- Updated date: 20260602

---
*Automated PR created by n8n + Claude AI*