### PR TITLE
CUDA-OpenCL-headers: Version bumped to 2026.05.29

### DIFF
--- a/devel/CUDA-OpenCL-headers/DETAILS
+++ b/devel/CUDA-OpenCL-headers/DETAILS
@@ -1,14 +1,15 @@
           MODULE=CUDA-OpenCL-headers
-         VERSION=2025.07.22
+         VERSION=2026.05.29
           SOURCE=cudatoolkit-$VERSION-linux-headers.tar.gz
  SOURCE_URL_FULL=https://github.com/KhronosGroup/OpenCL-Headers/archive/refs/tags/v$VERSION.tar.gz
-      SOURCE_VFY=sha256:98f0a3ea26b4aec051e533cb1750db2998ab8e82eda97269ed6efe66ec94a240
+      SOURCE_VFY=sha256:d9e6c48357de5002da11ce45de600e0c3ffe6ab4f628a3b9fe2b38603161658a
 SOURCE_DIRECTORY=$BUILD_DIRECTORY/OpenCL-Headers-$VERSION
         WEB_SITE=https://github.com/KhronosGroup/OpenCL-Headers/
             TYPE=cmake
          ENTERED=20101016
-         UPDATED=20251110
+         UPDATED=20260623
            SHORT="Nvidia CUDA and OpenCL headers extracted from SDK"
+
 cat << EOF
 Nvidia since 260 driver release stopped providing header files.
 Now CUDA headers are only present in CUDA Toolkit which weights


### PR DESCRIPTION
Upgrade CUDA-OpenCL-headers from 2025.07.22 to 2026.05.29

- Updated VERSION to 2026.05.29
- Updated SOURCE_VFY to sha256:d9e6c48357de5002da11ce45de600e0c3ffe6ab4f628a3b9fe2b38603161658a
- Updated UPDATED timestamp to 20260623

---
*Automated PR created by n8n + Claude AI*