### PR TITLE
python-faker: Version bumped to 40.22.0

### DIFF
--- a/python/python-faker/DETAILS
+++ b/python/python-faker/DETAILS
@@ -1,12 +1,12 @@
           MODULE=python-faker
-         VERSION=40.3.0
+         VERSION=40.22.0
           SOURCE=faker-$VERSION.tar.gz
       SOURCE_URL=https://pypi.python.org/packages/source/f/faker/
-      SOURCE_VFY=sha256:751245c34c4c38ddfa3863d6136590d7e085f35aab44bb5a9a76a2d73d007ef8
+      SOURCE_VFY=sha256:0df62f975c97f79be3d89d626c4ee1518604cb4fea94f7629697f0529fc757d5
 SOURCE_DIRECTORY=$BUILD_DIRECTORY/faker-$VERSION
         WEB_SITE=https://pypi.org/project/Faker/
          ENTERED=20221028
-         UPDATED=20260303
+         UPDATED=20260610
            SHORT="generates fake data"
 
 cat << EOF


### PR DESCRIPTION
Upgrade python-faker from 40.3.0 to 40.22.0

---
*Automated PR created by n8n + Claude AI*