### PR TITLE
cython: Version bumped to 3.2.9

### DIFF
--- a/compilers/cython/DETAILS
+++ b/compilers/cython/DETAILS
@@ -1,13 +1,13 @@
-       MODULE=cython
-      VERSION=3.2.8
-       SOURCE=$MODULE-$VERSION.tar.gz
-   SOURCE_URL=https://github.com/cython/cython/releases/download/$VERSION
-   SOURCE_VFY=sha256:f4f23a56b25221a06f91817fe8f3114ab8b48a4fac73187dbb64bc2c4a87961f
-     WEB_SITE=http://cython.org/
-      ENTERED=20120724
-      UPDATED=20260630
-     REPLACES=Cython
-        SHORT="C extensions for Python"
+    MODULE=cython
+   VERSION=3.2.9
+    SOURCE=$MODULE-$VERSION.tar.gz
+SOURCE_URL=https://github.com/cython/cython/releases/download/$VERSION
+SOURCE_VFY=sha256:d249c9022ab13286b17bd66f30609e800c5f95efeecb06168990c7a66cecde6c
+  WEB_SITE=http://cython.org/
+   ENTERED=20120724
+   UPDATED=20260724
+  REPLACES=Cython
+     SHORT="C extensions for Python"
 
 cat << EOF
 Cython is a language that makes writing C extensions for the Python language as


### PR DESCRIPTION
Upgrade cython from 3.2.8 to 3.2.9

- Version: 3.2.8 → 3.2.9
- Source: https://github.com/cython/cython/releases/download/3.2.9/cython-3.2.9.tar.gz
- SHA256: d249c9022ab13286b17bd66f30609e800c5f95efeecb06168990c7a66cecde6c

---
*Automated PR created by n8n + Claude AI*