### PR TITLE
openexr: version bumped to 3.4.13

### DIFF
--- a/graphics/openexr/DETAILS
+++ b/graphics/openexr/DETAILS
@@ -1,11 +1,11 @@
          MODULE=openexr
-        VERSION=3.4.12
+        VERSION=3.4.13
          SOURCE=$MODULE-$VERSION.tar.gz
 SOURCE_URL_FULL=git+https://github.com/openexr/openexr:$VERSION
-#     SOURCE_VFY=sha256:0c3a1668d80dc34b3385b948e3d1339db5bfdd69e59071f654d59b074d42126c
+     SOURCE_VFY=
        WEB_SITE=https://openexr.com/en/latest/
         ENTERED=20050601
-        UPDATED=20260525
+        UPDATED=20260620
           SHORT="A high dynamic-range (HDR) image file format"
 
 cat << EOF


### PR DESCRIPTION
llint didn't like the commented SOURCE_VFY, so just blank it instead.