### PR TITLE
libjxl: Version bumped to 0.12.0

### DIFF
--- a/graphics/libjxl/DETAILS
+++ b/graphics/libjxl/DETAILS
@@ -1,21 +1,24 @@
-          MODULE=libjxl
-         VERSION=0.11.2
-          SOURCE=$MODULE-$VERSION.tar.gz
- SOURCE_URL_FULL=https://github.com/libjxl/libjxl/archive/refs/tags/v$VERSION.tar.gz
-      SOURCE_VFY=sha256:ab38928f7f6248e2a98cc184956021acb927b16a0dee71b4d260dc040a4320ea
-        WEB_SITE=https://github.com/libjxl/libjxl
-            TYPE=cmake
-         ENTERED=20221214
-         UPDATED=20260211
-           SHORT="reference implementation of JPEG XL encoder and decoder"
+         MODULE=libjxl
+        VERSION=0.12.0
+         SOURCE=$MODULE-$VERSION.tar.gz
+SOURCE_URL_FULL=https://github.com/libjxl/libjxl/archive/refs/tags/v$VERSION.tar.gz
+     SOURCE_VFY=sha256:03e9be69a30be4011f559da75328b6d7cea8ad921fabfbd551ce10bf45cdc992
+       WEB_SITE=https://github.com/libjxl/libjxl
+           TYPE=cmake
+        ENTERED=20221214
+        UPDATED=20260702
+          SHORT="reference implementation of JPEG XL encoder and decoder"
 
 cat << EOF
-This repository contains a reference implementation of JPEG XL (encoder and decoder), called libjxl.
-This software library is used by many applications that support JPEG XL.
+This repository contains a reference implementation of JPEG XL (encoder and
+decoder), called libjxl. This software library is used by many applications that
+support JPEG XL.
 
-JPEG XL is in the final stages of standardization and its codestream and file format are frozen.
+JPEG XL is in the final stages of standardization and its codestream and file
+format are frozen.
 
-The library API, command line options, and tools in this repository are subject to change, however
-files encoded with cjxl conform to the JPEG XL format specification and can be decoded with current
-and future djxl decoders or libjxl decoding library.
+The library API, command line options, and tools in this repository are subject
+to change, however files encoded with cjxl conform to the JPEG XL format
+specification and can be decoded with current and future djxl decoders or libjxl
+decoding library.
 EOF


### PR DESCRIPTION
Upgrade libjxl from 0.11.2 to 0.12.0

- Updated VERSION to 0.12.0
- Updated SOURCE_VFY to match new release
- Updated UPDATED date to 20260702

---
*Automated PR created by n8n + Claude AI*