### PR TITLE
openjph: Version bumped to 0.31.0

### DIFF
--- a/graphics/openjph/DETAILS
+++ b/graphics/openjph/DETAILS
@@ -1,13 +1,13 @@
           MODULE=openjph
-         VERSION=0.30.0
+         VERSION=0.31.0
           SOURCE=$MODULE-$VERSION.tar.gz
  SOURCE_URL_FULL=https://github.com/aous72/OpenJPH/archive/refs/tags/$VERSION.tar.gz
 SOURCE_DIRECTORY=$BUILD_DIRECTORY/OpenJPH-$VERSION
-      SOURCE_VFY=sha256:3555306549678c81cf2f9d0d579be75a3a2dd6798e84e7ffeddd3e219e70e062
+      SOURCE_VFY=sha256:fe169dbbaae71a169a0a6a68dccb346616193252c1ca044217afa0d5d1dc436f
         WEB_SITE=https://github.com/aous72/OpenJPH
             TYPE=cmake
          ENTERED=20251105
-         UPDATED=20260621
+         UPDATED=20260727
            SHORT="implementation of High-throughput JPEG2000"
 
 cat << EOF


### PR DESCRIPTION
Upgrade openjph from 0.30.0 to 0.31.0

---
*Automated PR created by n8n + Claude AI*