### PR TITLE
harfbuzz: Version bumped to 14.2.1

### DIFF
--- a/graphics/harfbuzz/DETAILS
+++ b/graphics/harfbuzz/DETAILS
@@ -1,11 +1,11 @@
     MODULE=harfbuzz
-   VERSION=14.2.0
+   VERSION=14.2.1
     SOURCE=$MODULE-$VERSION.tar.xz
 SOURCE_URL=https://github.com/harfbuzz/harfbuzz/releases/download/$VERSION/
-SOURCE_VFY=sha256:94017020f96d025bb66ae91574e4cf334bcad23e8175a8a40565b3721bc2eaff
+SOURCE_VFY=sha256:a54a5d8e9380a41fbb762ce367bcbf7704792dfca0d93f1bbca86c5a57902e0e
   WEB_SITE=https://freedesktop.org/wiki/Software/HarfBuzz
    ENTERED=20130511
-   UPDATED=20260420
+   UPDATED=20260602
      SHORT="OpenType text shaping engine"
 
 cat << EOF


### PR DESCRIPTION
Upgrade harfbuzz from 14.2.0 to 14.2.1

- Updated VERSION to 14.2.1
- Updated SOURCE_VFY to a54a5d8e9380a41fbb762ce367bcbf7704792dfca0d93f1bbca86c5a57902e0e
- Updated UPDATED date to 20260602

---
*Automated PR created by n8n + Claude AI*