### PR TITLE
wakatime-cli: Version bumped to 2.19.0

### DIFF
--- a/utils/wakatime-cli/DETAILS
+++ b/utils/wakatime-cli/DETAILS
@@ -1,11 +1,11 @@
          MODULE=wakatime-cli
-        VERSION=2.16.1
+        VERSION=2.19.0
          SOURCE=$MODULE-$VERSION.tar.gz
 SOURCE_URL_FULL=https://github.com/wakatime/wakatime-cli/archive/refs/tags/v$VERSION.tar.gz
-     SOURCE_VFY=sha256:ed5a63b21c569007989d54241d0ad772c72f940ef7c95d5e41259eb64162e46e
+     SOURCE_VFY=sha256:63b798d3d72dd349917d5a8b3ea14ef4c0a4c4e09522b20a458fc19adb9708da
        WEB_SITE=https://github.com/wakatime/wakatime-cli
         ENTERED=20220710
-        UPDATED=20260614
+        UPDATED=20260617
           SHORT="Command line interface used by all WakaTime text editor plugins"
 
 cat <<EOF


### PR DESCRIPTION
Upgrade wakatime-cli from 2.16.1 to 2.19.0

- Updated VERSION to 2.19.0
- Updated SOURCE_VFY checksum
- Updated UPDATED date to 20260617

---
*Automated PR created by n8n + Claude AI*