### PR TITLE
fzf: Version bumped to 0.74.0

### DIFF
--- a/utils/fzf/DETAILS
+++ b/utils/fzf/DETAILS
@@ -1,11 +1,11 @@
          MODULE=fzf
-        VERSION=0.73.1
+        VERSION=0.74.0
          SOURCE=$MODULE-$VERSION.tar.gz
 SOURCE_URL_FULL=https://github.com/junegunn/fzf/archive/refs/tags/v$VERSION.tar.gz
-     SOURCE_VFY=sha256:ae4f49f8606a7d28498208fa1b93c5d3b890719eea97e02559e66160138b750c
+     SOURCE_VFY=sha256:55ab5f2256edd8890f81d407b63d3a3e81cffe10e318cd196031dc85efdeb079
        WEB_SITE=https://github.com/junegunn/fzf/
         ENTERED=20181112
-        UPDATED=20260526
+        UPDATED=20260707
           SHORT="Command-line fuzzy finder"
 
 cat << EOF


### PR DESCRIPTION
Upgrade fzf from 0.73.1 to 0.74.0

- Updated VERSION to 0.74.0
- Updated SOURCE_VFY to sha256:55ab5f2256edd8890f81d407b63d3a3e81cffe10e318cd196031dc85efdeb079
- Updated UPDATED date to 20260707

---
*Automated PR created by n8n + Claude AI*