### PR TITLE
c-ares: Version bumped to 1.34.7

### DIFF
--- a/net/c-ares/DETAILS
+++ b/net/c-ares/DETAILS
@@ -1,13 +1,13 @@
-          MODULE=c-ares
-         VERSION=1.34.6
-          SOURCE=$MODULE-$VERSION.tar.gz
-      SOURCE_URL=https://github.com/c-ares/c-ares/releases/download/v$VERSION/
-      SOURCE_VFY=sha256:912dd7cc3b3e8a79c52fd7fb9c0f4ecf0aaa73e45efda880266a2d6e26b84ef5
-        WEB_SITE=https://c-ares.org/
-            TYPE=cmake
-         ENTERED=20071025
-         UPDATED=20251209
-           SHORT="Asynchronous DNS request and name resolv library"
+    MODULE=c-ares
+   VERSION=1.34.7
+    SOURCE=$MODULE-$VERSION.tar.gz
+SOURCE_URL=https://github.com/c-ares/c-ares/releases/download/v$VERSION/
+SOURCE_VFY=sha256:556f781dd188ad932dc8263fee0ad3aaba675b4cd8e54d86908681b43ce3e327
+  WEB_SITE=https://c-ares.org/
+      TYPE=cmake
+   ENTERED=20071025
+   UPDATED=20260707
+     SHORT="Asynchronous DNS request and name resolv library"
 
 cat << EOF
 c-ares is a C library that performs DNS request and name resolves


### PR DESCRIPTION
Upgrade c-ares from version 1.34.6 to 1.34.7

---
*Automated PR created by n8n + Claude AI*