### PR TITLE
openjph: Version bumped to 0.28.1

### DIFF
--- a/graphics/openjph/DETAILS
+++ b/graphics/openjph/DETAILS
@@ -1,13 +1,13 @@
           MODULE=openjph
-         VERSION=0.27.4
+         VERSION=0.28.1
           SOURCE=$MODULE-$VERSION.tar.gz
  SOURCE_URL_FULL=https://github.com/aous72/OpenJPH/archive/refs/tags/$VERSION.tar.gz
 SOURCE_DIRECTORY=$BUILD_DIRECTORY/OpenJPH-$VERSION
-      SOURCE_VFY=sha256:4bd6c75cc74721b1a40c3e07206621d0c953d0b21e9f63c9982a8ecb4a6f326d
+      SOURCE_VFY=sha256:89629a3c0f61d474073076bb6195e9bb1d63fafb2e1c57ab46aee53a62f21819
         WEB_SITE=https://github.com/aous72/OpenJPH
             TYPE=cmake
          ENTERED=20251105
-         UPDATED=20260604
+         UPDATED=20260611
            SHORT="implementation of High-throughput JPEG2000"
 
 cat << EOF


### PR DESCRIPTION
Upgrade openjph from 0.27.4 to 0.28.1

- Update VERSION to 0.28.1
- Update SOURCE_VFY to sha256:89629a3c0f61d474073076bb6195e9bb1d63fafb2e1c57ab46aee53a62f21819
- Update UPDATED date to 20260611

---
*Automated PR created by n8n + Claude AI*