### PR TITLE
libseccomp: Version bumped to 2.6.1

### DIFF
--- a/libs/libseccomp/DETAILS
+++ b/libs/libseccomp/DETAILS
@@ -1,12 +1,12 @@
-          MODULE=libseccomp
-         VERSION=2.6.0
-          SOURCE=$MODULE-$VERSION.tar.gz
-      SOURCE_URL=https://github.com/seccomp/libseccomp/releases/download/v$VERSION
-      SOURCE_VFY=sha256:83b6085232d1588c379dc9b9cae47bb37407cf262e6e74993c61ba72d2a784dc
-        WEB_SITE=http://sourceforge.net/projects/libseccomp/
-         ENTERED=20130413
-         UPDATED=20250125
-           SHORT="Enhanced seccomp library"
+    MODULE=libseccomp
+   VERSION=2.6.1
+    SOURCE=$MODULE-$VERSION.tar.gz
+SOURCE_URL=https://github.com/seccomp/libseccomp/releases/download/v$VERSION
+SOURCE_VFY=sha256:501f66c667225d53791b97e1d7cf85ab764c297d04881f60f38f451c4b0ee1be
+  WEB_SITE=http://sourceforge.net/projects/libseccomp/
+   ENTERED=20130413
+   UPDATED=20260702
+     SHORT="Enhanced seccomp library"
 
 cat << EOF
 The libseccomp library provides and easy to use, platform independent, interface


### PR DESCRIPTION
Upgrade libseccomp from 2.6.0 to 2.6.1. Updated VERSION, SOURCE_VFY, and UPDATED date.

---
*Automated PR created by n8n + Claude AI*