### PR TITLE
brave-bin: Version bumped to 1.91.171

### DIFF
--- a/web/brave-bin/DETAILS
+++ b/web/brave-bin/DETAILS
@@ -1,12 +1,12 @@
           MODULE=brave-bin
-         VERSION=1.91.168
+         VERSION=1.91.171
           SOURCE=brave-browser-$VERSION-linux-amd64.zip
       SOURCE_URL=https://github.com/brave/brave-browser/releases/download/v$VERSION/
-      SOURCE_VFY=sha256:b662545261da9c58a0f0fabbab43deb60b16119bd86c06fec636b4a808a61f27
+      SOURCE_VFY=sha256:8c2d57363c05326295fdfe87162af850be2d7cc5863ffd59bb48f7f12c53eebd
 SOURCE_DIRECTORY=$BUILD_DIRECTORY/brave-browser-$VERSION-linux-amd64
         WEB_SITE=https://brave.com/
          ENTERED=20210628
-         UPDATED=20260607
+         UPDATED=20260611
            SHORT="brave web browser"
 
 cat << EOF


### PR DESCRIPTION
Upgrade brave-bin from 1.91.168 to 1.91.171

- Updated VERSION to 1.91.171
- Updated SOURCE_VFY to sha256:8c2d57363c05326295fdfe87162af850be2d7cc5863ffd59bb48f7f12c53eebd
- Updated UPDATED date to 20260611

---
*Automated PR created by n8n + Claude AI*