### PR TITLE
keepalived: Version bumped to 2.3.4

### DIFF
--- a/net/keepalived/DETAILS
+++ b/net/keepalived/DETAILS
@@ -1,12 +1,13 @@
-          MODULE=keepalived
-         VERSION=2.3.2
-          SOURCE=$MODULE-$VERSION.tar.gz
-      SOURCE_URL=https://www.keepalived.org/software/
-      SOURCE_VFY=sha256:77f4a22e5a23fa8e49b8916acdfb584c864e72905a2f1de2a7f62ed40a896160
-        WEB_SITE=http://www.keepalived.org/
-         ENTERED=20240226
-         UPDATED=20241208
-           SHORT="Simple and robust loadbalancing and high-availability daemon"
+    MODULE=keepalived
+   VERSION=2.3.4
+    SOURCE=$MODULE-$VERSION.tar.gz
+SOURCE_URL=https://www.keepalived.org/software/
+SOURCE_VFY=sha256:6afd95ddb7d3e0d3b8b8e5b3a489144131b61a01b06d29e883d0c44acc8a36bf
+  WEB_SITE=http://www.keepalived.org/
+   ENTERED=20240226
+   UPDATED=20260605
+     SHORT="Simple and robust loadbalancing and high-availability daemon"
+
 cat << EOF
 Keepalived is a routing software written in C. The main goal of the
 project is to provide simple and robust facilities for loadbalancing and


### PR DESCRIPTION
Upgrade keepalived from 2.3.2 to 2.3.4

- Updates VERSION to 2.3.4
- Updates SOURCE_VFY to sha256:6afd95ddb7d3e0d3b8b8e5b3a489144131b61a01b06d29e883d0c44acc8a36bf
- Updates UPDATED date to 20260605
- Preserves all other module configuration and descriptions

---
*Automated PR created by n8n + Claude AI*