### PR TITLE
aalib: remove gcc/c23 fix about a gpm call in aacurkbd.c

### DIFF
--- a/graphics/aalib/BUILD
+++ b/graphics/aalib/BUILD
@@ -1,6 +1,3 @@
-# fix the compile error with GCC/C23
-sed -i 's/Gpm_Wgetch[[:space:]]*(stdscr)/Gpm_Wgetch()/g' src/aacurkbd.c &&
-
 autoreconf -fi &&
 
 LDFLAGS=$(echo $LDFLAGS | sed "s/-z combreloc//") &&


### PR DESCRIPTION
I was getting this error:

aacurkbd.c: In function 'curses_getchar':
aacurkbd.c:96:13: error: too few arguments to function 'Gpm_Wgetch'
   96 |         c = Gpm_Wgetch();
In file included from aacurkbd.c:12:
/usr/include/gpm.h:271:12: note: declared here
  271 | extern int Gpm_Wgetch(void *win);
make[2]: *** [Makefile:718: aacurkbd.lo] Error 1