### PR TITLE
skim: Version bumped to 4.10.0

### DIFF
--- a/utils/skim/DETAILS
+++ b/utils/skim/DETAILS
@@ -1,11 +1,11 @@
          MODULE=skim
-        VERSION=4.8.0
+        VERSION=4.10.0
          SOURCE=$MODULE-$VERSION.tar.gz
 SOURCE_URL_FULL=https://github.com/skim-rs/skim/archive/v${VERSION}.tar.gz
-     SOURCE_VFY=sha256:b5dabe228f88da1e87263bc3623c565f756907d918b80452ab5f1ec20d4c3295
+     SOURCE_VFY=sha256:0f77826fe73b4ad69bc692bd3407156fec3ffde12b270472d933de13bf3bd1e7
        WEB_SITE=https://github.com/skim-rs/skim/
         ENTERED=20200627
-        UPDATED=20260617
+        UPDATED=20260629
           SHORT="Fuzzy Finder in rust"
 
 cat << EOF


### PR DESCRIPTION
Upgrade skim from 4.8.0 to 4.10.0

- Updated VERSION to 4.10.0
- Updated SOURCE_VFY to 0f77826fe73b4ad69bc692bd3407156fec3ffde12b270472d933de13bf3bd1e7
- Updated UPDATED date to 20260629

---
*Automated PR created by n8n + Claude AI*