### PR TITLE
srt: Version bumped to 1.5.6

### DIFF
--- a/security/srt/DETAILS
+++ b/security/srt/DETAILS
@@ -1,12 +1,12 @@
          MODULE=srt
-        VERSION=1.5.5
+        VERSION=1.5.6
          SOURCE=$MODULE-$VERSION.tar.gz
 SOURCE_URL_FULL=https://github.com/Haivision/srt/archive/v$VERSION.tar.gz
-     SOURCE_VFY=sha256:c3518bc43a71b5289032395b2db4c3e09e73d78b54247d56c14553a503b491cf
+     SOURCE_VFY=sha256:2c4980c2c4cfd142d21b829d939dc51db9c6628af5967fff62fd7290769569c7
        WEB_SITE=https://www.srtalliance.org/
            TYPE=cmake
         ENTERED=20180326
-        UPDATED=20260602
+        UPDATED=20260721
           SHORT="Secure Reliable Transport"
 
 cat << EOF


### PR DESCRIPTION
Upgrade srt from 1.5.5 to 1.5.6. This is a maintenance update to the Secure Reliable Transport library.

---
*Automated PR created by n8n + Claude AI*