### PR TITLE
spaceship-prompt: Version bumped to 4.22.3

### DIFF
--- a/utils/spaceship-prompt/DETAILS
+++ b/utils/spaceship-prompt/DETAILS
@@ -1,11 +1,11 @@
          MODULE=spaceship-prompt
-        VERSION=4.22.2
+        VERSION=4.22.3
          SOURCE=$MODULE-$VERSION.tar.gz
 SOURCE_URL_FULL=https://github.com/denysdovhan/spaceship-prompt/archive/v$VERSION.tar.gz
-     SOURCE_VFY=sha256:24230f0c0a8dce3bb20d05b20deb6ddb60116661410d324cf43eb138a4ea2097
+     SOURCE_VFY=sha256:12506d2fca2b1ab887a81b13cd18fb28877e19e0d36310404b3933b2c764f2f8
        WEB_SITE=https://spaceship-prompt.sh/
         ENTERED=20200412
-        UPDATED=20260518
+        UPDATED=20260603
           SHORT="A Zsh prompt for Astronauts"
 
 cat << EOF


### PR DESCRIPTION
Upgrade spaceship-prompt from 4.22.2 to 4.22.3

- Version: 4.22.3
- SHA256: 12506d2fca2b1ab887a81b13cd18fb28877e19e0d36310404b3933b2c764f2f8
- Updated: 20260603

---
*Automated PR created by n8n + Claude AI*