### PR TITLE
libass: Version bumped to 0.17.5

### DIFF
--- a/libs/libass/DETAILS
+++ b/libs/libass/DETAILS
@@ -1,11 +1,11 @@
           MODULE=libass
-         VERSION=0.17.4
+         VERSION=0.17.5
           SOURCE=$MODULE-$VERSION.tar.gz
  SOURCE_URL_FULL=http://github.com/libass/libass/archive/$VERSION.tar.gz
-      SOURCE_VFY=sha256:c287d180d93dc9c9021872574b618ac49027e84cc90e1289318b1ee68bb42251
+      SOURCE_VFY=sha256:fa286fc9ee1ba3b932703a3df7b8474d01dc8abe29ec69b6fa68781dc4bf7acc
         WEB_SITE=http://github.com/libass/libass/
          ENTERED=20071017
-         UPDATED=20250714
+         UPDATED=20260624
            SHORT="A library for SAA/ASS subtitles rendering"
 
 cat << EOF


### PR DESCRIPTION
Upgrade libass from 0.17.4 to 0.17.5

---
*Automated PR created by n8n + Claude AI*