### PR TITLE
blender: Version bumped to 5.1.2

### DIFF
--- a/graphics/blender/DETAILS
+++ b/graphics/blender/DETAILS
@@ -1,12 +1,12 @@
-          MODULE=blender
-         VERSION=4.5.5
-          SOURCE=$MODULE-$VERSION.tar.xz
-      SOURCE_URL=https://download.blender.org/source/
-      SOURCE_VFY=sha256:618f507de44ffef020c57a535a19a1a1beb4108353db700d6d98c6388674f86d
-        WEB_SITE=https://www.blender.org
-         ENTERED=20030929
-         UPDATED=20251119
-           SHORT="3D editor for modeling, animation, and rendering"
+    MODULE=blender
+   VERSION=5.1.2
+    SOURCE=$MODULE-$VERSION.tar.xz
+SOURCE_URL=https://download.blender.org/source/
+SOURCE_VFY=sha256:aedfd030231979b629b18049d93b92fd2794952ca0cf39ebde54e84438bed05a
+  WEB_SITE=https://www.blender.org
+   ENTERED=20030929
+   UPDATED=20260624
+     SHORT="3D editor for modeling, animation, and rendering"
 
 cat << EOF
 3D tool does everything from modeling, animation, rendering, and


### PR DESCRIPTION
Upgrade blender from 4.5.5 to 5.1.2

- Version: 5.1.2
- Source URL: https://download.blender.org/source/blender-5.1.2.tar.xz
- SHA256: aedfd030231979b629b18049d93b92fd2794952ca0cf39ebde54e84438bed05a

---
*Automated PR created by n8n + Claude AI*