### PR TITLE
libindi: Version bumped to 2.2.3

### DIFF
--- a/libs/libindi/DETAILS
+++ b/libs/libindi/DETAILS
@@ -1,12 +1,12 @@
           MODULE=libindi
-         VERSION=2.2.2
+         VERSION=2.2.3
           SOURCE=$MODULE-$VERSION.tar.gz
  SOURCE_URL_FULL=https://github.com/indilib/indi/archive/refs/tags/v$VERSION.tar.gz
-      SOURCE_VFY=sha256:e2069555088b70e118e491840180fe0ef85d12912c145f74dbc51e266dc1c8f2
+      SOURCE_VFY=sha256:b14800e4d84cf57d1c5f9ed30a51dc310c2fb9722abad10acc30a59f33d3b76b
 SOURCE_DIRECTORY=$BUILD_DIRECTORY/indi-$VERSION
         WEB_SITE=http://www.indilib.org/index.php?title=Main_Page
          ENTERED=20071027
-         UPDATED=20260601
+         UPDATED=20260614
            SHORT="instrument neutral distributed interface control protocol"
 
 cat << EOF


### PR DESCRIPTION
Upgrade libindi from 2.2.2 to 2.2.3

- Updated VERSION to 2.2.3
- Updated SOURCE_VFY to sha256:b14800e4d84cf57d1c5f9ed30a51dc310c2fb9722abad10acc30a59f33d3b76b
- Updated UPDATED timestamp to 20260614

---
*Automated PR created by n8n + Claude AI*