### PR TITLE
gdal: Version bumped to 3.13.2

### DIFF
--- a/libs/gdal/DETAILS
+++ b/libs/gdal/DETAILS
@@ -1,12 +1,12 @@
-          MODULE=gdal
-         VERSION=3.12.4
-          SOURCE=$MODULE-$VERSION.tar.gz
-      SOURCE_URL=https://github.com/OSGeo/gdal/releases/download/v$VERSION/
-      SOURCE_VFY=sha256:68844ae29557b7efae4292c3b4cb3a3b8a79d14b765b89c5a7b17cbae7fa715a
-        WEB_SITE=https://github.com/OSGeo/gdal
-         ENTERED=20050915
-         UPDATED=20260320
-           SHORT="Geospatial Data Abstraction Library"
+    MODULE=gdal
+   VERSION=3.13.2
+    SOURCE=$MODULE-$VERSION.tar.gz
+SOURCE_URL=https://github.com/OSGeo/gdal/releases/download/v$VERSION/
+SOURCE_VFY=sha256:1051c33db1d9e6a05907ac07cd06f5ce8ac0658f317c3229774cc2198a6c1252
+  WEB_SITE=https://github.com/OSGeo/gdal
+   ENTERED=20050915
+   UPDATED=20260724
+     SHORT="Geospatial Data Abstraction Library"
 
 cat << EOF
 is a translator library for raster geospatial data formats that is released


### PR DESCRIPTION
Upgrade gdal from 3.12.4 to 3.13.2

- Updated VERSION to 3.13.2
- Updated SOURCE_VFY to sha256:1051c33db1d9e6a05907ac07cd06f5ce8ac0658f317c3229774cc2198a6c1252
- Updated UPDATED timestamp to 20260724

---
*Automated PR created by n8n + Claude AI*