### PR TITLE
python-xxhash: Version bumped to 3.7.0

### DIFF
--- a/python/python-xxhash/DETAILS
+++ b/python/python-xxhash/DETAILS
@@ -1,12 +1,12 @@
           MODULE=python-xxhash
-         VERSION=3.6.0
+         VERSION=3.7.0
           SOURCE=xxhash-$VERSION.tar.gz
       SOURCE_URL=https://pypi.python.org/packages/source/x/xxhash/
-      SOURCE_VFY=sha256:f0162a78b13a0d7617b2845b90c763339d1f1d82bb04a4b07f4ab535cc5e05d6
+      SOURCE_VFY=sha256:6cc4eefbb542a5d6ffd6d70ea9c502957c925e800f998c5630ecc809d6702bae
 SOURCE_DIRECTORY=$BUILD_DIRECTORY/xxhash-$VERSION
         WEB_SITE=https://pypi.org/project/xxhash/
          ENTERED=20231129
-         UPDATED=20251111
+         UPDATED=20260602
            SHORT="python bindings for xxHash"
 
 cat << EOF


### PR DESCRIPTION
Upgrade python-xxhash from 3.6.0 to 3.7.0

---
*Automated PR created by n8n + Claude AI*