### PR TITLE
libphonenumber: Version bumped to 9.0.34

### DIFF
--- a/libs/libphonenumber/DETAILS
+++ b/libs/libphonenumber/DETAILS
@@ -1,11 +1,11 @@
          MODULE=libphonenumber
-        VERSION=9.0.32
+        VERSION=9.0.34
          SOURCE=$MODULE-$VERSION.tar.gz
 SOURCE_URL_FULL=https://github.com/google/libphonenumber/archive/refs/tags/v$VERSION.tar.gz
-     SOURCE_VFY=sha256:fef1a587ff4793d02cf10dc87d083e7a230e0caf56e8dfdf0da6a15f78420ed8
+     SOURCE_VFY=sha256:5d2a61572110f0538fdb1afbc1f8381426fbfbbf544b45e8ae905297f2f5befa
        WEB_SITE=https://github.com/googlei18n/libphonenumber
         ENTERED=20230824
-        UPDATED=20260603
+        UPDATED=20260703
           SHORT="common library to parse, format and validate international phone numbers"
 
 cat << EOF


### PR DESCRIPTION
Upgrade libphonenumber from 9.0.32 to 9.0.34

- Version: 9.0.34
- Source URL: https://github.com/google/libphonenumber/archive/refs/tags/v9.0.34.tar.gz
- SHA256: 5d2a61572110f0538fdb1afbc1f8381426fbfbbf544b45e8ae905297f2f5befa

---
*Automated PR created by n8n + Claude AI*