### PR TITLE
htop: Version bumped to 3.5.2

### DIFF
--- a/utils/htop/DETAILS
+++ b/utils/htop/DETAILS
@@ -1,11 +1,11 @@
     MODULE=htop
-   VERSION=3.5.1
+   VERSION=3.5.2
     SOURCE=$MODULE-$VERSION.tar.gz
 SOURCE_URL=https://github.com/htop-dev/htop/archive/${VERSION}/
-SOURCE_VFY=sha256:dfc4a09845e9bc86f466a722e62b8f87d59028ff39689077ff2257a6a605061d
+SOURCE_VFY=sha256:a66a62bbd1eba59889c68f868b643e53320eea93da19f43ba13c822a826d82ba
   WEB_SITE=http://hisham.hm/htop/index.php?page=main
    ENTERED=20040927
-   UPDATED=20260429
+   UPDATED=20260718
      SHORT="An interactive process viewer"
 
 cat << EOF


### PR DESCRIPTION
Upgrade htop from 3.5.1 to 3.5.2

- Updated VERSION to 3.5.2
- Updated SOURCE_VFY with new sha256 checksum
- Updated UPDATED date to 20260718

---
*Automated PR created by n8n + Claude AI*