### PR TITLE
nilfs-utils: Version bumped to 2.3.1

### DIFF
--- a/filesys/nilfs-utils/DETAILS
+++ b/filesys/nilfs-utils/DETAILS
@@ -1,12 +1,12 @@
-          MODULE=nilfs-utils
-         VERSION=2.3.0
-          SOURCE=$MODULE-$VERSION.tar.bz2
-      SOURCE_URL=https://nilfs.sourceforge.net/download/
-      SOURCE_VFY=sha256:c0876a7ecd13d4b54cb65abb9ad6cd0bf1ed102d03ca12738f12eab9bd84e67b
-        WEB_SITE=https://nilfs.sourceforge.net/en/
-         ENTERED=20100313
-         UPDATED=20260411
-           SHORT="A log-structured file system"
+    MODULE=nilfs-utils
+   VERSION=2.3.1
+    SOURCE=$MODULE-$VERSION.tar.bz2
+SOURCE_URL=https://nilfs.sourceforge.net/download/
+SOURCE_VFY=sha256:bf89d7ff4579c0df294b3493ed412cd4970b0a1eaaecb658e8f6c730153f0148
+  WEB_SITE=https://nilfs.sourceforge.net/en/
+   ENTERED=20100313
+   UPDATED=20260620
+     SHORT="A log-structured file system"
 
 cat << EOF
 NILFS is a new implementation of a log-structured file system (LFS) supporting


### PR DESCRIPTION
Upgrade nilfs-utils from 2.3.1 to 2.3.1. This is a routine version bump with updated SHA256 checksum verification.

---
*Automated PR created by n8n + Claude AI*