### PR TITLE
blosc2: Version bumped to 3.2.1

### DIFF
--- a/archive/blosc2/DETAILS
+++ b/archive/blosc2/DETAILS
@@ -1,12 +1,12 @@
           MODULE=blosc2
-         VERSION=3.1.4
+         VERSION=3.2.1
           SOURCE=$MODULE-$VERSION.tar.gz
  SOURCE_URL_FULL=https://github.com/Blosc/c-blosc2/archive/refs/tags/v$VERSION.tar.gz
-      SOURCE_VFY=sha256:085a2f4e3ea66e7ca4ceae17873e1a5fa4af7f72cd0286d0dd175bb864278960
+      SOURCE_VFY=sha256:945cc68d47ba2817279b5d64c0f9b5edce6849a52ac1a46ba8c3ecaedce35769
 SOURCE_DIRECTORY=$BUILD_DIRECTORY/c-$MODULE-$VERSION
         WEB_SITE=https://github.com/Blosc/c-blosc2/
          ENTERED=20240724
-         UPDATED=20260617
+         UPDATED=20260712
            SHORT="A blocking, shuffling and loss-less compression library"
 
 cat << EOF


### PR DESCRIPTION
Upgrade blosc2 from version 3.1.4 to 3.2.1. Updated SOURCE_VFY checksum and UPDATED date.

---
*Automated PR created by n8n + Claude AI*