### PR TITLE
libp11: Version bumped to 0.4.19

### DIFF
--- a/libs/libp11/DETAILS
+++ b/libs/libp11/DETAILS
@@ -1,12 +1,12 @@
-          MODULE=libp11
-         VERSION=0.4.18
-          SOURCE=$MODULE-$VERSION.tar.gz
-      SOURCE_URL=https://github.com/OpenSC/libp11/releases/download/libp11-$VERSION/
-      SOURCE_VFY=sha256:9292de67ca73aba1deacf577c9086b595765f36ef47712cfeb49fa31f6e772fb
-        WEB_SITE=https://github.com/OpenSC/libp11
-         ENTERED=20200131
-         UPDATED=20260411
-           SHORT="PKCS#11 wrapper library"
+    MODULE=libp11
+   VERSION=0.4.19
+    SOURCE=$MODULE-$VERSION.tar.gz
+SOURCE_URL=https://github.com/OpenSC/libp11/releases/download/libp11-$VERSION/
+SOURCE_VFY=sha256:a344ca201ffa71822881e45e86457ab9a0115d07d03da0d69c7e5a7268255a35
+  WEB_SITE=https://github.com/OpenSC/libp11
+   ENTERED=20200131
+   UPDATED=20260722
+     SHORT="PKCS#11 wrapper library"
 
 cat << EOF
 PKCS#11 wrapper library.


### PR DESCRIPTION
Upgrade libp11 from 0.4.18 to 0.4.19. Updated SOURCE_VFY checksum and UPDATED date.

---
*Automated PR created by n8n + Claude AI*