### PR TITLE
openjph: Version bumped to 0.30.0

### DIFF
--- a/graphics/openjph/DETAILS
+++ b/graphics/openjph/DETAILS
@@ -1,13 +1,13 @@
           MODULE=openjph
-         VERSION=0.29.0
+         VERSION=0.30.0
           SOURCE=$MODULE-$VERSION.tar.gz
  SOURCE_URL_FULL=https://github.com/aous72/OpenJPH/archive/refs/tags/$VERSION.tar.gz
 SOURCE_DIRECTORY=$BUILD_DIRECTORY/OpenJPH-$VERSION
-      SOURCE_VFY=sha256:1302a296308996af4c023b7f104133f0d48e89e18b86da999973c476b5e8b584
+      SOURCE_VFY=sha256:3555306549678c81cf2f9d0d579be75a3a2dd6798e84e7ffeddd3e219e70e062
         WEB_SITE=https://github.com/aous72/OpenJPH
             TYPE=cmake
          ENTERED=20251105
-         UPDATED=20260617
+         UPDATED=20260621
            SHORT="implementation of High-throughput JPEG2000"
 
 cat << EOF


### PR DESCRIPTION
Upgrade openjph from 0.29.0 to 0.30.0

- Updated VERSION to 0.30.0
- Updated SOURCE_VFY with new sha256 checksum
- Updated UPDATED date to 20260621

---
*Automated PR created by n8n + Claude AI*