### PR TITLE
ripgrep: Version bumped to 15.2.0

### DIFF
--- a/utils/ripgrep/DETAILS
+++ b/utils/ripgrep/DETAILS
@@ -1,12 +1,12 @@
-          MODULE=ripgrep
-         VERSION=15.1.0
-          SOURCE=$MODULE-$VERSION.tar.gz
- SOURCE_URL_FULL=https://github.com/BurntSushi/ripgrep/archive/$VERSION.tar.gz
-      SOURCE_VFY=sha256:046fa01a216793b8bd2750f9d68d4ad43986eb9c0d6122600f993906012972e8
-        WEB_SITE=https://github.com/BurntSushi/ripgrep/
-         ENTERED=20190417
-         UPDATED=20251027
-           SHORT="Recursively searches directories for a regex pattern"
+         MODULE=ripgrep
+        VERSION=15.2.0
+         SOURCE=$MODULE-$VERSION.tar.gz
+SOURCE_URL_FULL=https://github.com/BurntSushi/ripgrep/archive/$VERSION.tar.gz
+     SOURCE_VFY=sha256:7605249d3eb0d5f170e3414498e3344e26b1e7a147aec518b57090b80036a562
+       WEB_SITE=https://github.com/BurntSushi/ripgrep/
+        ENTERED=20190417
+        UPDATED=20260716
+          SHORT="Recursively searches directories for a regex pattern"
 
 cat << EOF
 ripgrep is a line-oriented search tool that recursively searches your current


### PR DESCRIPTION
Upgrade ripgrep from 15.1.0 to 15.2.0. This is a routine version bump with no structural changes to the module.

---
*Automated PR created by n8n + Claude AI*