### PR TITLE
python-reportlab: Version bumped to 4.5.1

### DIFF
--- a/python/python-reportlab/DETAILS
+++ b/python/python-reportlab/DETAILS
@@ -1,15 +1,16 @@
           MODULE=python-reportlab
-         VERSION=4.4.4
+         VERSION=4.5.1
           SOURCE=reportlab-$VERSION.tar.gz
       SOURCE_URL=https://pypi.python.org/packages/source/r/reportlab/
-      SOURCE_VFY=sha256:cb2f658b7f4a15be2cc68f7203aa67faef67213edd4f2d4bdd3eb20dab75a80d
- SOURCE_DIRECTORY=$BUILD_DIRECTORY/reportlab-$VERSION
+      SOURCE_VFY=sha256:9fdf68f4de9171ec66acb4a5feed8f8ca2af43479e707a6fbb0daa75d88e5494
+SOURCE_DIRECTORY=$BUILD_DIRECTORY/reportlab-$VERSION
         WEB_SITE=https://pypi.org/project/reportlab2/#files
             TYPE=python3
          ENTERED=20040423
-         UPDATED=20251021
+         UPDATED=20260602
         REPLACES=reportlab
            SHORT="produces high-quality PDF files"
+
 cat << EOF
 Report Lab produces high quality PDF files
 EOF


### PR DESCRIPTION
Upgrade python-reportlab from version 4.4.4 to 4.5.1

---
*Automated PR created by n8n + Claude AI*