### PR TITLE
SDL2-compat: New module at version 2.32.70

### DIFF
--- a/libs/SDL2-compat/DEPENDS
+++ b/libs/SDL2-compat/DEPENDS
@@ -1,0 +1,2 @@
+depends SDL2
+

--- a/libs/SDL2-compat/DETAILS
+++ b/libs/SDL2-compat/DETAILS
@@ -1,0 +1,16 @@
+    MODULE=SDL2-compat
+   VERSION=2.32.70
+    SOURCE=sdl2-compat-${VERSION}.tar.gz
+SOURCE_URL=https://github.com/libsdl-org/sdl2-compat/releases/download/release-${VERSION}/${SOURCE}
+SOURCE_VFY=sha256:998fa62557eb46ffe7e5c3e2c123bc332f7df9d9f593b3ceed88ed1158428a44
+  WEB_SITE=https://github.com/libsdl-org/sdl2-compat
+   ENTERED=20260609
+   UPDATED=20260609
+     SHORT="SDL 1.2 compatibility layer for SDL 2.0"
+
+cat << 'EOF'
+SDL2-compat is a compatibility layer that allows SDL 1.2 applications to run
+with SDL 2.0. It provides an SDL 1.2-compatible API on top of SDL 2.0,
+enabling legacy game code and applications to work with modern SDL without
+requiring major code rewrites.
+EOF


### PR DESCRIPTION
Add SDL2-compat module version 2.32.70 - SDL 1.2 compatibility layer for SDL 2.0

---
*Automated PR created by n8n + Claude AI*