### PR TITLE
radare2: Version bumped to 6.1.6

### DIFF
--- a/editors/radare2/DETAILS
+++ b/editors/radare2/DETAILS
@@ -1,12 +1,12 @@
          MODULE=radare2
-        VERSION=6.1.4
+        VERSION=6.1.6
          SOURCE=$MODULE-$VERSION.tar.gz
 SOURCE_URL_FULL=https://github.com/radareorg/radare2/archive/refs/tags/$VERSION.tar.gz
-     SOURCE_VFY=sha256:e025d623aa253e20b050164e65f140e437c110812a7b4c8b1b1342f692dfb452
+     SOURCE_VFY=sha256:7370c52cb22cba3ab02ee77970fd258a8ecdbf3fd3282f2647ff12393c6ae8ac
        WEB_SITE=https://www.radare.org/n/
            TYPE=meson
         ENTERED=20210429
-        UPDATED=20260413
+        UPDATED=20260604
           SHORT="reverse engineering framework"
 
 cat << EOF


### PR DESCRIPTION
Upgrade radare2 from 6.1.4 to 6.1.6

---
*Automated PR created by n8n + Claude AI*