### PR TITLE
stress-ng: Version bumped to 0.21.03

### DIFF
--- a/utils/stress-ng/DETAILS
+++ b/utils/stress-ng/DETAILS
@@ -1,11 +1,11 @@
          MODULE=stress-ng
-        VERSION=0.21.02
+        VERSION=0.21.03
          SOURCE=$MODULE-$VERSION.tar.gz
 SOURCE_URL_FULL=https://github.com/ColinIanKing/$MODULE/archive/refs/tags/V${VERSION}.tar.gz
-     SOURCE_VFY=sha256:71502d31f77987c3bda6931d47b44d7b03d8ac689e8154bbda676cf9d42e2b4e
+     SOURCE_VFY=sha256:6db7089ad9cc2c13d0aa1cf8755112adac92858f4582a46c765bb6b7e1c3e1af
        WEB_SITE=https://github.com/ColinIanKing/stress-ng
         ENTERED=20250106
-        UPDATED=20260604
+        UPDATED=20260612
           SHORT="stress test a computer system in various selectable ways"
 
 cat << EOF


### PR DESCRIPTION
Upgrade stress-ng from 0.21.02 to 0.21.03

---
*Automated PR created by n8n + Claude AI*