### PR TITLE
pystring: Version bumped to 1.2.0

### DIFF
--- a/libs/pystring/DETAILS
+++ b/libs/pystring/DETAILS
@@ -1,14 +1,15 @@
-          MODULE=pystring
-         VERSION=1.1.4
-          SOURCE=$MODULE-$VERSION.tar.gz
- SOURCE_URL_FULL=https://github.com/imageworks/pystring/archive/refs/tags/v$VERSION.tar.gz
-      SOURCE_VFY=sha256:49da0fe2a049340d3c45cce530df63a2278af936003642330287b68cefd788fb
-        WEB_SITE=https://github.com/imageworks/pystring
-            TYPE=cmake
-         ENTERED=20210717
-         UPDATED=20230810
-           SHORT="C++ functions matching the interface and behavior of python string methods with std::string"
+         MODULE=pystring
+        VERSION=1.2.0
+         SOURCE=$MODULE-$VERSION.tar.gz
+SOURCE_URL_FULL=https://github.com/imageworks/pystring/archive/refs/tags/v$VERSION.tar.gz
+     SOURCE_VFY=sha256:020a603a757ba1e429f4b1ea6feb3afbe0fb34bcafa355032e1f1b8a0019d198
+       WEB_SITE=https://github.com/imageworks/pystring
+           TYPE=cmake
+        ENTERED=20210717
+        UPDATED=20260622
+          SHORT="C++ functions matching the interface and behavior of python string methods with std::string"
 
 cat << EOF
-C++ functions matching the interface and behavior of python string methods with std::string.
+C++ functions matching the interface and behavior of python string methods with
+std::string.
 EOF


### PR DESCRIPTION
Upgrade pystring from 1.1.4 to 1.2.0

- Updated VERSION to 1.2.0
- Updated SOURCE_VFY to sha256:020a603a757ba1e429f4b1ea6feb3afbe0fb34bcafa355032e1f1b8a0019d198
- Updated UPDATED date to 20260622
- All other module details preserved

---
*Automated PR created by n8n + Claude AI*