### PR TITLE
nut: Version bumped to 2.8.5

### DIFF
--- a/utils/nut/DETAILS
+++ b/utils/nut/DETAILS
@@ -1,12 +1,12 @@
-          MODULE=nut
-         VERSION=2.8.4
-          SOURCE=$MODULE-$VERSION.tar.gz
-      SOURCE_URL=http://www.networkupstools.org/source/${VERSION%.*}/
-      SOURCE_VFY=sha256:0130ba82ea79f04ba4f34c5249a85943977efd984ed7df6aec1a518d5a3594f8
-        WEB_SITE=http://www.networkupstools.org/
-         ENTERED=20100324
-         UPDATED=20251203
-           SHORT="Network UPS Tools"
+    MODULE=nut
+   VERSION=2.8.5
+    SOURCE=$MODULE-$VERSION.tar.gz
+SOURCE_URL=http://www.networkupstools.org/source/${VERSION%.*}/
+SOURCE_VFY=sha256:18bf32e59eb764b13da3c4fa70384926d7fa584cb31d2fe7f137a570633eeec1
+  WEB_SITE=http://www.networkupstools.org/
+   ENTERED=20100324
+   UPDATED=20260609
+     SHORT="Network UPS Tools"
 
 cat << EOF
 The primary goal of the Network UPS Tools (NUT) project is to provide


### PR DESCRIPTION
Upgrade nut from 2.8.4 to 2.8.5

- Updated VERSION to 2.8.5
- Updated SOURCE_VFY to sha256:18bf32e59eb764b13da3c4fa70384926d7fa584cb31d2fe7f137a570633eeec1
- Updated UPDATED date to 20260609

---
*Automated PR created by n8n + Claude AI*