### PR TITLE
libevent: Version bumped to 2.1.13

### DIFF
--- a/libs/libevent/DETAILS
+++ b/libs/libevent/DETAILS
@@ -1,12 +1,12 @@
           MODULE=libevent
-         VERSION=2.1.12
+         VERSION=2.1.13
           SOURCE=$MODULE-$VERSION-stable.tar.gz
 SOURCE_DIRECTORY=$BUILD_DIRECTORY/$MODULE-$VERSION-stable
       SOURCE_URL=http://github.com/libevent/libevent/releases/download/release-$VERSION-stable/
-      SOURCE_VFY=sha256:92e6de1be9ec176428fd2367677e61ceffc2ee1cb119035037a27d346b0403bb
+      SOURCE_VFY=sha256:f7e9383b8c0baa81b687e5b5eecc01beefaf1b19b64151d95ed61647fe7a315c
         WEB_SITE=http://www.monkey.org/~provos/libevent
          ENTERED=20060904
-         UPDATED=20200717
+         UPDATED=20260702
            SHORT="An event notification library"
 
 cat << EOF


### PR DESCRIPTION
Upgrade libevent from version 2.1.12 to 2.1.13. This update includes the latest stable release with bug fixes and improvements.

---
*Automated PR created by n8n + Claude AI*