### PR TITLE
patchelf: Version bumped to 0.19.0

### DIFF
--- a/utils/patchelf/DETAILS
+++ b/utils/patchelf/DETAILS
@@ -1,13 +1,14 @@
-          MODULE=patchelf
-         VERSION=0.18.0
-          SOURCE=$MODULE-$VERSION.tar.gz
- SOURCE_URL_FULL=https://github.com/NixOS/patchelf/archive/refs/tags/$VERSION.tar.gz
-      SOURCE_VFY=sha256:1451d01ee3a21100340aed867d0b799f46f0b1749680028d38c3f5d0128fb8a7
-        WEB_SITE=https://nixos.org/patchelf.html
-         ENTERED=20230902
-         UPDATED=20230902
-           SHORT="modify existing ELF executables and libraries"
+         MODULE=patchelf
+        VERSION=0.19.0
+         SOURCE=$MODULE-$VERSION.tar.gz
+SOURCE_URL_FULL=https://github.com/NixOS/patchelf/archive/refs/tags/$VERSION.tar.gz
+     SOURCE_VFY=sha256:cbcabe6e2e00d930ef882d8aa4fafe0183133b24827700d4a0a72b886cc265b3
+       WEB_SITE=https://nixos.org/patchelf.html
+        ENTERED=20230902
+        UPDATED=20260627
+          SHORT="modify existing ELF executables and libraries"
 
 cat << EOF
-PatchELF is a simple utility for modifying existing ELF executables and libraries.
+PatchELF is a simple utility for modifying existing ELF executables and
+libraries.
 EOF


### PR DESCRIPTION
Upgrade patchelf from 0.18.0 to 0.19.0

- Updated VERSION to 0.19.0
- Updated SOURCE_VFY to cbcabe6e2e00d930ef882d8aa4fafe0183133b24827700d4a0a72b886cc265b3
- Updated UPDATED timestamp to 20260627

---
*Automated PR created by n8n + Claude AI*