### PR TITLE
libical: Version bumped to 4.0.4

### DIFF
--- a/libs/libical/DETAILS
+++ b/libs/libical/DETAILS
@@ -1,11 +1,11 @@
          MODULE=libical
-        VERSION=4.0.3
+        VERSION=4.0.4
          SOURCE=$MODULE-$VERSION.tar.gz
 SOURCE_URL_FULL=http://github.com/$MODULE/$MODULE/archive/v$VERSION.tar.gz
-     SOURCE_VFY=sha256:86f29029d0ec9fa30c9001de16c0859a3816ae154ff5b097392b014e21a3d254
+     SOURCE_VFY=sha256:c851cdb46da5e6397881dafaa592c5516fb49da05dd1bb095f711a6d20eac422
        WEB_SITE=https://github.com/libical/libical/
         ENTERED=20021128
-        UPDATED=20260614
+        UPDATED=20260725
           SHORT="An implementation of the IETF's Calendar protocol"
 
 cat << EOF


### PR DESCRIPTION
Upgrade libical from 4.0.3 to 4.0.4

- Version: 4.0.3 → 4.0.4
- Source: http://github.com/libical/libical/archive/v4.0.4.tar.gz
- SHA256: c851cdb46da5e6397881dafaa592c5516fb49da05dd1bb095f711a6d20eac422

---
*Automated PR created by n8n + Claude AI*