### PR TITLE
httpd: Version bumped to 2.4.68

### DIFF
--- a/web/httpd/DETAILS
+++ b/web/httpd/DETAILS
@@ -1,12 +1,12 @@
-          MODULE=httpd
-         VERSION=2.4.67
-          SOURCE=$MODULE-$VERSION.tar.bz2
-      SOURCE_URL=https://dlcdn.apache.org/httpd/
-      SOURCE_VFY=sha256:66cd206637b0d5c446fa7dabe75fe03525da8fb55855876c46288cd88b136aa4
-        WEB_SITE=https://www.apache.org
-         ENTERED=20020710
-         UPDATED=20260504
-           SHORT="A popular HTTP server"
+    MODULE=httpd
+   VERSION=2.4.68
+    SOURCE=$MODULE-$VERSION.tar.bz2
+SOURCE_URL=https://dlcdn.apache.org/httpd/
+SOURCE_VFY=sha256:68c74d4df38c26bed4dfbdb8f3baf1eb532f3872357becc1bba5d136f6b63c06
+  WEB_SITE=https://www.apache.org
+   ENTERED=20020710
+   UPDATED=20260608
+     SHORT="A popular HTTP server"
 
 cat << EOF
 Apache is the world's most popular HTTP server, being quite possibly the best


### PR DESCRIPTION
Upgrade httpd from 2.4.67 to 2.4.68

- Updated VERSION to 2.4.68
- Updated SOURCE_VFY with new sha256 hash: 68c74d4df38c26bed4dfbdb8f3baf1eb532f3872357becc1bba5d136f6b63c06
- Updated UPDATED date to 20260608
- All other module properties preserved

---
*Automated PR created by n8n + Claude AI*