### PR TITLE
patchelf: Version bumped to 0.19.1

### DIFF
--- a/utils/patchelf/DETAILS
+++ b/utils/patchelf/DETAILS
@@ -1,11 +1,11 @@
          MODULE=patchelf
-        VERSION=0.19.0
+        VERSION=0.19.1
          SOURCE=$MODULE-$VERSION.tar.gz
 SOURCE_URL_FULL=https://github.com/NixOS/patchelf/archive/refs/tags/$VERSION.tar.gz
-     SOURCE_VFY=sha256:cbcabe6e2e00d930ef882d8aa4fafe0183133b24827700d4a0a72b886cc265b3
+     SOURCE_VFY=sha256:39cd33c4810f10ec479d22b8ee6cf8e7acb77c356f3864e3270e2d45f7d23448
        WEB_SITE=https://nixos.org/patchelf.html
         ENTERED=20230902
-        UPDATED=20260627
+        UPDATED=20260707
           SHORT="modify existing ELF executables and libraries"
 
 cat << EOF


### PR DESCRIPTION
Upgrade patchelf from 0.19.0 to 0.19.1

- Updated VERSION to 0.19.1
- Updated SOURCE_VFY to sha256:39cd33c4810f10ec479d22b8ee6cf8e7acb77c356f3864e3270e2d45f7d23448
- Updated UPDATED date to 20260707

---
*Automated PR created by n8n + Claude AI*