### PR TITLE
firefox: Version bumped to 152.0.2

### DIFF
--- a/web/firefox/DETAILS
+++ b/web/firefox/DETAILS
@@ -1,12 +1,12 @@
-          MODULE=firefox
-         VERSION=152.0.1
-          SOURCE=$MODULE-$VERSION.source.tar.xz
-      SOURCE_URL=https://archive.mozilla.org/pub/firefox/releases/$VERSION/source
-      SOURCE_VFY=sha256:bff037bd04f0df25a330daa7133bea6eee5a02b7ce39da30581580271502f15e
-        WEB_SITE=https://www.mozilla.org/en-US/firefox
-         ENTERED=20110814
-         UPDATED=20260618
-           SHORT="A web browser from mozilla.org"
+    MODULE=firefox
+   VERSION=152.0.2
+    SOURCE=$MODULE-$VERSION.source.tar.xz
+SOURCE_URL=https://archive.mozilla.org/pub/firefox/releases/$VERSION/source
+SOURCE_VFY=sha256:79f3f454e79ec75eef0ff60243510fe5445c430ed70efbfef597a2760a7a5d3b
+  WEB_SITE=https://www.mozilla.org/en-US/firefox
+   ENTERED=20110814
+   UPDATED=20260623
+     SHORT="A web browser from mozilla.org"
 
 cat << EOF
 A web browser from mozilla.org.


### PR DESCRIPTION
Upgrade firefox to version 152.0.2

- Updated VERSION from 152.0.1 to 152.0.2
- Updated SOURCE_VFY with new sha256 checksum
- Updated UPDATED date to 20260623

---
*Automated PR created by n8n + Claude AI*