### PR TITLE
libpsl: Version bumped to 0.22.0

### DIFF
--- a/libs/libpsl/DETAILS
+++ b/libs/libpsl/DETAILS
@@ -1,12 +1,12 @@
-          MODULE=libpsl
-         VERSION=0.21.5
-          SOURCE=$MODULE-$VERSION.tar.gz
-      SOURCE_URL=https://github.com/rockdaboot/libpsl/releases/download/${VERSION}/
-      SOURCE_VFY=sha256:1dcc9ceae8b128f3c0b3f654decd0e1e891afc6ff81098f227ef260449dae208
-        WEB_SITE=https://github.com/rockdaboot/libpsl
-         ENTERED=20180512
-         UPDATED=20240206
-           SHORT="Public Suffix List library"
+    MODULE=libpsl
+   VERSION=0.22.0
+    SOURCE=$MODULE-$VERSION.tar.gz
+SOURCE_URL=https://github.com/rockdaboot/libpsl/releases/download/${VERSION}/
+SOURCE_VFY=sha256:c45c3aa17576b99873e05a9b09a44041b065bbfa390e6d474d06fbfaeb9c7722
+  WEB_SITE=https://github.com/rockdaboot/libpsl
+   ENTERED=20180512
+   UPDATED=20260627
+     SHORT="Public Suffix List library"
 
 cat << EOF
 Public Suffix List library.


### PR DESCRIPTION
Upgrade libpsl from 0.21.5 to 0.22.0

---
*Automated PR created by n8n + Claude AI*