### PR TITLE
radare2: Version bumped to 6.1.8

### DIFF
--- a/editors/radare2/DETAILS
+++ b/editors/radare2/DETAILS
@@ -1,12 +1,12 @@
          MODULE=radare2
-        VERSION=6.1.6
+        VERSION=6.1.8
          SOURCE=$MODULE-$VERSION.tar.gz
 SOURCE_URL_FULL=https://github.com/radareorg/radare2/archive/refs/tags/$VERSION.tar.gz
-     SOURCE_VFY=sha256:7370c52cb22cba3ab02ee77970fd258a8ecdbf3fd3282f2647ff12393c6ae8ac
+     SOURCE_VFY=sha256:84d0e32af697f720c9f480f6b3e56b08f64251d90cfe2d8f163431c006c0053e
        WEB_SITE=https://www.radare.org/n/
            TYPE=meson
         ENTERED=20210429
-        UPDATED=20260604
+        UPDATED=20260623
           SHORT="reverse engineering framework"
 
 cat << EOF


### PR DESCRIPTION
Upgrade radare2 from 6.1.6 to 6.1.8

- Updated VERSION to 6.1.8
- Updated SOURCE_VFY with new SHA256 checksum
- Updated UPDATED date to 20260623

---
*Automated PR created by n8n + Claude AI*