### PR TITLE
xmlsec1: Version bumped to 1.3.12

### DIFF
--- a/doc-tools/xmlsec1/DETAILS
+++ b/doc-tools/xmlsec1/DETAILS
@@ -1,11 +1,11 @@
     MODULE=xmlsec1
-   VERSION=1.3.11
+   VERSION=1.3.12
     SOURCE=$MODULE-$VERSION.tar.gz
 SOURCE_URL=https://github.com/lsh123/xmlsec/releases/download/$VERSION/
-SOURCE_VFY=sha256:53675e98fa83b48201d24f7bfbcaeaa1b51496b8b19ff969785856bdeb196af3
+SOURCE_VFY=sha256:24045199af12d93fe5fdbbbf7e386e823e4842071e9432e2b90ac108b889a923
   WEB_SITE=https://www.aleksey.com/xmlsec/
    ENTERED=20201101
-   UPDATED=20260422
+   UPDATED=20260622
      SHORT="XML Security Library"
 
 cat << EOF


### PR DESCRIPTION
Upgrade xmlsec1 from 1.3.11 to 1.3.12

Updates the XML Security Library to the latest release with bug fixes and improvements.

---
*Automated PR created by n8n + Claude AI*