### PR TITLE
skim: Version bumped to 5.3.1

### DIFF
--- a/utils/skim/DETAILS
+++ b/utils/skim/DETAILS
@@ -1,11 +1,11 @@
          MODULE=skim
-        VERSION=5.2.0
+        VERSION=5.3.1
          SOURCE=$MODULE-$VERSION.tar.gz
 SOURCE_URL_FULL=https://github.com/skim-rs/skim/archive/v${VERSION}.tar.gz
-     SOURCE_VFY=sha256:d885d14f773ab769648c0ff8bce194dbe80b184fbda758b1801e1806d62c3e57
+     SOURCE_VFY=sha256:bd8298d8e232840b71e66c88249b91bf0b2e6d1aa320ad3fc405a002c521885c
        WEB_SITE=https://github.com/skim-rs/skim/
         ENTERED=20200627
-        UPDATED=20260718
+        UPDATED=20260720
           SHORT="Fuzzy Finder in rust"
 
 cat << EOF


### PR DESCRIPTION
Upgrade skim from 5.2.0 to 5.3.1

- Updated VERSION to 5.3.1
- Updated SOURCE_VFY to bd8298d8e232840b71e66c88249b91bf0b2e6d1aa320ad3fc405a002c521885c
- Updated UPDATED date to 20260720

---
*Automated PR created by n8n + Claude AI*