### PR TITLE
firefox: Version bumped to 153.0

### DIFF
--- a/web/firefox/DETAILS
+++ b/web/firefox/DETAILS
@@ -1,11 +1,11 @@
     MODULE=firefox
-   VERSION=152.0.6
+   VERSION=153.0
     SOURCE=$MODULE-$VERSION.source.tar.xz
 SOURCE_URL=https://archive.mozilla.org/pub/firefox/releases/$VERSION/source
-SOURCE_VFY=sha256:ea220c4f8d19d4edaa20e6dadfd3c4aeb07dbed017ade2828fd814d660660f0e
+SOURCE_VFY=sha256:bc510f74c8c4c692d31e559aeb5850849d13bc98214ac81e004f66f819a55522
   WEB_SITE=https://www.mozilla.org/en-US/firefox
    ENTERED=20110814
-   UPDATED=20260714
+   UPDATED=20260722
      SHORT="A web browser from mozilla.org"
 
 cat << EOF


### PR DESCRIPTION
Upgrade firefox from 152.0.6 to 153.0

- Updated VERSION to 153.0
- Updated SOURCE_VFY to bc510f74c8c4c692d31e559aeb5850849d13bc98214ac81e004f66f819a55522
- Updated UPDATED date to 20260722

---
*Automated PR created by n8n + Claude AI*