### PR TITLE
fluidsynth: Version bumped to 2.5.7

### DIFF
--- a/audio/fluidsynth/DETAILS
+++ b/audio/fluidsynth/DETAILS
@@ -1,11 +1,11 @@
          MODULE=fluidsynth
-        VERSION=2.5.6
+        VERSION=2.5.7
          SOURCE=$MODULE-$VERSION.tar.gz
 SOURCE_URL_FULL=https://github.com/FluidSynth/${MODULE}/archive/v$VERSION.tar.gz
-     SOURCE_VFY=sha256:0825f024c9cf7a18073739b83612d46542ecbfb349ae9147a1e9f08e2d524407
+     SOURCE_VFY=sha256:ce27840221ab00dd59bf27e85ecbba480c6c2a7c9fbec4243658f68f59c07f4a
        WEB_SITE=https://www.fluidsynth.org/
         ENTERED=20060317
-        UPDATED=20260704
+        UPDATED=20260725
           SHORT="A real-time software synthesizer"
 
 cat << EOF


### PR DESCRIPTION
Upgrade fluidsynth from 2.5.6 to 2.5.7

---
*Automated PR created by n8n + Claude AI*