### PR TITLE
libgit2: Version bumped to 1.9.5

### DIFF
--- a/libs/libgit2/DETAILS
+++ b/libs/libgit2/DETAILS
@@ -1,11 +1,11 @@
          MODULE=libgit2
-        VERSION=1.9.4
+        VERSION=1.9.5
          SOURCE=$MODULE-$VERSION.tar.gz
 SOURCE_URL_FULL=https://github.com/libgit2/libgit2/archive/v$VERSION.tar.gz
-     SOURCE_VFY=sha256:824b73bd13647800fe4b566a1008ae77fea0e3e3424edab632fcfd8c0b14ba8b
+     SOURCE_VFY=sha256:f5ae0c8f41a3a19e6f4aaafb604a7f4285a5a754d802d074359ed875acc3e65b
        WEB_SITE=https://libgit2.org/
         ENTERED=20150205
-        UPDATED=20260522
+        UPDATED=20260718
           SHORT="Pure C implementation of the Git core methods"
 
 cat << EOF


### PR DESCRIPTION
Update libgit2 from 1.9.4 to 1.9.5

- Version: 1.9.4 → 1.9.5
- SHA256: f5ae0c8f41a3a19e6f4aaafb604a7f4285a5a754d802d074359ed875acc3e65b
- Source: https://github.com/libgit2/libgit2/archive/v1.9.5.tar.gz
- Updated: 20260718

---
*Automated PR created by n8n + Claude AI*