### PR TITLE
libheif: Version bumped to 1.23.1

### DIFF
--- a/libs/libheif/DETAILS
+++ b/libs/libheif/DETAILS
@@ -1,11 +1,11 @@
     MODULE=libheif
-   VERSION=1.23.0
+   VERSION=1.23.1
     SOURCE=$MODULE-$VERSION.tar.gz
 SOURCE_URL=https://github.com/strukturag/libheif/releases/download/v$VERSION/
-SOURCE_VFY=sha256:4c9182b18897617182eed12ab5eb9f9d855b3aa3a736d6bdb31abc034ec7d393
+SOURCE_VFY=sha256:0de0327f60fcd47de90d5654c6fe152232738d60d84fe084ec3e0f35e03b166a
   WEB_SITE=https://github.com/strukturag/libheif/
    ENTERED=20181108
-   UPDATED=20260529
+   UPDATED=20260627
      SHORT="HEIF file format decoder and encoder"
 
 cat << EOF


### PR DESCRIPTION
Upgrade libheif from 1.23.0 to 1.23.1

- Updated VERSION to 1.23.1
- Updated SOURCE_VFY to sha256:0de0327f60fcd47de90d5654c6fe152232738d60d84fe084ec3e0f35e03b166a
- Updated UPDATED timestamp to 20260627

---
*Automated PR created by n8n + Claude AI*