### PR TITLE
gh: Version bumped to 2.96.0

### DIFF
--- a/devel/gh/DETAILS
+++ b/devel/gh/DETAILS
@@ -1,12 +1,12 @@
           MODULE=gh
-         VERSION=2.95.0
+         VERSION=2.96.0
           SOURCE=gh-cli-$VERSION.tar.gz
  SOURCE_URL_FULL=https://github.com/cli/cli/archive/refs/tags/v$VERSION.tar.gz
-      SOURCE_VFY=sha256:b6a1c88cbd15f49f60a68d210a117a60b349bcb0d028a0dca0ef2d9dc92bd028
+      SOURCE_VFY=sha256:8d80d0aeccea7bec8024f8c30365bbfa76852901f2b2cb0afb7ab2cbf6d317c2
 SOURCE_DIRECTORY=$BUILD_DIRECTORY/cli-$VERSION
         WEB_SITE=https://cli.github.com/
          ENTERED=20210423
-         UPDATED=20260617
+         UPDATED=20260703
            SHORT="Official command-line wrapper for GitHub"
 
 cat << EOF


### PR DESCRIPTION
Upgrade gh from version 2.95.0 to 2.96.0

---
*Automated PR created by n8n + Claude AI*