### PR TITLE
libraqm: Version bumped to 0.11.0

### DIFF
--- a/graphics/libraqm/DETAILS
+++ b/graphics/libraqm/DETAILS
@@ -1,13 +1,13 @@
           MODULE=libraqm
-         VERSION=0.10.5
+         VERSION=0.11.0
           SOURCE=raqm-$VERSION.tar.xz
       SOURCE_URL=https://github.com/HOST-Oman/libraqm/releases/download/v${VERSION}/
-      SOURCE_VFY=sha256:563053e724892a7b037913110ea2daef50ad575d4fa9f7c368ae1e4515f5e856
+      SOURCE_VFY=sha256:3d0add115f7d4a9410d3377462ed3c05e86342193ef984183e4380e3787b2d4c
 SOURCE_DIRECTORY=$BUILD_DIRECTORY/raqm-$VERSION/
         WEB_SITE=https://github.com/HOST-Oman/libraqm/
             TYPE=meson
          ENTERED=20160610
-         UPDATED=20260411
+         UPDATED=20260723
            SHORT="library and API for text layout"
 
 cat << EOF


### PR DESCRIPTION
Upgrade libraqm from 0.10.5 to 0.11.0

- New version: 0.11.0
- Source: https://github.com/HOST-Oman/libraqm/releases/download/v0.11.0/raqm-0.11.0.tar.xz
- SHA256: 3d0add115f7d4a9410d3377462ed3c05e86342193ef984183e4380e3787b2d4c

---
*Automated PR created by n8n + Claude AI*