### PR TITLE
minimagick: Version bumped to 5.3.2

### DIFF
--- a/graphics/minimagick/DETAILS
+++ b/graphics/minimagick/DETAILS
@@ -1,12 +1,12 @@
-          MODULE=minimagick
-         VERSION=5.3.1
-          SOURCE=$MODULE-$VERSION.tar.gz
- SOURCE_URL_FULL=https://github.com/minimagick/minimagick/archive/v$VERSION.tar.gz
-      SOURCE_VFY=sha256:b744e8c22c021bd9ae66e3bc1b1ced64c082d0bdb99fc87d10937a7f8c268086
-        WEB_SITE=https://github.com/minimagick/minimagick
-         ENTERED=20150303
-         UPDATED=20251212
-           SHORT="A Ruby wrapper for ImageMagick"
+         MODULE=minimagick
+        VERSION=5.3.2
+         SOURCE=$MODULE-$VERSION.tar.gz
+SOURCE_URL_FULL=https://github.com/minimagick/minimagick/archive/v$VERSION.tar.gz
+     SOURCE_VFY=sha256:7a85909ac3a60f58514b148290a4382e2c34cc83d5f2effcbf8d327cfb3870ea
+       WEB_SITE=https://github.com/minimagick/minimagick
+        ENTERED=20150303
+        UPDATED=20260715
+          SHORT="A Ruby wrapper for ImageMagick"
 
 cat << EOF
 Ruby wrapper for ImageMagick.


### PR DESCRIPTION
Upgrade minimagick from 5.3.1 to 5.3.2

- Updated VERSION to 5.3.2
- Updated SOURCE_VFY to sha256:7a85909ac3a60f58514b148290a4382e2c34cc83d5f2effcbf8d327cfb3870ea
- Updated UPDATED date to 20260715

---
*Automated PR created by n8n + Claude AI*