### PR TITLE
brave-bin: Version bumped to 1.92.143

### DIFF
--- a/web/brave-bin/DETAILS
+++ b/web/brave-bin/DETAILS
@@ -1,12 +1,12 @@
           MODULE=brave-bin
-         VERSION=1.92.141
+         VERSION=1.92.143
           SOURCE=brave-browser-$VERSION-linux-amd64.zip
       SOURCE_URL=https://github.com/brave/brave-browser/releases/download/v$VERSION/
-      SOURCE_VFY=sha256:8ae740ffd38cc33c0eb16f2f1cce89fde009deb8bb2ba2ea3e514942829ae2ab
+      SOURCE_VFY=sha256:95a0402e6da4c35683d4edcfe74043558a06fd6de5341dcccf1f148ac0534809
 SOURCE_DIRECTORY=$BUILD_DIRECTORY/brave-browser-$VERSION-linux-amd64
         WEB_SITE=https://brave.com/
          ENTERED=20210628
-         UPDATED=20260721
+         UPDATED=20260724
            SHORT="brave web browser"
 
 cat << EOF


### PR DESCRIPTION
Upgrade brave-bin from 1.92.141 to 1.92.143

- Version: 1.92.143
- SHA256: 95a0402e6da4c35683d4edcfe74043558a06fd6de5341dcccf1f148ac0534809
- Updated date: 20260724

---
*Automated PR created by n8n + Claude AI*