### PR TITLE
virtualbox-module: Version bumped to 7.2.10

### DIFF
--- a/kernel/virtualbox-module/DETAILS
+++ b/kernel/virtualbox-module/DETAILS
@@ -1,12 +1,12 @@
           MODULE=virtualbox-module
-         VERSION=7.2.8
+         VERSION=7.2.10
           SOURCE=VirtualBox-$VERSION.tar.bz2
 SOURCE_DIRECTORY=$BUILD_DIRECTORY/VirtualBox-$VERSION
       SOURCE_URL=https://download.virtualbox.org/virtualbox/$VERSION
-      SOURCE_VFY=sha256:0642ed4a12b7204cd30c0abbc2c10c1cc7ad55ce1756a01e86a16d4b6b066592
+      SOURCE_VFY=sha256:203a02e3c33ed02fdd75211a58bc9e77c9a8042ad4fa91ddc2914afbd2d67125
         WEB_SITE=https://virtualbox.org
          ENTERED=20090202
-         UPDATED=20260422
+         UPDATED=20260619
            SHORT="Kernel module for VirtualBox"
 
 cat << EOF


### PR DESCRIPTION
Upgrade virtualbox-module from 7.2.8 to 7.2.10

- Version: 7.2.8 → 7.2.10
- Source: https://download.virtualbox.org/virtualbox/7.2.10/VirtualBox-7.2.10.tar.bz2
- SHA256: 203a02e3c33ed02fdd75211a58bc9e77c9a8042ad4fa91ddc2914afbd2d67125

---
*Automated PR created by n8n + Claude AI*