### PR TITLE
firefox: Version bumped to 152.0

### DIFF
--- a/web/firefox/DETAILS
+++ b/web/firefox/DETAILS
@@ -1,11 +1,11 @@
     MODULE=firefox
-   VERSION=151.0.4
+   VERSION=152.0
     SOURCE=$MODULE-$VERSION.source.tar.xz
 SOURCE_URL=https://archive.mozilla.org/pub/firefox/releases/$VERSION/source
-SOURCE_VFY=sha256:ffda1991cc3b9b35d3c034314d253a51d6a20f603b693db2f55a00fa840e83a7
+SOURCE_VFY=sha256:5e5f9acb550d065a43934e0fcd11ed3ec22f7266fc9ad63df757406b432a5127
   WEB_SITE=https://www.mozilla.org/en-US/firefox
    ENTERED=20110814
-   UPDATED=20260609
+   UPDATED=20260616
      SHORT="A web browser from mozilla.org"
 
 cat << EOF


### PR DESCRIPTION
Upgrade firefox from 151.0.4 to 152.0

- Version: 152.0
- Source: https://archive.mozilla.org/pub/firefox/releases/152.0/source/firefox-152.0.source.tar.xz
- SHA256: 5e5f9acb550d065a43934e0fcd11ed3ec22f7266fc9ad63df757406b432a5127

---
*Automated PR created by n8n + Claude AI*