### PR TITLE
libphonenumber: Version bumped to 9.0.35

### DIFF
--- a/libs/libphonenumber/DETAILS
+++ b/libs/libphonenumber/DETAILS
@@ -1,11 +1,11 @@
          MODULE=libphonenumber
-        VERSION=9.0.34
+        VERSION=9.0.35
          SOURCE=$MODULE-$VERSION.tar.gz
 SOURCE_URL_FULL=https://github.com/google/libphonenumber/archive/refs/tags/v$VERSION.tar.gz
-     SOURCE_VFY=sha256:5d2a61572110f0538fdb1afbc1f8381426fbfbbf544b45e8ae905297f2f5befa
+     SOURCE_VFY=sha256:a3b01ad172764edc4385954ea4ab8fecc9a91ae05ccb8d494bfc5323c28312ee
        WEB_SITE=https://github.com/googlei18n/libphonenumber
         ENTERED=20230824
-        UPDATED=20260703
+        UPDATED=20260717
           SHORT="common library to parse, format and validate international phone numbers"
 
 cat << EOF


### PR DESCRIPTION
Upgrade libphonenumber from 9.0.34 to 9.0.35

- Updated VERSION to 9.0.35
- Updated SOURCE_VFY to sha256:a3b01ad172764edc4385954ea4ab8fecc9a91ae05ccb8d494bfc5323c28312ee
- Updated UPDATED date to 20260717

---
*Automated PR created by n8n + Claude AI*