### PR TITLE
skim: Version bumped to 5.4.0

### DIFF
--- a/utils/skim/DETAILS
+++ b/utils/skim/DETAILS
@@ -1,11 +1,11 @@
          MODULE=skim
-        VERSION=5.3.2
+        VERSION=5.4.0
          SOURCE=$MODULE-$VERSION.tar.gz
 SOURCE_URL_FULL=https://github.com/skim-rs/skim/archive/v${VERSION}.tar.gz
-     SOURCE_VFY=sha256:f0889a63c4b1e834db1456a5d0c722e4bddaa7a476b7cc3b7837caf3f4baac53
+     SOURCE_VFY=sha256:f968750ddd453c031f6fec5164c0a1e24eb7c52639fe64f3b5bb657664f0e591
        WEB_SITE=https://github.com/skim-rs/skim/
         ENTERED=20200627
-        UPDATED=20260721
+        UPDATED=20260722
           SHORT="Fuzzy Finder in rust"
 
 cat << EOF


### PR DESCRIPTION
Upgrade skim from 5.3.2 to 5.4.0

- Updates to latest upstream release
- SHA256: f968750ddd453c031f6fec5164c0a1e24eb7c52639fe64f3b5bb657664f0e591

---
*Automated PR created by n8n + Claude AI*