### PR TITLE
blosc2: Version bumped to 3.2.3

### DIFF
--- a/archive/blosc2/DETAILS
+++ b/archive/blosc2/DETAILS
@@ -1,12 +1,12 @@
           MODULE=blosc2
-         VERSION=3.2.1
+         VERSION=3.2.3
           SOURCE=$MODULE-$VERSION.tar.gz
  SOURCE_URL_FULL=https://github.com/Blosc/c-blosc2/archive/refs/tags/v$VERSION.tar.gz
-      SOURCE_VFY=sha256:945cc68d47ba2817279b5d64c0f9b5edce6849a52ac1a46ba8c3ecaedce35769
+      SOURCE_VFY=sha256:32977709c21f3fec50befa7a031fa624b963427b69d3ffb69c91aadc9279c887
 SOURCE_DIRECTORY=$BUILD_DIRECTORY/c-$MODULE-$VERSION
         WEB_SITE=https://github.com/Blosc/c-blosc2/
          ENTERED=20240724
-         UPDATED=20260712
+         UPDATED=20260716
            SHORT="A blocking, shuffling and loss-less compression library"
 
 cat << EOF


### PR DESCRIPTION
Upgrade blosc2 from version 3.2.1 to 3.2.3

---
*Automated PR created by n8n + Claude AI*