### PR TITLE
cbindgen: Version bumped to 0.29.4

### DIFF
--- a/devel/cbindgen/DETAILS
+++ b/devel/cbindgen/DETAILS
@@ -1,11 +1,11 @@
          MODULE=cbindgen
-        VERSION=0.29.3
+        VERSION=0.29.4
          SOURCE=$MODULE-$VERSION.tar.gz
 SOURCE_URL_FULL=https://github.com/mozilla/cbindgen/archive/v$VERSION.tar.gz
-     SOURCE_VFY=sha256:f3589ce10fd6a61b32d1ac1a1043112838e44b401432f4db9838c2a9ec4322f8
+     SOURCE_VFY=sha256:9b5757e915cf8be523d3aca282b9b5651bafa112e14bf1ba488562ba282807d6
        WEB_SITE=https://github.com/eqrion/cbindgen
         ENTERED=20181023
-        UPDATED=20260529
+        UPDATED=20260722
           SHORT="generate C bindings for Rust code"
 
 cat << EOF


### PR DESCRIPTION
Upgrade cbindgen from 0.29.3 to 0.29.4

- Version: 0.29.3 → 0.29.4
- Updated date: 20260529 → 20260722
- SHA256: 9b5757e915cf8be523d3aca282b9b5651bafa112e14bf1ba488562ba282807d6

---
*Automated PR created by n8n + Claude AI*