### PR TITLE
kitty: Version bumped to 0.48.1

### DIFF
--- a/terminal/kitty/DETAILS
+++ b/terminal/kitty/DETAILS
@@ -1,11 +1,11 @@
          MODULE=kitty
-        VERSION=0.48.0
+        VERSION=0.48.1
          SOURCE=$MODULE-$VERSION.tar.gz
 SOURCE_URL_FULL=https://github.com/kovidgoyal/kitty/archive/v$VERSION.tar.gz
-     SOURCE_VFY=sha256:a463a12bc96457a97c78c13638dd3e381f643ac4d3f3ea73ace0cbf4bf5389aa
+     SOURCE_VFY=sha256:4f4db39d7309e4841b1c45ebb4be5bbfaff5068f41691bd787d47cc7858e8fe7
        WEB_SITE=https://sw.kovidgoyal.net/kitty/
         ENTERED=20190110
-        UPDATED=20260718
+        UPDATED=20260724
           SHORT="A GPU based terminal emulator"
 
 cat << EOF


### PR DESCRIPTION
Upgrade kitty from version 0.48.0 to 0.48.1

- Updated SOURCE_VFY hash for new release
- Updated UPDATED date to 20260724
- All other module attributes preserved

---
*Automated PR created by n8n + Claude AI*