### PR TITLE
hwdata: Version bumped to 0.408

### DIFF
--- a/system/hwdata/DETAILS
+++ b/system/hwdata/DETAILS
@@ -1,11 +1,11 @@
          MODULE=hwdata
-        VERSION=0.407
+        VERSION=0.408
          SOURCE=$MODULE-$VERSION.tar.gz
 SOURCE_URL_FULL=https://github.com/vcrhonek/hwdata/archive/refs/tags/v$VERSION.tar.gz
-     SOURCE_VFY=sha256:6a88f6f5cb510fbfaa9c49488348b7fcd7aa209b0a331f24dfebb1c8c339568b
+     SOURCE_VFY=sha256:ac7c34efc5941d5cbf739a8f7f6c84b1c2edea493fd3fca10906ef64d7afd690
        WEB_SITE=https://github.com/vcrhonek/hwdata
         ENTERED=20220214
-        UPDATED=20260518
+        UPDATED=20260605
           SHORT="hardware identification database"
 
 cat << EOF


### PR DESCRIPTION
Upgrade hwdata from 0.407 to 0.408 - hardware identification database update

---
*Automated PR created by n8n + Claude AI*