### PR TITLE
starship: Version bumped to 1.26.0

### DIFF
--- a/utils/starship/DETAILS
+++ b/utils/starship/DETAILS
@@ -1,11 +1,11 @@
          MODULE=starship
-        VERSION=1.25.1
+        VERSION=1.26.0
          SOURCE=$MODULE-$VERSION.tar.gz
 SOURCE_URL_FULL=https://github.com/starship/starship/archive/v$VERSION.tar.gz
-     SOURCE_VFY=sha256:521306b14066ee7e332d998ef5b5b6455fdc6085c52e86b6316a7cdc37bae1d8
+     SOURCE_VFY=sha256:8c95e8a6c596b29ac192104eae00dd991e8c8fd66083fd2b34d6b223a5803a59
        WEB_SITE=https://starship.rs/
         ENTERED=20190921
-        UPDATED=20260502
+        UPDATED=20260629
           SHORT="The cross-shell prompt for astronauts"
 
 cat << EOF


### PR DESCRIPTION
Upgrade starship from 1.25.1 to 1.26.0

- Version: 1.25.1 → 1.26.0
- Source: https://github.com/starship/starship/archive/v1.26.0.tar.gz
- SHA256: 8c95e8a6c596b29ac192104eae00dd991e8c8fd66083fd2b34d6b223a5803a59
- Updated: 20260629

---
*Automated PR created by n8n + Claude AI*