### PR TITLE
python-numpy: Version bumped to 2.5.0

### DIFF
--- a/python/python-numpy/DETAILS
+++ b/python/python-numpy/DETAILS
@@ -1,13 +1,13 @@
           MODULE=python-numpy
-         VERSION=2.4.6
+         VERSION=2.5.0
           SOURCE=numpy-$VERSION.tar.gz
       SOURCE_URL=https://pypi.python.org/packages/source/n/numpy/
-      SOURCE_VFY=sha256:f3a3570c4a2a16746ac2c31a7c7c7b0c186b95ce902e33db6f28094ed7387dda
+      SOURCE_VFY=sha256:5a129578019311b6e56bdd714250f19b518f7dceeeb8d1af5490f4942d3f891c
 SOURCE_DIRECTORY=$BUILD_DIRECTORY/numpy-$VERSION
         WEB_SITE=http://www.numpy.org/
         REPLACES=numpy
          ENTERED=20020708
-         UPDATED=20260519
+         UPDATED=20260621
            SHORT="Fundamental package for scientific computing with Python"
 
 cat << EOF


### PR DESCRIPTION
Upgrade python-numpy from 2.4.6 to 2.5.0

- Updated VERSION to 2.5.0
- Updated SOURCE_VFY checksum to match new release
- Updated UPDATED field to 20260621

---
*Automated PR created by n8n + Claude AI*