### PR TITLE
rsync: Version bumped to 3.4.4

### DIFF
--- a/net/rsync/DETAILS
+++ b/net/rsync/DETAILS
@@ -1,13 +1,13 @@
-          MODULE=rsync
-         VERSION=3.4.3
-          SOURCE=$MODULE-$VERSION.tar.gz
-      SOURCE_URL=https://download.samba.org/pub/rsync/src/
-      SOURCE_VFY=sha256:c72e63ca3021cbc80ba86ec30102773f4c5631fbc492b52e773b3958f82a53d3
-        WEB_SITE=http://rsync.samba.org
-         ENTERED=20010922
-         UPDATED=20260520
-           SHORT="A replacement for rcp"
-           PSAFE=no
+    MODULE=rsync
+   VERSION=3.4.4
+    SOURCE=$MODULE-$VERSION.tar.gz
+SOURCE_URL=https://download.samba.org/pub/rsync/src/
+SOURCE_VFY=sha256:bd88cf82fa653da32314fb229136407c5c90f80d1758d8f4b091767877d8fa96
+  WEB_SITE=http://rsync.samba.org
+   ENTERED=20010922
+   UPDATED=20260609
+     SHORT="A replacement for rcp"
+PSAFE=no
 
 cat << EOF
 rsync is a replacement for rcp (and scp) that has many more features.


### PR DESCRIPTION
Upgrade rsync from 3.4.3 to 3.4.4

- Version: 3.4.3 → 3.4.4
- SHA256: bd88cf82fa653da32314fb229136407c5c90f80d1758d8f4b091767877d8fa96
- Source: https://download.samba.org/pub/rsync/src/rsync-3.4.4.tar.gz

---
*Automated PR created by n8n + Claude AI*