### PR TITLE
fluidsynth: Version bumped to 2.5.6

### DIFF
--- a/audio/fluidsynth/DETAILS
+++ b/audio/fluidsynth/DETAILS
@@ -1,11 +1,11 @@
          MODULE=fluidsynth
-        VERSION=2.5.5
+        VERSION=2.5.6
          SOURCE=$MODULE-$VERSION.tar.gz
 SOURCE_URL_FULL=https://github.com/FluidSynth/${MODULE}/archive/v$VERSION.tar.gz
-     SOURCE_VFY=sha256:0827eefc06f66157c332d7bd0d65ee81be5d4c795f214db7ba0e1c70ee394430
+     SOURCE_VFY=sha256:0825f024c9cf7a18073739b83612d46542ecbfb349ae9147a1e9f08e2d524407
        WEB_SITE=https://www.fluidsynth.org/
         ENTERED=20060317
-        UPDATED=20260613
+        UPDATED=20260704
           SHORT="A real-time software synthesizer"
 
 cat << EOF


### PR DESCRIPTION
Upgrade fluidsynth from version 2.5.5 to 2.5.6

---
*Automated PR created by n8n + Claude AI*