### PR TITLE
frei0r-plugins: Version bumped to 3.2.0

### DIFF
--- a/video/frei0r-plugins/DETAILS
+++ b/video/frei0r-plugins/DETAILS
@@ -1,12 +1,12 @@
           MODULE=frei0r-plugins
-         VERSION=3.1.3
+         VERSION=3.2.0
           SOURCE=$MODULE-$VERSION.tar.gz
  SOURCE_URL_FULL=https://github.com/dyne/frei0r/archive/v$VERSION.tar.gz
-      SOURCE_VFY=sha256:dcf290cdfbe583d007c300aa7733c9350ed957a0e30ca897a5c098875b8aa5dc
+      SOURCE_VFY=sha256:a0fbf466e5d1965ab0a40842d50a63bdac8bfa1cfbce2f8e5b73eb862ec1182b
 SOURCE_DIRECTORY=$BUILD_DIRECTORY/${MODULE%-*}-$VERSION
         WEB_SITE=https://github.com/dyne/frei0r
          ENTERED=20100210
-         UPDATED=20260427
+         UPDATED=20260608
            SHORT="Plugin API for video sources and filters"
 
 cat << EOF


### PR DESCRIPTION
Upgrade frei0r-plugins from 3.1.3 to 3.2.0

- Updated VERSION to 3.2.0
- Updated SOURCE_VFY to match new release
- Updated UPDATED field to 20260608

---
*Automated PR created by n8n + Claude AI*