### PR TITLE
grpc: Version bumped to 1.81.1

### DIFF
--- a/devel/grpc/DETAILS
+++ b/devel/grpc/DETAILS
@@ -1,11 +1,11 @@
          MODULE=grpc
-        VERSION=1.81.0
+        VERSION=1.81.1
          SOURCE=$MODULE-$VERSION.tar.gz
 SOURCE_URL_FULL=https://github.com/grpc/grpc/archive/refs/tags/v$VERSION.tar.gz
-     SOURCE_VFY=sha256:41b695614b26652ff9e97ce50cfd4a6c7a3d45a9fe598d1454407746499bbf2c
+     SOURCE_VFY=sha256:48ae0d05f87206112d9e9144a923191ee1e482141a70686ec58dc86d0b40fddc
        WEB_SITE=https://grpc.io/
         ENTERED=20240401
-        UPDATED=20260601
+        UPDATED=20260608
           SHORT="high-performance remote procedure call (RPC) framework that can run anywhere"
 
 cat << EOF


### PR DESCRIPTION
Upgrade grpc from 1.81.0 to 1.81.1

- Version: 1.81.0 → 1.81.1
- Source: https://github.com/grpc/grpc/archive/refs/tags/v1.81.1.tar.gz
- SHA256: 48ae0d05f87206112d9e9144a923191ee1e482141a70686ec58dc86d0b40fddc

---
*Automated PR created by n8n + Claude AI*