### PR TITLE
tlp: Version bumped to 1.10.2

### DIFF
--- a/utils/tlp/DETAILS
+++ b/utils/tlp/DETAILS
@@ -1,12 +1,12 @@
           MODULE=tlp
-         VERSION=1.10.1
+         VERSION=1.10.2
           SOURCE=$MODULE-$VERSION.tar.gz
 SOURCE_DIRECTORY=$BUILD_DIRECTORY/TLP-$VERSION
  SOURCE_URL_FULL=https://github.com/linrunner/TLP/archive/$VERSION.tar.gz
-      SOURCE_VFY=sha256:c3f1f4b72a603a134e24b21364669a828180a3de5cbe62917ba88f0c53ca6397
+      SOURCE_VFY=sha256:a0b8bd8193d96853d2876c552b3b2bdf46bd1258fffc9ac598acc67eb73b56d5
         WEB_SITE=http://linrunner.de/en/tlp/tlp.html
          ENTERED=20180227
-         UPDATED=20260611
+         UPDATED=20260707
            SHORT="Linux Advanced Power Management"
 
 cat << EOF


### PR DESCRIPTION
Upgrade tlp from 1.10.1 to 1.10.2

- Update VERSION to 1.10.2
- Update SOURCE_VFY to a0b8bd8193d96853d2876c552b3b2bdf46bd1258fffc9ac598acc67eb73b56d5
- Update UPDATED date to 20260707
- No changes to dependencies or build process

---
*Automated PR created by n8n + Claude AI*