### PR TITLE
dmraid: move to the crater

### DIFF
--- a/crater/dmraid/BUILD
+++ b/crater/dmraid/BUILD
@@ -1,0 +1,4 @@
+export LDFLAGS+=" -ldevmapper"
+cd $VERSION/$MODULE &&
+autoreconf -fi &&
+default_build

--- a/crater/dmraid/DEPENDS
+++ b/crater/dmraid/DEPENDS
@@ -1,0 +1,1 @@
+depends lvm2

--- a/crater/dmraid/DETAILS
+++ b/crater/dmraid/DETAILS
@@ -1,0 +1,21 @@
+          MODULE=dmraid
+         VERSION=1.0.0.rc16-3
+          SOURCE=$MODULE-$VERSION.tar.bz2
+      SOURCE_URL=https://people.redhat.com/~heinzm/sw/$MODULE/src/
+SOURCE_DIRECTORY=$BUILD_DIRECTORY/$MODULE
+      SOURCE_VFY=sha1:162b6173b91a0121a52402d2ed939b43d74ff605
+        WEB_SITE="http://people.redhat.com/~heinzm/"
+         ENTERED=20081025
+         UPDATED=20260117
+           SHORT="discovers, activates, deactivates and displays software RAID sets"
+PSAFE=no
+
+cat <<EOF
+This software discovers, activates, deactivates and displays properties
+of software RAID sets (eg, ATARAID) and contained DOS partitions.
+
+It allows for RAID set creation/removal/rebuild of Intel Software RAID.
+
+dmraid uses libdevmapper and the device-mapper kernel runtime to create
+devices with respective mappings for the ATARAID sets discovered.
+EOF


### PR DESCRIPTION
It hasn't been maintained in 13 years (it's literally been stuck on '1.0.0.rc16-3' that whole time) and it hasn't even been used by Lunar since 19 years ago, and with the latest autoconf update, it doesn't even compile any more.