### PR TITLE
linux-lts: Version bumped to 6.18.39

### DIFF
--- a/kernel/linux-lts/DETAILS
+++ b/kernel/linux-lts/DETAILS
@@ -1,5 +1,5 @@
         MODULE=linux-lts
-       VERSION=6.18.38
+       VERSION=6.18.39
           BASE=$(echo $VERSION | cut -d. -f1,2)
         SOURCE=linux-$BASE.tar.xz
 if [ -n "$(echo $VERSION | cut -d. -f3)" ] ; then
@@ -10,10 +10,10 @@ fi
 SOURCE2_URL[0]=$KERNEL_URL/pub/linux/kernel/v6.x
 SOURCE2_URL[1]=https://www.kernel.org/pub/linux/kernel/v6.x
     SOURCE_VFY=sha256:9106a4605da9e31ff17659d958782b815f9591ab308d03b0ee21aad6c7dced4b
-   SOURCE2_VFY=sha256:7eab309d7ae7498096f0d3bd4868d00bd5e6d3443feb1f672a785bfbab02ace8
+   SOURCE2_VFY=sha256:0b401aba8965399fb82bf6d5f137aec7452e1d2631de5308e44fd3a4eed858bc
       WEB_SITE=https://www.kernel.org/
        ENTERED=20111121
-       UPDATED=20260706
+       UPDATED=20260718
          SHORT="The core of a Linux GNU Operating System"
 TMPFS=off
 KEEP_SOURCE=on


### PR DESCRIPTION
Upgrade linux-lts kernel to version 6.18.39 with updated source checksums.

- VERSION: 6.18.38 → 6.18.39
- SOURCE_VFY: sha256:9106a4605da9e31ff17659d958782b815f9591ab308d03b0ee21aad6c7dced4b
- SOURCE2_VFY: sha256:0b401aba8965399fb82bf6d5f137aec7452e1d2631de5308e44fd3a4eed858bc
- UPDATED: 20260718

---
*Automated PR created by n8n + Claude AI*