### PR TITLE
wakatime-cli: Version bumped to 2.15.3

### DIFF
--- a/utils/wakatime-cli/DETAILS
+++ b/utils/wakatime-cli/DETAILS
@@ -1,11 +1,11 @@
          MODULE=wakatime-cli
-        VERSION=2.15.1
+        VERSION=2.15.3
          SOURCE=$MODULE-$VERSION.tar.gz
 SOURCE_URL_FULL=https://github.com/wakatime/wakatime-cli/archive/refs/tags/v$VERSION.tar.gz
-     SOURCE_VFY=sha256:ec11488a6b0533b303931da2fb709fc942cb6cbe43a604b6d36ad1929befbb3f
+     SOURCE_VFY=sha256:9ed3250a59f17f8ce7fe7920db25214b2ba9a062c5f0bd80d1866cb0f35bed7c
        WEB_SITE=https://github.com/wakatime/wakatime-cli
         ENTERED=20220710
-        UPDATED=20260610
+        UPDATED=20260612
           SHORT="Command line interface used by all WakaTime text editor plugins"
 
 cat <<EOF


### PR DESCRIPTION
Upgrade wakatime-cli from 2.15.1 to 2.15.3

- Version: 2.15.1 -> 2.15.3
- SHA256: 9ed3250a59f17f8ce7fe7920db25214b2ba9a062c5f0bd80d1866cb0f35bed7c
- Updated: 20260612

---
*Automated PR created by n8n + Claude AI*