### PR TITLE
audacious: Version bumped to 4.6.1

### DIFF
--- a/audio/audacious/DETAILS
+++ b/audio/audacious/DETAILS
@@ -1,12 +1,12 @@
-          MODULE=audacious
-         VERSION=4.5.1
-          SOURCE=$MODULE-$VERSION.tar.bz2
-      SOURCE_URL=https://distfiles.audacious-media-player.org/
-      SOURCE_VFY=sha256:7194743a0a41b1d8f582c071488b77f7b917be47ca5e142dd76af5d81d36f9cd
-        WEB_SITE=https://audacious-media-player.org
-         ENTERED=20060613
-         UPDATED=20260107
-           SHORT="GTK port of XMMS"
+    MODULE=audacious
+   VERSION=4.6.1
+    SOURCE=$MODULE-$VERSION.tar.bz2
+SOURCE_URL=https://distfiles.audacious-media-player.org/
+SOURCE_VFY=sha256:62a5a609267eca7f6e3ce52ef6f42d5618d2961e3b4ddc227c6a5859026965d9
+  WEB_SITE=https://audacious-media-player.org
+   ENTERED=20060613
+   UPDATED=20260608
+     SHORT="GTK port of XMMS"
 
 cat << EOF
 Audacious is a media player based on XMMS ( http://www.xmms.org/ ). The


### PR DESCRIPTION
Upgrade audacious from 4.5.1 to 4.6.1

- Version: 4.5.1 → 4.6.1
- Source URL: https://distfiles.audacious-media-player.org/audacious-4.6.1.tar.bz2
- SHA256: 62a5a609267eca7f6e3ce52ef6f42d5618d2961e3b4ddc227c6a5859026965d9

---
*Automated PR created by n8n + Claude AI*