### PR TITLE
git: Fix the NO_RUST flag

### DIFF
--- a/devel/git/BUILD
+++ b/devel/git/BUILD
@@ -13,7 +13,7 @@ if in_depends $MODULE pcre2; then
 fi
 
 # disable the rust depend
-OPTS="WITH_RUST=0"
+OPTS="NO_RUST=1"
 
 make prefix=/usr \
      gitexecdir=/usr/lib/git-core \


### PR DESCRIPTION
Seems it's changed from WITH_RUST to NO_RUST

Also they're threatening that with git 3.x, rust will be a required
dependency.
