### PR TITLE
skim: Version bumped to 5.1.3

### DIFF
--- a/utils/skim/DETAILS
+++ b/utils/skim/DETAILS
@@ -1,11 +1,11 @@
          MODULE=skim
-        VERSION=4.10.0
+        VERSION=5.1.3
          SOURCE=$MODULE-$VERSION.tar.gz
 SOURCE_URL_FULL=https://github.com/skim-rs/skim/archive/v${VERSION}.tar.gz
-     SOURCE_VFY=sha256:0f77826fe73b4ad69bc692bd3407156fec3ffde12b270472d933de13bf3bd1e7
+     SOURCE_VFY=sha256:e348fa7690c9e1fe33ecf8f162324101214a658082e887e9372dd264dbea6f48
        WEB_SITE=https://github.com/skim-rs/skim/
         ENTERED=20200627
-        UPDATED=20260629
+        UPDATED=20260717
           SHORT="Fuzzy Finder in rust"
 
 cat << EOF


### PR DESCRIPTION
Update skim from 4.10.0 to 5.1.3

- Version: 5.1.3
- Source: https://github.com/skim-rs/skim/archive/v5.1.3.tar.gz
- SHA256: e348fa7690c9e1fe33ecf8f162324101214a658082e887e9372dd264dbea6f48

---
*Automated PR created by n8n + Claude AI*