### PR TITLE
yt-dlp: Version bumped to 2026.07.04

### DIFF
--- a/video/yt-dlp/DETAILS
+++ b/video/yt-dlp/DETAILS
@@ -1,11 +1,11 @@
          MODULE=yt-dlp
-        VERSION=2026.06.09
+        VERSION=2026.07.04
          SOURCE=$MODULE-$VERSION.tar.gz
 SOURCE_URL_FULL=https://github.com/yt-dlp/yt-dlp/archive/refs/tags/$VERSION.tar.gz
-     SOURCE_VFY=sha256:6add707714c1d9a960cb6f4de1dcbd9fbf857f1bc488d26b43f0701246a06f38
+     SOURCE_VFY=sha256:7fb7ca0509dd8f21263246d3d749a346e049fa9d3cfdef072e05c7bbd88d6fc0
        WEB_SITE=https://github.com/yt-dlp/yt-dlp
         ENTERED=20221226
-        UPDATED=20260610
+        UPDATED=20260705
           SHORT="youtube download manager"
 
 cat << EOF


### PR DESCRIPTION
Update yt-dlp from 2026.06.09 to 2026.07.04

---
*Automated PR created by n8n + Claude AI*