### PR TITLE
firefox: Version bumped to 151.0.4

### DIFF
--- a/web/firefox/DETAILS
+++ b/web/firefox/DETAILS
@@ -1,12 +1,12 @@
-          MODULE=firefox
-         VERSION=151.0.3
-          SOURCE=$MODULE-$VERSION.source.tar.xz
-      SOURCE_URL=https://archive.mozilla.org/pub/firefox/releases/$VERSION/source
-      SOURCE_VFY=sha256:7820284ed489057a3750715ccaa22d87e1965fd54f6525d3565f1e70743bfe66
-        WEB_SITE=https://www.mozilla.org/en-US/firefox
-         ENTERED=20110814
-         UPDATED=20260605
-           SHORT="A web browser from mozilla.org"
+    MODULE=firefox
+   VERSION=151.0.4
+    SOURCE=$MODULE-$VERSION.source.tar.xz
+SOURCE_URL=https://archive.mozilla.org/pub/firefox/releases/$VERSION/source
+SOURCE_VFY=sha256:ffda1991cc3b9b35d3c034314d253a51d6a20f603b693db2f55a00fa840e83a7
+  WEB_SITE=https://www.mozilla.org/en-US/firefox
+   ENTERED=20110814
+   UPDATED=20260609
+     SHORT="A web browser from mozilla.org"
 
 cat << EOF
 A web browser from mozilla.org.


### PR DESCRIPTION
Upgrade firefox from 151.0.3 to 151.0.4

- Updated VERSION to 151.0.4
- Updated SOURCE_VFY to ffda1991cc3b9b35d3c034314d253a51d6a20f603b693db2f55a00fa840e83a7
- Updated UPDATED date to 20260609

---
*Automated PR created by n8n + Claude AI*