### PR TITLE
gmic-qt: Version bumped to 3.7.6

### DIFF
--- a/graphics/gmic-qt/DETAILS
+++ b/graphics/gmic-qt/DETAILS
@@ -1,14 +1,14 @@
 # This uses the same tarball as gmic so if you update gmic 
 # YOU HAVE to update this one.
           MODULE=gmic-qt
-         VERSION=3.7.5
+         VERSION=3.7.6
           SOURCE=gmic\_${VERSION}.tar.gz
       SOURCE_URL=https://gmic.eu/files/source/
-      SOURCE_VFY=sha256:159d15a5b6fcd6cf1da676ef971a3fd4ebeadc8d1c009c0f9275c2af4034e5e4
+      SOURCE_VFY=sha256:640bc1c72b1bb0eeb056771b1c57291403a4f3bffda372c4ea24ee2db8175a67
 SOURCE_DIRECTORY=$BUILD_DIRECTORY/gmic-$VERSION
         WEB_SITE=https://gmic.eu
          ENTERED=20201208
-         UPDATED=20260502
+         UPDATED=20260603
            SHORT="GUI components for GMIC"
 
 cat << EOF


### PR DESCRIPTION
Upgrade gmic-qt from 3.7.5 to 3.7.6. This update synchronizes with the gmic tarball release. SHA256 checksum verified: 640bc1c72b1bb0eeb056771b1c57291403a4f3bffda372c4ea24ee2db8175a67

---
*Automated PR created by n8n + Claude AI*