### PR TITLE
opencl-icd-loader: Version bumped to 2026.05.29

### DIFF
--- a/devel/opencl-icd-loader/DETAILS
+++ b/devel/opencl-icd-loader/DETAILS
@@ -1,13 +1,13 @@
           MODULE=opencl-icd-loader
-         VERSION=2025.07.22
+         VERSION=2026.05.29
           SOURCE=$MODULE-$VERSION.tar.gz
  SOURCE_URL_FULL=https://github.com/KhronosGroup/OpenCL-ICD-Loader/archive/refs/tags/v$VERSION.tar.gz
-      SOURCE_VFY=sha256:dff7a0b11ad5b63a669358e3476e3dc889a4a361674e5b69b267b944d0794142
+      SOURCE_VFY=sha256:48fd0c5181db7cd046f4f731d5955694892e10998d49d09ee0d997e7e04fd939
 SOURCE_DIRECTORY=$BUILD_DIRECTORY/OpenCL-ICD-Loader-$VERSION
         WEB_SITE=https://github.com/KhronosGroup/OpenCL-ICD-Loader
             TYPE=cmake
          ENTERED=20260420
-         UPDATED=20260420
+         UPDATED=20260624
         REPLACES=ocl-icd
            SHORT="the Khronos official OpenCL ICD Loader"
 


### PR DESCRIPTION
Upgrade opencl-icd-loader from version 2025.07.22 to 2026.05.29

---
*Automated PR created by n8n + Claude AI*