### PR TITLE
blosc2: Version bumped to 3.3.0

### DIFF
--- a/archive/blosc2/DETAILS
+++ b/archive/blosc2/DETAILS
@@ -1,12 +1,12 @@
           MODULE=blosc2
-         VERSION=3.2.3
+         VERSION=3.3.0
           SOURCE=$MODULE-$VERSION.tar.gz
  SOURCE_URL_FULL=https://github.com/Blosc/c-blosc2/archive/refs/tags/v$VERSION.tar.gz
-      SOURCE_VFY=sha256:32977709c21f3fec50befa7a031fa624b963427b69d3ffb69c91aadc9279c887
+      SOURCE_VFY=sha256:9659a54ef60278e80398c82c742b4e0ca0fbb85792fe9194df94ecfbec8f496b
 SOURCE_DIRECTORY=$BUILD_DIRECTORY/c-$MODULE-$VERSION
         WEB_SITE=https://github.com/Blosc/c-blosc2/
          ENTERED=20240724
-         UPDATED=20260716
+         UPDATED=20260728
            SHORT="A blocking, shuffling and loss-less compression library"
 
 cat << EOF


### PR DESCRIPTION
Upgrade blosc2 from 3.2.3 to 3.3.0. Updated source URL and SHA256 checksum. UPDATED date set to 20260728.

---
*Automated PR created by n8n + Claude AI*