### PR TITLE
OpenCSG: Version bumped to 1.8.2

### DIFF
--- a/graphics/OpenCSG/DETAILS
+++ b/graphics/OpenCSG/DETAILS
@@ -1,14 +1,15 @@
-          MODULE=OpenCSG
-         VERSION=1.8.1
-          SOURCE=$MODULE-$VERSION.tar.gz
-      SOURCE_URL=https://www.opencsg.org
-      SOURCE_VFY=sha256:afcc004a89ed3bc478a9e4ba39b20f3d589b24e23e275b7383f91a590d4d57c5
-        WEB_SITE=https://www.opencsg.org
-            TYPE=cmake
-         ENTERED=20160414
-         UPDATED=20250609
-           SHORT="image-based CSG rendering using OpenGL"
+    MODULE=OpenCSG
+   VERSION=1.8.2
+    SOURCE=$MODULE-$VERSION.tar.gz
+SOURCE_URL=https://www.opencsg.org
+SOURCE_VFY=sha256:5ac5df73b1ad3340dd6705ff90e009f1a946bb9536c21c2263a6f974265664c0
+  WEB_SITE=https://www.opencsg.org
+      TYPE=cmake
+   ENTERED=20160414
+   UPDATED=20260622
+     SHORT="image-based CSG rendering using OpenGL"
 PSAFE=no
+
 cat << EOF
 OpenCSG is a library that does image-based CSG
 (Constructive Solid Geometry) rendering using OpenGL.


### PR DESCRIPTION
Update OpenCSG from 1.8.1 to 1.8.2

- Version: 1.8.1 → 1.8.2
- SHA256: afcc004a89ed3bc478a9e4ba39b20f3d589b24e23e275b7383f91a590d4d57c5 → 5ac5df73b1ad3340dd6705ff90e009f1a946bb9536c21c2263a6f974265664c0
- Updated: 20250609 → 20260622

---
*Automated PR created by n8n + Claude AI*