### PR TITLE
ocl-icd: Version bumped to 2.3.5

### DIFF
--- a/devel/ocl-icd/DETAILS
+++ b/devel/ocl-icd/DETAILS
@@ -1,12 +1,13 @@
-          MODULE=ocl-icd
-         VERSION=2.3.4
-          SOURCE=$MODULE-$VERSION.tar.gz
- SOURCE_URL_FULL=https://github.com/OCL-dev/ocl-icd/archive/refs/tags/v$VERSION.tar.gz
-      SOURCE_VFY=sha256:1a302b71b7304cca5a36f69d017b1af2b762cc4c2dd1c0c0e2fc1933db25c9cc
-        WEB_SITE=https://github.com/OCL-dev/ocl-icd
-         ENTERED=20160610
-         UPDATED=20251228
-           SHORT="OpenCL ICD loader"
+         MODULE=ocl-icd
+        VERSION=2.3.5
+         SOURCE=$MODULE-$VERSION.tar.gz
+SOURCE_URL_FULL=https://github.com/OCL-dev/ocl-icd/archive/refs/tags/v$VERSION.tar.gz
+     SOURCE_VFY=sha256:cdd7984425fa92d37273eee4180b5f57b047eda6dd8fd623e58498f844b09b75
+       WEB_SITE=https://github.com/OCL-dev/ocl-icd
+        ENTERED=20160610
+        UPDATED=20260728
+          SHORT="OpenCL ICD loader"
+
 cat << EOF
 OpenCL implementations are provided as ICD (Installable Client Driver).
 An OpenCL program can use several ICD thanks to the use of an ICD Loader


### PR DESCRIPTION
Upgrade ocl-icd from 2.3.4 to 2.3.5. Updated VERSION, SOURCE_VFY hash, and UPDATED date.

---
*Automated PR created by n8n + Claude AI*