### PR TITLE
catch2: Version bumped to 3.15.1

### DIFF
--- a/devel/catch2/DETAILS
+++ b/devel/catch2/DETAILS
@@ -1,13 +1,13 @@
           MODULE=catch2
-         VERSION=3.14.0
+         VERSION=3.15.1
           SOURCE=$MODULE-$VERSION.tar.gz
  SOURCE_URL_FULL=https://github.com/catchorg/Catch2/archive/refs/tags/v$VERSION.tar.gz
-      SOURCE_VFY=sha256:ba2a939efead3c833c499cf487e185762f419a71d30158cd1b43c6079c586490
+      SOURCE_VFY=sha256:be23a52b85cf04cd9587612147a10b023d59ed9757fa1843cc99e615d6c0893c
 SOURCE_DIRECTORY=$BUILD_DIRECTORY/Catch2-$VERSION
         WEB_SITE=https://github.com/catchorg/catch2
             TYPE=cmake
          ENTERED=20231007
-         UPDATED=20260408
+         UPDATED=20260614
            SHORT="unit testing framework for C++"
 
 cat << EOF


### PR DESCRIPTION
Upgrade catch2 from 3.14.0 to 3.15.1

- Updated VERSION to 3.15.1
- Updated SOURCE_VFY to be23a52b85cf04cd9587612147a10b023d59ed9757fa1843cc99e615d6c0893c
- Updated UPDATED date to 20260614

---
*Automated PR created by n8n + Claude AI*