### PR TITLE
rtorrent: Version bumped to 0.16.15

### DIFF
--- a/distributed/rtorrent/DETAILS
+++ b/distributed/rtorrent/DETAILS
@@ -1,11 +1,11 @@
          MODULE=rtorrent
-        VERSION=0.16.13
+        VERSION=0.16.15
          SOURCE=$MODULE-$VERSION.tar.gz
 SOURCE_URL_FULL=https://github.com/rakshasa/rtorrent/archive/v${VERSION}.tar.gz
-     SOURCE_VFY=sha256:0f757aa9cb7fc724385e99c0ed893a3d32643481028673ea55982b68d202faa8
+     SOURCE_VFY=sha256:5237e311390e6f7c06cd34596c94ab24fc0fd133c2ab43ef878ababc42d4d20d
        WEB_SITE=https://rakshasa.github.io/rtorrent/
         ENTERED=20060704
-        UPDATED=20260604
+        UPDATED=20260622
           SHORT="A BitTorrent client using libtorrent"
 
 cat << EOF


### PR DESCRIPTION
Upgrade rtorrent from 0.16.13 to 0.16.15

Changes:
- Version updated to 0.16.15
- SHA256 checksum updated
- UPDATED date set to 20260622

---
*Automated PR created by n8n + Claude AI*