### PR TITLE
skim: Version bumped to 4.8.0

### DIFF
--- a/utils/skim/DETAILS
+++ b/utils/skim/DETAILS
@@ -1,11 +1,11 @@
          MODULE=skim
-        VERSION=4.6.3
+        VERSION=4.8.0
          SOURCE=$MODULE-$VERSION.tar.gz
 SOURCE_URL_FULL=https://github.com/skim-rs/skim/archive/v${VERSION}.tar.gz
-     SOURCE_VFY=sha256:ce5bd17c0440760607ff403cf8363437e30b95100840a4704ccbf86c3b0709c2
+     SOURCE_VFY=sha256:b5dabe228f88da1e87263bc3623c565f756907d918b80452ab5f1ec20d4c3295
        WEB_SITE=https://github.com/skim-rs/skim/
         ENTERED=20200627
-        UPDATED=20260523
+        UPDATED=20260617
           SHORT="Fuzzy Finder in rust"
 
 cat << EOF


### PR DESCRIPTION
Upgrade skim from 4.6.3 to 4.8.0

Changelog:
- Updated to version 4.8.0
- SHA256: b5dabe228f88da1e87263bc3623c565f756907d918b80452ab5f1ec20d4c3295

---
*Automated PR created by n8n + Claude AI*