### PR TITLE
yt-dlp: Version bumped to 2026.06.09

### DIFF
--- a/video/yt-dlp/DETAILS
+++ b/video/yt-dlp/DETAILS
@@ -1,11 +1,11 @@
          MODULE=yt-dlp
-        VERSION=2026.03.17
+        VERSION=2026.06.09
          SOURCE=$MODULE-$VERSION.tar.gz
 SOURCE_URL_FULL=https://github.com/yt-dlp/yt-dlp/archive/refs/tags/$VERSION.tar.gz
-     SOURCE_VFY=sha256:924483986441d8a1e669a0e4371d753a9256ce4bdc06032394ccb7b793342434
+     SOURCE_VFY=sha256:6add707714c1d9a960cb6f4de1dcbd9fbf857f1bc488d26b43f0701246a06f38
        WEB_SITE=https://github.com/yt-dlp/yt-dlp
         ENTERED=20221226
-        UPDATED=20260318
+        UPDATED=20260610
           SHORT="youtube download manager"
 
 cat << EOF


### PR DESCRIPTION
Upgrade yt-dlp from 2026.03.17 to 2026.06.09

---
*Automated PR created by n8n + Claude AI*