### PR TITLE
glow: Version bumped to 2.1.2

### DIFF
--- a/doc-tools/glow/DETAILS
+++ b/doc-tools/glow/DETAILS
@@ -1,11 +1,11 @@
           MODULE=glow
-         VERSION=2.1.1
+         VERSION=2.1.2
           SOURCE=$MODULE-$VERSION.tar.gz
       SOURCE_URL=https://github.com/charmbracelet/glow/archive/v${VERSION}/
-      SOURCE_VFY=sha256:f13e1d6be1ab4baf725a7fedc4cd240fc7e5c7276af2d92f199e590e1ef33967
+      SOURCE_VFY=sha256:1b933139da1d08647bf5b3f112cab9548fdc2b40c056c7fa3d84d8706de5265a
         WEB_SITE=https://github.com/charmbracelet/glow/
          ENTERED=20201225
-         UPDATED=20250913
+         UPDATED=20260619
            SHORT="Markdown renderer for the CLI"
 
 cat << EOF


### PR DESCRIPTION
Update glow from 2.1.1 to 2.1.2

- Version: 2.1.1 → 2.1.2
- SHA256: 1b933139da1d08647bf5b3f112cab9548fdc2b40c056c7fa3d84d8706de5265a
- Updated: 20260619

---
*Automated PR created by n8n + Claude AI*