### PR TITLE
wakatime-cli: Version bumped to 2.22.0

### DIFF
--- a/utils/wakatime-cli/DETAILS
+++ b/utils/wakatime-cli/DETAILS
@@ -1,11 +1,11 @@
          MODULE=wakatime-cli
-        VERSION=2.20.1
+        VERSION=2.22.0
          SOURCE=$MODULE-$VERSION.tar.gz
 SOURCE_URL_FULL=https://github.com/wakatime/wakatime-cli/archive/refs/tags/v$VERSION.tar.gz
-     SOURCE_VFY=sha256:8e9ee7aae6af13760ad26f8e061cc046ac7ea527c21ecd47283bd7230c073bb5
+     SOURCE_VFY=sha256:89084504dee74417311a992b59f310b5a25c85a7159a08498b7a1b18d36e9a0f
        WEB_SITE=https://github.com/wakatime/wakatime-cli
         ENTERED=20220710
-        UPDATED=20260620
+        UPDATED=20260712
           SHORT="Command line interface used by all WakaTime text editor plugins"
 
 cat <<EOF


### PR DESCRIPTION
Upgrade wakatime-cli from 2.20.1 to 2.22.0

- Updated VERSION to 2.22.0
- Updated SOURCE_VFY to 89084504dee74417311a992b59f310b5a25c85a7159a08498b7a1b18d36e9a0f
- Updated UPDATED date to 20260712

---
*Automated PR created by n8n + Claude AI*