### PR TITLE
paho-mqtt-c: Version bumped to 1.3.14

### DIFF
--- a/net/paho-mqtt-c/DETAILS
+++ b/net/paho-mqtt-c/DETAILS
@@ -1,13 +1,13 @@
-           MODULE=paho-mqtt-c
-          VERSION=1.3.13
-           SOURCE=$MODULE-$VERSION.tar.gz
-  SOURCE_URL_FULL=https://github.com/eclipse/paho.mqtt.c/archive/refs/tags/v${VERSION}.tar.gz
- SOURCE_DIRECTORY=$BUILD_DIRECTORY/${MODULE//-/.}-$VERSION
-       SOURCE_VFY=sha256:47c77e95609812da82feee30db435c3b7c720d4fd3147d466ead126e657b6d9c
-         WEB_SITE=https://www.eclipse.org/paho/
-          ENTERED=20220213
-          UPDATED=20241208
-            SHORT="Eclipse Paho C Client Library for the MQTT Protocol"
+          MODULE=paho-mqtt-c
+         VERSION=1.3.14
+          SOURCE=$MODULE-$VERSION.tar.gz
+ SOURCE_URL_FULL=https://github.com/eclipse/paho.mqtt.c/archive/refs/tags/v${VERSION}.tar.gz
+SOURCE_DIRECTORY=$BUILD_DIRECTORY/${MODULE//-/.}-$VERSION
+      SOURCE_VFY=sha256:7af7d906e60a696a80f1b7c2bd7d6eb164aaad908ff4c40c3332ac2006d07346
+        WEB_SITE=https://www.eclipse.org/paho/
+         ENTERED=20220213
+         UPDATED=20260605
+           SHORT="Eclipse Paho C Client Library for the MQTT Protocol"
 
 cat << EOF
 Eclipse Paho C Client Library for the MQTT Protocol.


### PR DESCRIPTION
Upgrade paho-mqtt-c from 1.3.13 to 1.3.14

- Version: 1.3.13 → 1.3.14
- Source: https://github.com/eclipse/paho.mqtt.c/archive/refs/tags/v1.3.14.tar.gz
- SHA256: 7af7d906e60a696a80f1b7c2bd7d6eb164aaad908ff4c40c3332ac2006d07346
- Updated: 20260605

---
*Automated PR created by n8n + Claude AI*