### PR TITLE
libindi: Version bumped to 2.2.3.1

### DIFF
--- a/libs/libindi/DETAILS
+++ b/libs/libindi/DETAILS
@@ -1,12 +1,12 @@
           MODULE=libindi
-         VERSION=2.2.2
+         VERSION=2.2.3.1
           SOURCE=$MODULE-$VERSION.tar.gz
  SOURCE_URL_FULL=https://github.com/indilib/indi/archive/refs/tags/v$VERSION.tar.gz
-      SOURCE_VFY=sha256:e2069555088b70e118e491840180fe0ef85d12912c145f74dbc51e266dc1c8f2
+      SOURCE_VFY=sha256:3be8b3618f844ced78bd6f048985a8935d30eda8437184d5423d10091285606d
 SOURCE_DIRECTORY=$BUILD_DIRECTORY/indi-$VERSION
         WEB_SITE=http://www.indilib.org/index.php?title=Main_Page
          ENTERED=20071027
-         UPDATED=20260601
+         UPDATED=20260618
            SHORT="instrument neutral distributed interface control protocol"
 
 cat << EOF


### PR DESCRIPTION
Upgrade libindi from version 2.2.2 to 2.2.3.1

- Updated VERSION to 2.2.3.1
- Updated SOURCE_VFY to sha256:3be8b3618f844ced78bd6f048985a8935d30eda8437184d5423d10091285606d
- Updated UPDATED date to 20260618

---
*Automated PR created by n8n + Claude AI*