### PR TITLE
openjph: Version bumped to 0.27.4

### DIFF
--- a/graphics/openjph/DETAILS
+++ b/graphics/openjph/DETAILS
@@ -1,13 +1,13 @@
           MODULE=openjph
-         VERSION=0.27.3
+         VERSION=0.27.4
           SOURCE=$MODULE-$VERSION.tar.gz
  SOURCE_URL_FULL=https://github.com/aous72/OpenJPH/archive/refs/tags/$VERSION.tar.gz
 SOURCE_DIRECTORY=$BUILD_DIRECTORY/OpenJPH-$VERSION
-      SOURCE_VFY=sha256:f96808ef72cf3acca73a52123bda3e680f6550dfb4774ad7de57eb3ce26de57a
+      SOURCE_VFY=sha256:4bd6c75cc74721b1a40c3e07206621d0c953d0b21e9f63c9982a8ecb4a6f326d
         WEB_SITE=https://github.com/aous72/OpenJPH
             TYPE=cmake
          ENTERED=20251105
-         UPDATED=20260514
+         UPDATED=20260604
            SHORT="implementation of High-throughput JPEG2000"
 
 cat << EOF


### PR DESCRIPTION
Upgrade openjph from 0.27.3 to 0.27.4

- Updated VERSION to 0.27.4
- Updated SOURCE_VFY with new SHA256 checksum
- Updated UPDATED date to 20260604

---
*Automated PR created by n8n + Claude AI*