### PR TITLE
meson-python: Version bumped to 0.20.0

### DIFF
--- a/devel/meson-python/DETAILS
+++ b/devel/meson-python/DETAILS
@@ -1,11 +1,11 @@
          MODULE=meson-python
-        VERSION=0.19.0
+        VERSION=0.20.0
          SOURCE=$MODULE-$VERSION.tar.gz
 SOURCE_URL_FULL=https://github.com/mesonbuild/meson-python/archive/refs/tags/$VERSION.tar.gz
-     SOURCE_VFY=sha256:2d3efafb7e85e93d766a1ae46a53aec97fc4c97bdb07c341f803a32be10b29e9
+     SOURCE_VFY=sha256:e291a3e92914784136e5784bb56f9a436a18397a0e1e64c670d058b3abf74709
        WEB_SITE=https://github.com/mesonbuild/meson-python
         ENTERED=20250823
-        UPDATED=20260203
+        UPDATED=20260610
           SHORT="back-end built on top of the Meson build system"
 
 cat << EOF


### PR DESCRIPTION
Upgrade meson-python from 0.19.0 to 0.20.0

---
*Automated PR created by n8n + Claude AI*