### PR TITLE
stress-ng: Version bumped to 0.21.02

### DIFF
--- a/utils/stress-ng/DETAILS
+++ b/utils/stress-ng/DETAILS
@@ -1,11 +1,11 @@
          MODULE=stress-ng
-        VERSION=0.21.01
+        VERSION=0.21.02
          SOURCE=$MODULE-$VERSION.tar.gz
 SOURCE_URL_FULL=https://github.com/ColinIanKing/$MODULE/archive/refs/tags/V${VERSION}.tar.gz
-     SOURCE_VFY=sha256:4c898d9b1911124f43f1fb6a18a725badbe795f5b628531afd4b631127ad8073
+     SOURCE_VFY=sha256:71502d31f77987c3bda6931d47b44d7b03d8ac689e8154bbda676cf9d42e2b4e
        WEB_SITE=https://github.com/ColinIanKing/stress-ng
         ENTERED=20250106
-        UPDATED=20260502
+        UPDATED=20260604
           SHORT="stress test a computer system in various selectable ways"
 
 cat << EOF


### PR DESCRIPTION
Upgrade stress-ng from 0.21.01 to 0.21.02

---
*Automated PR created by n8n + Claude AI*