### PR TITLE
stress-ng: Version bumped to 0.21.04

### DIFF
--- a/utils/stress-ng/DETAILS
+++ b/utils/stress-ng/DETAILS
@@ -1,11 +1,11 @@
          MODULE=stress-ng
-        VERSION=0.21.03
+        VERSION=0.21.04
          SOURCE=$MODULE-$VERSION.tar.gz
 SOURCE_URL_FULL=https://github.com/ColinIanKing/$MODULE/archive/refs/tags/V${VERSION}.tar.gz
-     SOURCE_VFY=sha256:6db7089ad9cc2c13d0aa1cf8755112adac92858f4582a46c765bb6b7e1c3e1af
+     SOURCE_VFY=sha256:a328ba050bd3014f07a3265fb6c1aab071ae942dfad75c7459cce45a987869e1
        WEB_SITE=https://github.com/ColinIanKing/stress-ng
         ENTERED=20250106
-        UPDATED=20260612
+        UPDATED=20260714
           SHORT="stress test a computer system in various selectable ways"
 
 cat << EOF


### PR DESCRIPTION
Upgrade stress-ng from 0.21.03 to 0.21.04

---
*Automated PR created by n8n + Claude AI*