### PR TITLE
OpenImageIO-oiio: Version bumped to 3.1.14.1

### DIFF
--- a/graphics/OpenImageIO-oiio/DETAILS
+++ b/graphics/OpenImageIO-oiio/DETAILS
@@ -1,12 +1,12 @@
           MODULE=OpenImageIO-oiio
-         VERSION=3.1.12.0
+         VERSION=3.1.14.1
           SOURCE=OpenImageIO-$VERSION.tar.gz
       SOURCE_URL=https://github.com/AcademySoftwareFoundation/OpenImageIO/releases/download/v$VERSION/
-      SOURCE_VFY=sha256:704511376faf32767cdcd9aa9a6d0be2b03b91f849ad9008227dc9f0e14bc265
+      SOURCE_VFY=sha256:747341fd98f10d82868ec7663f1f3763cf6fb9acf8a2ed81fc3f25256ef019be
 SOURCE_DIRECTORY=$BUILD_DIRECTORY/OpenImageIO-$VERSION
         WEB_SITE=http://www.openimageio.org/
          ENTERED=20130329
-         UPDATED=20260409
+         UPDATED=20260622
            SHORT="library for reading and writing images"
 
 cat << EOF


### PR DESCRIPTION
Upgrade OpenImageIO-oiio from 3.1.12.0 to 3.1.14.1

- Updated VERSION to 3.1.14.1
- Updated SOURCE_VFY hash
- Updated UPDATED date to 20260622

---
*Automated PR created by n8n + Claude AI*