### PR TITLE
openal: Version bumped to 1.25.2

### DIFF
--- a/audio/openal/DETAILS
+++ b/audio/openal/DETAILS
@@ -1,12 +1,12 @@
           MODULE=openal
-         VERSION=1.25.1
+         VERSION=1.25.2
           SOURCE=$MODULE-soft-$VERSION.tar.gz
  SOURCE_URL_FULL=https://github.com/kcat/openal-soft/archive/${VERSION}.tar.gz
 SOURCE_DIRECTORY=$BUILD_DIRECTORY/$MODULE-soft-$VERSION
-      SOURCE_VFY=sha256:5f8efe8dfba5e9307a50251ba615ace857c7fa9dddfe34130b83e213d7f7cf24
+      SOURCE_VFY=sha256:fb27e5839aa11f0e5b9d33756965291fad5d6909ab928ea1f796f4a1a6877894
         WEB_SITE=https://github.com/kcat/openal-soft/
          ENTERED=20030129
-         UPDATED=20260125
+         UPDATED=20260718
            SHORT="3D Audio Library"
 
 cat << EOF


### PR DESCRIPTION
Update openal to version 1.25.2 from 1.25.1. This upgrade updates the source hash to match the new release tarball.

---
*Automated PR created by n8n + Claude AI*