### PR TITLE
libpqxx: Version bumped to 7.10.7

### DIFF
--- a/sql/libpqxx/DETAILS
+++ b/sql/libpqxx/DETAILS
@@ -1,12 +1,12 @@
-          MODULE=libpqxx
-         VERSION=7.10.5
-          SOURCE=$MODULE-$VERSION.tar.gz
- SOURCE_URL_FULL=https://github.com/jtv/libpqxx/archive/$VERSION.tar.gz
-      SOURCE_VFY=sha256:aa214df8b98672a43a39b68a37da87af1415a44965f6e484f85ca0eb4f151367
-        WEB_SITE=http://pqxx.org/development/libpqxx/
-         ENTERED=20050728
-         UPDATED=20260101
-           SHORT="C++ client API for PostgreSQL"
+         MODULE=libpqxx
+        VERSION=7.10.7
+         SOURCE=$MODULE-$VERSION.tar.gz
+SOURCE_URL_FULL=https://github.com/jtv/libpqxx/archive/$VERSION.tar.gz
+     SOURCE_VFY=sha256:8c09cf20d57695621376f34d6da24c2c40c28408ab3b7ca92dc661ff9ad4b906
+       WEB_SITE=http://pqxx.org/development/libpqxx/
+        ENTERED=20050728
+        UPDATED=20260607
+          SHORT="C++ client API for PostgreSQL"
 
 cat << EOF
 C++ client API for PostgreSQL. The standard front-end (in the sense of


### PR DESCRIPTION
Upgrade libpqxx from 7.10.5 to 7.10.7

- Updated VERSION to 7.10.7
- Updated SOURCE_VFY to 8c09cf20d57695621376f34d6da24c2c40c28408ab3b7ca92dc661ff9ad4b906
- Updated UPDATED date to 20260607

---
*Automated PR created by n8n + Claude AI*