### PR TITLE
skim: Version bumped to 5.2.0

### DIFF
--- a/utils/skim/DETAILS
+++ b/utils/skim/DETAILS
@@ -1,11 +1,11 @@
          MODULE=skim
-        VERSION=5.1.3
+        VERSION=5.2.0
          SOURCE=$MODULE-$VERSION.tar.gz
 SOURCE_URL_FULL=https://github.com/skim-rs/skim/archive/v${VERSION}.tar.gz
-     SOURCE_VFY=sha256:e348fa7690c9e1fe33ecf8f162324101214a658082e887e9372dd264dbea6f48
+     SOURCE_VFY=sha256:d885d14f773ab769648c0ff8bce194dbe80b184fbda758b1801e1806d62c3e57
        WEB_SITE=https://github.com/skim-rs/skim/
         ENTERED=20200627
-        UPDATED=20260717
+        UPDATED=20260718
           SHORT="Fuzzy Finder in rust"
 
 cat << EOF


### PR DESCRIPTION
Upgrade skim from 5.1.3 to 5.2.0

- Updated VERSION to 5.2.0
- Updated SOURCE_VFY to sha256:d885d14f773ab769648c0ff8bce194dbe80b184fbda758b1801e1806d62c3e57
- Updated UPDATED timestamp to 20260718

---
*Automated PR created by n8n + Claude AI*