### PR TITLE
bfs: Version bumped to 4.1.4

### DIFF
--- a/utils/bfs/DETAILS
+++ b/utils/bfs/DETAILS
@@ -1,11 +1,11 @@
          MODULE=bfs
-        VERSION=4.1.3
+        VERSION=4.1.4
          SOURCE=$MODULE-$VERSION.tar.gz
 SOURCE_URL_FULL=https://github.com/tavianator/bfs/archive/$VERSION.tar.gz
-     SOURCE_VFY=sha256:64ed282aa3a1e05f10c9888943857cb1b0fb783e12ffd15500249383f13ea5b6
+     SOURCE_VFY=sha256:0cac6849efb8a9447268fb273de3fab38f8460adb26a1770934e3f325fab8f5d
        WEB_SITE=https://github.com/tavianator/bfs/
         ENTERED=20200109
-        UPDATED=20260616
+        UPDATED=20260629
           SHORT="A breadth-first version of the UNIX find command"
 
 cat << EOF


### PR DESCRIPTION
Upgrade bfs from 4.1.3 to 4.1.4. This is a routine version bump with updated SHA256 checksum and UPDATED date.

---
*Automated PR created by n8n + Claude AI*