### PR TITLE
fmt: Version bumped to 12.2.0

### DIFF
--- a/libs/fmt/DETAILS
+++ b/libs/fmt/DETAILS
@@ -1,11 +1,11 @@
          MODULE=fmt
-        VERSION=12.1.0
+        VERSION=12.2.0
          SOURCE=$MODULE-$VERSION.tar.gz
 SOURCE_URL_FULL=https://github.com/fmtlib/fmt/archive/refs/tags/$VERSION.tar.gz
-     SOURCE_VFY=sha256:ea7de4299689e12b6dddd392f9896f08fb0777ac7168897a244a6d6085043fea
+     SOURCE_VFY=sha256:8b852bb5aa6e7d8564f9e81394055395dd1d1936d38dfd3a17792a02bebd7af0
        WEB_SITE=https://github.com/fmtlib/fmt
         ENTERED=20231101
-        UPDATED=20260531
+        UPDATED=20260619
           SHORT="open-source formatting library"
 
 cat << EOF


### PR DESCRIPTION
Upgrade fmt from 12.1.0 to 12.2.0

- Updated VERSION to 12.2.0
- Updated SOURCE_VFY to sha256:8b852bb5aa6e7d8564f9e81394055395dd1d1936d38dfd3a17792a02bebd7af0
- Updated UPDATED date to 20260619

---
*Automated PR created by n8n + Claude AI*