### PR TITLE
postfix: Version bumped to 3.11.5

### DIFF
--- a/mail/postfix/DETAILS
+++ b/mail/postfix/DETAILS
@@ -1,11 +1,11 @@
     MODULE=postfix
-   VERSION=3.11.4
+   VERSION=3.11.5
     SOURCE=$MODULE-$VERSION.tar.gz
 SOURCE_URL=ftp://ftp.porcupine.org/mirrors/postfix-release/official/
-SOURCE_VFY=sha256:226ec59a18e43e277691005e31496f7608b9ba9210be600a267fb217a4a6cee9
+SOURCE_VFY=sha256:4a6ab3d0e9390989fa201fc6c446045fc702c4e16e7a247c3ae261c9e9bee610
   WEB_SITE=https://www.postfix.org/
    ENTERED=20020125
-   UPDATED=20260619
+   UPDATED=20260714
      SHORT="A fast and secure drop-in replacement for sendmail"
 
 cat << EOF


### PR DESCRIPTION
Upgrade postfix from 3.11.4 to 3.11.5. SHA256 checksum updated. UPDATED date set to current date.

---
*Automated PR created by n8n + Claude AI*