### PR TITLE
openjph: Version bumped to 0.29.0

### DIFF
--- a/graphics/openjph/DETAILS
+++ b/graphics/openjph/DETAILS
@@ -1,13 +1,13 @@
           MODULE=openjph
-         VERSION=0.28.1
+         VERSION=0.29.0
           SOURCE=$MODULE-$VERSION.tar.gz
  SOURCE_URL_FULL=https://github.com/aous72/OpenJPH/archive/refs/tags/$VERSION.tar.gz
 SOURCE_DIRECTORY=$BUILD_DIRECTORY/OpenJPH-$VERSION
-      SOURCE_VFY=sha256:89629a3c0f61d474073076bb6195e9bb1d63fafb2e1c57ab46aee53a62f21819
+      SOURCE_VFY=sha256:1302a296308996af4c023b7f104133f0d48e89e18b86da999973c476b5e8b584
         WEB_SITE=https://github.com/aous72/OpenJPH
             TYPE=cmake
          ENTERED=20251105
-         UPDATED=20260611
+         UPDATED=20260617
            SHORT="implementation of High-throughput JPEG2000"
 
 cat << EOF


### PR DESCRIPTION
Upgrade openjph from 0.28.1 to 0.29.0

- Updated VERSION to 0.29.0
- Updated SOURCE_VFY to sha256:1302a296308996af4c023b7f104133f0d48e89e18b86da999973c476b5e8b584
- Updated UPDATED timestamp to 20260617
- All other fields preserved from existing module

---
*Automated PR created by n8n + Claude AI*