### PR TITLE
gsoap: Version bumped to 2.8.143

### DIFF
--- a/devel/gsoap/DETAILS
+++ b/devel/gsoap/DETAILS
@@ -1,12 +1,12 @@
           MODULE=gsoap
-         VERSION=2.8.140
+         VERSION=2.8.143
           SOURCE=$MODULE\_$VERSION.zip
       SOURCE_URL=$SFORGE_URL/gsoap2/
-      SOURCE_VFY=sha256:46a2a91f1d9fd756fd6e6e3b82deb673e3f7cc574d234c91132cfaf90449d3ab
+      SOURCE_VFY=sha256:b5381584cbc8591078b339ada159fb060586c0e1e4666b68b4a3958ef2e2b1e9
 SOURCE_DIRECTORY=$BUILD_DIRECTORY/$MODULE-${VERSION%.*}
         WEB_SITE=https://www.genivia.com/products.html
          ENTERED=20231023
-         UPDATED=20260203
+         UPDATED=20260619
            SHORT="for SOAP and REST Web Services and XML-Based Applications"
 
 cat << EOF


### PR DESCRIPTION
Upgrade gsoap from version 2.8.140 to 2.8.143. Updated SOURCE_VFY hash and UPDATED date.

---
*Automated PR created by n8n + Claude AI*