### PR TITLE
rtorrent: Version bumped to 0.16.13

### DIFF
--- a/distributed/rtorrent/DETAILS
+++ b/distributed/rtorrent/DETAILS
@@ -1,11 +1,11 @@
          MODULE=rtorrent
-        VERSION=0.16.12
+        VERSION=0.16.13
          SOURCE=$MODULE-$VERSION.tar.gz
 SOURCE_URL_FULL=https://github.com/rakshasa/rtorrent/archive/v${VERSION}.tar.gz
-     SOURCE_VFY=sha256:765ac29788a96a05c6a9541edea0de855dd144d89008b2003752ad5d8a0791e5
+     SOURCE_VFY=sha256:0f757aa9cb7fc724385e99c0ed893a3d32643481028673ea55982b68d202faa8
        WEB_SITE=https://rakshasa.github.io/rtorrent/
         ENTERED=20060704
-        UPDATED=20260519
+        UPDATED=20260604
           SHORT="A BitTorrent client using libtorrent"
 
 cat << EOF


### PR DESCRIPTION
Upgrade rtorrent from 0.16.12 to 0.16.13

- Updated VERSION to 0.16.13
- Updated SOURCE_VFY to sha256:0f757aa9cb7fc724385e99c0ed893a3d32643481028673ea55982b68d202faa8
- Updated UPDATED date to 20260604

---
*Automated PR created by n8n + Claude AI*