### PR TITLE
rsyslog: version bumped to 8.2606.0 + new protobuf-c/snappy optional …

### DIFF
--- a/utils/rsyslog/BUILD
+++ b/utils/rsyslog/BUILD
@@ -11,7 +11,6 @@ OPTS+=" --exec-prefix=/usr  \
         --enable-rsyslogrt  \
         --enable-omjournal  \
         --enable-omprog     \
-        --enable-impstats   \
         --enable-imptcp     \
         --disable-rfc3195" &&
 

--- a/utils/rsyslog/DEPENDS
+++ b/utils/rsyslog/DEPENDS
@@ -1,9 +1,16 @@
-depends xconsole
 depends libestr
 depends json-c
 depends liblogging
 depends libfastjson
 depends zlib
+
+optional_depends protobuf-c \
+                 "--enable-impstats --enable-impstats-push"  \
+                 "--disable-impstats --disable-impstats-push" \
+                 "for periodic output of internal counters, impstats (If you say yes here, also select snappy next)"
+
+optional_depends snappy "" "" \
+                 "for compression support with the impstats feature"
 
 optional_depends systemd \
                  "--enable-libsystemd --enable-imjournal"  \
@@ -60,3 +67,5 @@ optional_depends net-snmp \
                  "--disable-snmp" \
                  "for SNMP support" \
                  "n"
+
+optional_depends xconsole "" "" "for following logs through GUI"

--- a/utils/rsyslog/DETAILS
+++ b/utils/rsyslog/DETAILS
@@ -1,12 +1,12 @@
           MODULE=rsyslog
-         VERSION=8.2512.0
+         VERSION=8.2606.0
           SOURCE=$MODULE-$VERSION.tar.gz
  SOURCE_URL_FULL=https://github.com/rsyslog/rsyslog/archive/v${VERSION}.tar.gz
-      SOURCE_VFY=sha256:0a43a8f61c28054f71a2de1c4e5081a652b89a51d3872f30ea2487cbc86494e3
+      SOURCE_VFY=sha256:023de692700ac51b4577e1cae87103710cd593af5d0d25dc8778261c9db7babd
         WEB_SITE=https://www.rsyslog.com/
       MAINTAINER=ratler@lunar-linux.org
          ENTERED=20080731
-         UPDATED=20260107
+         UPDATED=20260718
            SHORT="An enhanced multi-threaded syslogd"
 
 cat << EOF


### PR DESCRIPTION
…deps.

- Make xconsole optional since it's a GUI application, it's better if it's possible to install on non-GUI systems, like servers.
- Introduce protobuf-c and snappy as optional dependencies when enabling the impstats feature.