### PR TITLE
tig: Version bumped to 2.6.1

### DIFF
--- a/devel/tig/DETAILS
+++ b/devel/tig/DETAILS
@@ -1,12 +1,12 @@
-          MODULE=tig
-         VERSION=2.6.0
-          SOURCE=$MODULE-$VERSION.tar.gz
-      SOURCE_URL=https://github.com/jonas/tig/releases/download/tig-$VERSION/
-      SOURCE_VFY=sha256:99d4a0fdd3d93547ebacfe511195cb92e4f75b91644c06293c067f401addeb3e
-        WEB_SITE=https://jonas.github.io/tig/
-         ENTERED=20070419
-         UPDATED=20250918
-           SHORT="Text mode interface for git"
+    MODULE=tig
+   VERSION=2.6.1
+    SOURCE=$MODULE-$VERSION.tar.gz
+SOURCE_URL=https://github.com/jonas/tig/releases/download/tig-$VERSION/
+SOURCE_VFY=sha256:5adeabdcd93aa0423d618da8b878b53482bef6e0e9e1fe224acc0f18031fe91e
+  WEB_SITE=https://jonas.github.io/tig/
+   ENTERED=20070419
+   UPDATED=20260624
+     SHORT="Text mode interface for git"
 
 cat << EOF
 Tig is a git repository browser that additionally can act as a pager for output


### PR DESCRIPTION
Upgrade tig from 2.6.0 to 2.6.1

---
*Automated PR created by n8n + Claude AI*