### PR TITLE
tree-sitter: Version bumped to 0.26.10

### DIFF
--- a/devel/tree-sitter/DETAILS
+++ b/devel/tree-sitter/DETAILS
@@ -1,11 +1,11 @@
          MODULE=tree-sitter
-        VERSION=0.26.9
+        VERSION=0.26.10
          SOURCE=$MODULE-$VERSION.tar.gz
 SOURCE_URL_FULL=https://github.com/tree-sitter/tree-sitter/archive/refs/tags/v$VERSION.tar.gz
-     SOURCE_VFY=sha256:8e14780500933f43d86662fcaa1b0ce99ebe9c220f4680bc929dce09a0e0cfc6
+     SOURCE_VFY=sha256:450cb85fd1af34111eb162e931e0e9e4d4dbf23fc09b9cb56f6299a1a80483b6
        WEB_SITE=https://tree-sitter.github.io/tree-sitter/
         ENTERED=20210703
-        UPDATED=20260520
+        UPDATED=20260629
           SHORT="An incremental parsing system for programming tools"
 
 cat << EOF


### PR DESCRIPTION
Upgrade tree-sitter from 0.26.9 to 0.26.10

---
*Automated PR created by n8n + Claude AI*