### PR TITLE
libical: Version bumped to 4.0.3

### DIFF
--- a/libs/libical/DETAILS
+++ b/libs/libical/DETAILS
@@ -1,11 +1,11 @@
          MODULE=libical
-        VERSION=4.0.2
+        VERSION=4.0.3
          SOURCE=$MODULE-$VERSION.tar.gz
 SOURCE_URL_FULL=http://github.com/$MODULE/$MODULE/archive/v$VERSION.tar.gz
-     SOURCE_VFY=sha256:39a979bb5474af3c4601c83dc71512c1121dee56722b3d8d8668ed75bd78ccdd
+     SOURCE_VFY=sha256:86f29029d0ec9fa30c9001de16c0859a3816ae154ff5b097392b014e21a3d254
        WEB_SITE=https://github.com/libical/libical/
         ENTERED=20021128
-        UPDATED=20260530
+        UPDATED=20260614
           SHORT="An implementation of the IETF's Calendar protocol"
 
 cat << EOF


### PR DESCRIPTION
Upgrade libical from 4.0.2 to 4.0.3. Updated VERSION, SOURCE_VFY checksum, and UPDATED date.

---
*Automated PR created by n8n + Claude AI*