### PR TITLE
squid: Version bumped to 7.6

### DIFF
--- a/web/squid/DETAILS
+++ b/web/squid/DETAILS
@@ -1,12 +1,12 @@
-          MODULE=squid
-         VERSION=7.5
-          SOURCE=$MODULE-$VERSION.tar.xz
-      SOURCE_URL=https://github.com/squid-cache/squid/releases/download/SQUID_${VERSION/./_}/
-     SOURCE_VFY=sha256:f6058907db0150d2f5d228482b5a9e5678920cf368ae0ccbcecceb2ff4c35106
-        WEB_SITE=http://www.squid-cache.org
-         ENTERED=20011214
-         UPDATED=20260314
-           SHORT="A full-featured Web proxy cache"
+    MODULE=squid
+   VERSION=7.6
+    SOURCE=$MODULE-$VERSION.tar.xz
+SOURCE_URL=https://github.com/squid-cache/squid/releases/download/SQUID_${VERSION/./_}/
+SOURCE_VFY=sha256:852178fdc37c5b0786a934fc990c7d2fffc82acf19b2284be209b96431d25992
+  WEB_SITE=http://www.squid-cache.org
+   ENTERED=20011214
+   UPDATED=20260609
+     SHORT="A full-featured Web proxy cache"
 
 cat << EOF
 Squid is...


### PR DESCRIPTION
Upgrade squid from version 7.5 to 7.6. Updated SOURCE_VFY with new SHA256 checksum and UPDATED date.

---
*Automated PR created by n8n + Claude AI*