### PR TITLE
linux-lts: Version bumped to 6.18.37

### DIFF
--- a/kernel/linux-lts/DETAILS
+++ b/kernel/linux-lts/DETAILS
@@ -1,5 +1,5 @@
         MODULE=linux-lts
-       VERSION=6.18.36
+       VERSION=6.18.37
           BASE=$(echo $VERSION | cut -d. -f1,2)
         SOURCE=linux-$BASE.tar.xz
 if [ -n "$(echo $VERSION | cut -d. -f3)" ] ; then
@@ -10,10 +10,10 @@ fi
 SOURCE2_URL[0]=$KERNEL_URL/pub/linux/kernel/v6.x
 SOURCE2_URL[1]=https://www.kernel.org/pub/linux/kernel/v6.x
     SOURCE_VFY=sha256:9106a4605da9e31ff17659d958782b815f9591ab308d03b0ee21aad6c7dced4b
-   SOURCE2_VFY=sha256:4772326ac484039c9d37c4874a0e3e418c8f5db973620b62ac3f888a0125bab9
+   SOURCE2_VFY=sha256:014d59b54b2323a671a42e19fcea0f2320afc4ae48875e702641ebe84cc7e3a6
       WEB_SITE=https://www.kernel.org/
        ENTERED=20111121
-       UPDATED=20260620
+       UPDATED=20260628
          SHORT="The core of a Linux GNU Operating System"
 TMPFS=off
 KEEP_SOURCE=on


### PR DESCRIPTION
Upgrade linux-lts from 6.18.36 to 6.18.37

Updated kernel patch from 6.18.36 to 6.18.37. The base kernel source (linux-6.18.tar.xz) remains the same with the corresponding patch applied.

- VERSION: 6.18.36 → 6.18.37
- SOURCE_VFY: sha256:9106a4605da9e31ff17659d958782b815f9591ab308d03b0ee21aad6c7dced4b (unchanged)
- SOURCE2_VFY: sha256:014d59b54b2323a671a42e19fcea0f2320afc4ae48875e702641ebe84cc7e3a6
- UPDATED: 20260628

---
*Automated PR created by n8n + Claude AI*