### PR TITLE
libtorrent: Version bumped to 0.16.13

### DIFF
--- a/libs/libtorrent/DETAILS
+++ b/libs/libtorrent/DETAILS
@@ -1,11 +1,11 @@
          MODULE=libtorrent
-        VERSION=0.16.12
+        VERSION=0.16.13
          SOURCE=$MODULE-$VERSION.tar.gz
 SOURCE_URL_FULL=https://github.com/rakshasa/libtorrent/archive/v${VERSION}.tar.gz
-     SOURCE_VFY=sha256:1ecbb5d7802e18e807d3c2f58499e5c189ef81badb2c6c6ebb2399d49c08f5c1
+     SOURCE_VFY=sha256:17a3bbf8a75b18347e460c479f51ee1f1e4927bcdd444052940df6f0b31a530c
        WEB_SITE=https://rakshasa.github.io/rtorrent/
         ENTERED=20060704
-        UPDATED=20260519
+        UPDATED=20260604
           SHORT="A BitTorrent library written in C++"
 
 cat << EOF


### PR DESCRIPTION
Upgrade libtorrent from 0.16.12 to 0.16.13. Updated SHA256 checksum and UPDATED date.

---
*Automated PR created by n8n + Claude AI*