### PR TITLE
rapydscript-ng: Version bumped to 0.7.24

### DIFF
--- a/devel/rapydscript-ng/DETAILS
+++ b/devel/rapydscript-ng/DETAILS
@@ -1,12 +1,12 @@
-          MODULE=rapydscript-ng
-         VERSION=0.7.22
-          SOURCE=$MODULE-$VERSION.tar.gz
- SOURCE_URL_FULL=https://github.com/kovidgoyal/rapydscript-ng/archive/refs/tags/v$VERSION.tar.gz
-      SOURCE_VFY=sha256:04bc3d1b59d24743bd54fde35cc02bb9bc0b0e5d053ef3072cd0682e02903bf7
-        WEB_SITE=https://github.com/kovidgoyal/rapydscript-ng
-         ENTERED=20221117
-         UPDATED=20230226
-           SHORT="pythonic javascript"
+         MODULE=rapydscript-ng
+        VERSION=0.7.24
+         SOURCE=$MODULE-$VERSION.tar.gz
+SOURCE_URL_FULL=https://github.com/kovidgoyal/rapydscript-ng/archive/refs/tags/v$VERSION.tar.gz
+     SOURCE_VFY=sha256:f6f961337c8f6ceaf619634ed7372cb9e163b0b9dadf951275cd657f50fd2298
+       WEB_SITE=https://github.com/kovidgoyal/rapydscript-ng
+        ENTERED=20221117
+        UPDATED=20260624
+          SHORT="pythonic javascript"
 
 cat << EOF
 Pythonic javascript.


### PR DESCRIPTION
Upgrade rapydscript-ng from 0.7.22 to 0.7.24. Updated SOURCE_VFY hash and UPDATED date.

---
*Automated PR created by n8n + Claude AI*