### PR TITLE
enchant: Version bumped to 2.8.18

### DIFF
--- a/editors/enchant/DETAILS
+++ b/editors/enchant/DETAILS
@@ -1,11 +1,11 @@
     MODULE=enchant
-   VERSION=2.8.16
+   VERSION=2.8.18
     SOURCE=$MODULE-$VERSION.tar.gz
 SOURCE_URL=https://github.com/rrthomas/enchant/releases/download/v$VERSION/
-SOURCE_VFY=sha256:d73162b5eff401a6397e1215e2b103bcef83f921c396c7f6b1394d2450d124e2
+SOURCE_VFY=sha256:883a16f0898c7b1af38046d8bce5c658156698498541e9344c60e317e8d48f2a
   WEB_SITE=https://abiword.github.io/enchant/
    ENTERED=20070312
-   UPDATED=20260502
+   UPDATED=20260705
      SHORT="A generic spell checking library"
 
 cat << EOF


### PR DESCRIPTION
Upgrade enchant from 2.8.16 to 2.8.18

- Updated VERSION to 2.8.18
- Updated SOURCE_VFY to sha256:883a16f0898c7b1af38046d8bce5c658156698498541e9344c60e317e8d48f2a
- Updated UPDATED date to 20260705

---
*Automated PR created by n8n + Claude AI*