### PR TITLE
jq: Version bumped to 1.8.2

### DIFF
--- a/utils/jq/DETAILS
+++ b/utils/jq/DETAILS
@@ -1,12 +1,12 @@
-          MODULE=jq
-         VERSION=1.8.1
-          SOURCE=${MODULE}-${VERSION}.tar.gz
-      SOURCE_URL=https://github.com/stedolan/jq/releases/download/$MODULE-$VERSION
-      SOURCE_VFY=sha256:2be64e7129cecb11d5906290eba10af694fb9e3e7f9fc208a311dc33ca837eb0
-        WEB_SITE=http://stedolan.github.io/jq/
-         ENTERED=20180725
-         UPDATED=20250704
-           SHORT="Command-line JSON processor"
+    MODULE=jq
+   VERSION=1.8.2
+    SOURCE=${MODULE}-${VERSION}.tar.gz
+SOURCE_URL=https://github.com/stedolan/jq/releases/download/$MODULE-$VERSION
+SOURCE_VFY=sha256:71b8d6e8f5fe81f6c6d0d110e3892251f6ce76ed095abd315e26e6e1193af3af
+  WEB_SITE=http://stedolan.github.io/jq/
+   ENTERED=20180725
+   UPDATED=20260620
+     SHORT="Command-line JSON processor"
 
 cat << EOF
 Command-line JSON processor.


### PR DESCRIPTION
Upgrade jq from 1.8.1 to 1.8.2

- Version: 1.8.1 → 1.8.2
- Source: https://github.com/stedolan/jq/releases/download/jq-1.8.2/jq-1.8.2.tar.gz
- SHA256: 71b8d6e8f5fe81f6c6d0d110e3892251f6ce76ed095abd315e26e6e1193af3af
- Updated date: 20260620

---
*Automated PR created by n8n + Claude AI*