### PR TITLE
python-zipp: Version bumped to 4.1.0

### DIFF
--- a/python/python-zipp/DETAILS
+++ b/python/python-zipp/DETAILS
@@ -1,12 +1,12 @@
           MODULE=python-zipp
-         VERSION=3.23.0
+         VERSION=4.1.0
           SOURCE=zipp-$VERSION.tar.gz
       SOURCE_URL=https://pypi.python.org/packages/source/z/zipp
-      SOURCE_VFY=sha256:a07157588a12518c9d4034df3fbbee09c814741a33ff63c05fa29d26a2404166
+      SOURCE_VFY=sha256:4cb57381f544315db7688e976e922a2b18cdb513d21cc194eb42232ba2a3e602
 SOURCE_DIRECTORY=$BUILD_DIRECTORY/zipp-$VERSION
         WEB_SITE=https://pypi.org/project/zipp/
          ENTERED=20220110
-         UPDATED=20250829
+         UPDATED=20260602
            SHORT="Pathlib-compatible object wrapper for zip files"
 
 cat << EOF


### PR DESCRIPTION
Upgrade python-zipp from version 3.23.0 to 4.1.0

---
*Automated PR created by n8n + Claude AI*