### PR TITLE
wayland-protocols: Version bumped to 1.49

### DIFF
--- a/wayland/wayland-protocols/DETAILS
+++ b/wayland/wayland-protocols/DETAILS
@@ -1,12 +1,12 @@
     MODULE=wayland-protocols
-   VERSION=1.48
+   VERSION=1.49
     SOURCE=$MODULE-$VERSION.tar.xz
 SOURCE_URL=https://gitlab.freedesktop.org/wayland/wayland-protocols/-/releases/$VERSION/downloads
-SOURCE_VFY=sha256:398036ac0eb6484982ddbde7ff86848d753231f9cdeeae983f06b52946625aa1
+SOURCE_VFY=sha256:ec4c8f74942d6dff7ace8b4ce4764f0ef9ff618a935d974ea77edee2ad240b14
   WEB_SITE=https://wayland.freedesktop.org
       TYPE=meson
    ENTERED=20160310
-   UPDATED=20260402
+   UPDATED=20260607
      SHORT="Specifications of extended Wayland protocols"
 
 cat << EOF


### PR DESCRIPTION
Upgrade wayland-protocols from version 1.48 to 1.49. Updated SOURCE_VFY and UPDATED date. No changes to dependencies or build process required.

---
*Automated PR created by n8n + Claude AI*