### PR TITLE
kitty: Version bumped to 0.48.0

### DIFF
--- a/terminal/kitty/DETAILS
+++ b/terminal/kitty/DETAILS
@@ -1,11 +1,11 @@
          MODULE=kitty
-        VERSION=0.47.4
+        VERSION=0.48.0
          SOURCE=$MODULE-$VERSION.tar.gz
 SOURCE_URL_FULL=https://github.com/kovidgoyal/kitty/archive/v$VERSION.tar.gz
-     SOURCE_VFY=sha256:85c219299aeb5581f982c3ac893339d683d70f39d1024b3658a57addcd83c4b2
+     SOURCE_VFY=sha256:a463a12bc96457a97c78c13638dd3e381f643ac4d3f3ea73ace0cbf4bf5389aa
        WEB_SITE=https://sw.kovidgoyal.net/kitty/
         ENTERED=20190110
-        UPDATED=20260615
+        UPDATED=20260718
           SHORT="A GPU based terminal emulator"
 
 cat << EOF


### PR DESCRIPTION
Update kitty to version 0.48.0 from upstream release

---
*Automated PR created by n8n + Claude AI*