### PR TITLE
libwacom: Version bumped to 2.19.1

### DIFF
--- a/libs/libwacom/DETAILS
+++ b/libs/libwacom/DETAILS
@@ -1,12 +1,12 @@
-          MODULE=libwacom
-         VERSION=2.19.0
-          SOURCE=$MODULE-$VERSION.tar.xz
-      SOURCE_URL=https://github.com/linuxwacom/libwacom/releases/download/libwacom-$VERSION/
-      SOURCE_VFY=sha256:8dd84e75d322aa5f33b2fe781cb67efa5706fedcf483737b4657557f33055a93
-        WEB_SITE=https://github.com/linuxwacom/libwacom/
-         ENTERED=20130217
-         UPDATED=20260601
-           SHORT="Library to identify Wacom tablets and their features"
+    MODULE=libwacom
+   VERSION=2.19.1
+    SOURCE=$MODULE-$VERSION.tar.xz
+SOURCE_URL=https://github.com/linuxwacom/libwacom/releases/download/libwacom-$VERSION/
+SOURCE_VFY=sha256:a1e5b1e7ef60fa70ed05b55d888d980ec7e86bd15594857f3c48c529b661bf32
+  WEB_SITE=https://github.com/linuxwacom/libwacom/
+   ENTERED=20130217
+   UPDATED=20260720
+     SHORT="Library to identify Wacom tablets and their features"
 
 cat << EOF
 Libwacom supplies metadata about Wacome tablets including whether or not


### PR DESCRIPTION
Upgrade libwacom from 2.19.0 to 2.19.1

- Version: 2.19.0 → 2.19.1
- Source: https://github.com/linuxwacom/libwacom/releases/download/libwacom-2.19.1/libwacom-2.19.1.tar.xz
- SHA256: a1e5b1e7ef60fa70ed05b55d888d980ec7e86bd15594857f3c48c529b661bf32
- Updated: 20260720

---
*Automated PR created by n8n + Claude AI*