### PR TITLE
grafana: Version bumped to 13.0.2

### DIFF
--- a/web/grafana/DETAILS
+++ b/web/grafana/DETAILS
@@ -1,11 +1,11 @@
          MODULE=grafana
-        VERSION=12.1.1
+        VERSION=13.0.2
          SOURCE=$MODULE-$VERSION.tar.gz
 SOURCE_URL_FULL=http://github.com/grafana/grafana/archive/v$VERSION.tar.gz
-     SOURCE_VFY=sha256:ff9bb988385c47b5b9429c9dd928d7084def8b950815d96badc9ded495361519
+     SOURCE_VFY=sha256:3f6ccffda94137c9679d0993312a83a76815406efd3df7dabbb8f99467e7e8c6
        WEB_SITE=http://grafana.org/
         ENTERED=20150919
-        UPDATED=20250818
+        UPDATED=20260604
           SHORT="A general purpose dashboard and graph composer"
 
 cat << EOF


### PR DESCRIPTION
Upgrade grafana from version 12.1.1 to 13.0.2

---
*Automated PR created by n8n + Claude AI*