### PR TITLE
firefox: Version bumped to 152.0.6

### DIFF
--- a/web/firefox/DETAILS
+++ b/web/firefox/DETAILS
@@ -1,11 +1,11 @@
     MODULE=firefox
-   VERSION=152.0.5
+   VERSION=152.0.6
     SOURCE=$MODULE-$VERSION.source.tar.xz
 SOURCE_URL=https://archive.mozilla.org/pub/firefox/releases/$VERSION/source
-SOURCE_VFY=sha256:0a0341b05ac68834c4071665fe11f1e6729084b4e4ffcd70241097b0ad2cb224
+SOURCE_VFY=sha256:ea220c4f8d19d4edaa20e6dadfd3c4aeb07dbed017ade2828fd814d660660f0e
   WEB_SITE=https://www.mozilla.org/en-US/firefox
    ENTERED=20110814
-   UPDATED=20260707
+   UPDATED=20260714
      SHORT="A web browser from mozilla.org"
 
 cat << EOF


### PR DESCRIPTION
Upgrade firefox from 152.0.5 to 152.0.6

- Version: 152.0.5 → 152.0.6
- SHA256: ea220c4f8d19d4edaa20e6dadfd3c4aeb07dbed017ade2828fd814d660660f0e
- Updated: 20260707 → 20260714

---
*Automated PR created by n8n + Claude AI*