### PR TITLE
blosc2: Version bumped to 3.1.4

### DIFF
--- a/archive/blosc2/DETAILS
+++ b/archive/blosc2/DETAILS
@@ -1,12 +1,12 @@
           MODULE=blosc2
-         VERSION=2.23.1
+         VERSION=3.1.4
           SOURCE=$MODULE-$VERSION.tar.gz
  SOURCE_URL_FULL=https://github.com/Blosc/c-blosc2/archive/refs/tags/v$VERSION.tar.gz
-      SOURCE_VFY=sha256:3a1a55d1e3794fb2b51a12e722d611b3e577443abb7ff9951666511f576ea3da
+      SOURCE_VFY=sha256:085a2f4e3ea66e7ca4ceae17873e1a5fa4af7f72cd0286d0dd175bb864278960
 SOURCE_DIRECTORY=$BUILD_DIRECTORY/c-$MODULE-$VERSION
         WEB_SITE=https://github.com/Blosc/c-blosc2/
          ENTERED=20240724
-         UPDATED=20260401
+         UPDATED=20260617
            SHORT="A blocking, shuffling and loss-less compression library"
 
 cat << EOF


### PR DESCRIPTION
Upgrade blosc2 from version 2.23.1 to 3.1.4

---
*Automated PR created by n8n + Claude AI*