### PR TITLE
fzf: Version bumped to 0.74.1

### DIFF
--- a/utils/fzf/DETAILS
+++ b/utils/fzf/DETAILS
@@ -1,11 +1,11 @@
          MODULE=fzf
-        VERSION=0.74.0
+        VERSION=0.74.1
          SOURCE=$MODULE-$VERSION.tar.gz
 SOURCE_URL_FULL=https://github.com/junegunn/fzf/archive/refs/tags/v$VERSION.tar.gz
-     SOURCE_VFY=sha256:55ab5f2256edd8890f81d407b63d3a3e81cffe10e318cd196031dc85efdeb079
+     SOURCE_VFY=sha256:ba37120bbe45966c6eba6a00c8ea64b86c3c57e349cb55b1c3e0f522976fd978
        WEB_SITE=https://github.com/junegunn/fzf/
         ENTERED=20181112
-        UPDATED=20260707
+        UPDATED=20260718
           SHORT="Command-line fuzzy finder"
 
 cat << EOF


### PR DESCRIPTION
Upgrade fzf from 0.74.0 to 0.74.1

- Updated VERSION to 0.74.1
- Updated SOURCE_VFY to ba37120bbe45966c6eba6a00c8ea64b86c3c57e349cb55b1c3e0f522976fd978
- Updated UPDATED date to 20260718

---
*Automated PR created by n8n + Claude AI*