### PR TITLE
libpsl: Version bumped to 0.23.0

### DIFF
--- a/libs/libpsl/DETAILS
+++ b/libs/libpsl/DETAILS
@@ -1,11 +1,11 @@
     MODULE=libpsl
-   VERSION=0.22.0
+   VERSION=0.23.0
     SOURCE=$MODULE-$VERSION.tar.gz
 SOURCE_URL=https://github.com/rockdaboot/libpsl/releases/download/${VERSION}/
-SOURCE_VFY=sha256:c45c3aa17576b99873e05a9b09a44041b065bbfa390e6d474d06fbfaeb9c7722
+SOURCE_VFY=sha256:f39b9631b3d369a21259ea4654f8875c0ec6995ce9551c0eb5d423e4c011f911
   WEB_SITE=https://github.com/rockdaboot/libpsl
    ENTERED=20180512
-   UPDATED=20260627
+   UPDATED=20260712
      SHORT="Public Suffix List library"
 
 cat << EOF


### PR DESCRIPTION
Upgrade libpsl from 0.22.0 to 0.23.0

- Updated VERSION to 0.23.0
- Updated SOURCE_VFY to f39b9631b3d369a21259ea4654f8875c0ec6995ce9551c0eb5d423e4c011f911
- Updated UPDATED timestamp to 20260712

---
*Automated PR created by n8n + Claude AI*