### PR TITLE
atuin: Version bumped to 18.17.1

### DIFF
--- a/utils/atuin/DETAILS
+++ b/utils/atuin/DETAILS
@@ -1,11 +1,11 @@
          MODULE=atuin
-        VERSION=18.16.0
+        VERSION=18.17.1
          SOURCE=$MODULE-$VERSION.tar.gz
 SOURCE_URL_FULL=https://github.com/atuinsh/atuin/archive/v$VERSION.tar.gz
-     SOURCE_VFY=sha256:433a6ee912d84b2aa4b59b329775a7ee1a1cdc3094412c2f185ac5ce681a64f0
+     SOURCE_VFY=sha256:851c3f4870e4bd181b98d2dae60b9fd76ef30f05f16a85efa21ac7e7cf294862
        WEB_SITE=https://atuin.sh
         ENTERED=20251026
-        UPDATED=20260429
+        UPDATED=20260715
           SHORT="Magical shell history"
 
 cat << EOF


### PR DESCRIPTION
Update atuin from 18.16.0 to 18.17.1. This upgrade includes the latest features and bug fixes from the upstream release.

---
*Automated PR created by n8n + Claude AI*