### PR TITLE
transmission: Version bumped to 4.1.3

### DIFF
--- a/distributed/transmission/DETAILS
+++ b/distributed/transmission/DETAILS
@@ -1,11 +1,11 @@
           MODULE=transmission
-         VERSION=4.1.2
+         VERSION=4.1.3
           SOURCE=$MODULE-$VERSION.tar.xz
       SOURCE_URL=https://github.com/transmission/transmission/releases/download/$VERSION/
-      SOURCE_VFY=sha256:
+      SOURCE_VFY=sha256:ce7d2d8b101f7eb54bc3cf0bc55f52f7ebd4a25fa48e00bdca9a7e0fc02617da
         WEB_SITE=http://transmissionbt.com
          ENTERED=20060626
-         UPDATED=20260606
+         UPDATED=20260630
            SHORT="A fast and powerful BitTorrent client"
 
 cat << EOF


### PR DESCRIPTION
Upgrade transmission from 4.1.2 to 4.1.3

- Version: 4.1.3
- Source: https://github.com/transmission/transmission/releases/download/4.1.3/transmission-4.1.3.tar.xz
- SHA256: ce7d2d8b101f7eb54bc3cf0bc55f52f7ebd4a25fa48e00bdca9a7e0fc02617da
- Updated: 20260630

---
*Automated PR created by n8n + Claude AI*