### PR TITLE
liburing: Version bumped to 2.15

### DIFF
--- a/libs/liburing/DETAILS
+++ b/libs/liburing/DETAILS
@@ -1,12 +1,12 @@
           MODULE=liburing
-         VERSION=2.14
+         VERSION=2.15
           SOURCE=$MODULE-$VERSION.tar.gz
       SOURCE_URL=https://github.com/axboe/liburing/archive/refs/tags
-      SOURCE_VFY=sha256:5f80964108981c6ad979c735f0b4877d5f49914c2a062f8e88282f26bf61de0c
+      SOURCE_VFY=sha256:8d052f2622dcb3678cbaee5ff582a87572672a6c0a56533cdda5b65cb636120a
 SOURCE_DIRECTORY=$BUILD_DIRECTORY/$MODULE-$MODULE-$VERSION
         WEB_SITE=https://git.kernel.dk/cgit/liburing/
          ENTERED=20200723
-         UPDATED=20260210
+         UPDATED=20260629
            SHORT="Linux-native io_uring I/O access library"
 
 cat << EOF


### PR DESCRIPTION
Upgrade liburing from 2.14 to 2.15

- Updated VERSION to 2.15
- Updated SOURCE_VFY with new SHA256 checksum
- Updated UPDATED field to 20260629

---
*Automated PR created by n8n + Claude AI*