### PR TITLE
libarchive: Version bumped to 3.8.9

### DIFF
--- a/archive/libarchive/DETAILS
+++ b/archive/libarchive/DETAILS
@@ -1,13 +1,13 @@
-          MODULE=libarchive
-         VERSION=3.8.8
-          SOURCE=$MODULE-$VERSION.tar.gz
- SOURCE_URL_FULL=https://github.com/libarchive/libarchive/archive/refs/tags/v$VERSION.tar.gz
-      SOURCE_VFY=sha256:528f9c91e11238cbb5ce6d79b20fa3bb48a5cd124008036af1913d84fc5ba420
-        WEB_SITE=https://libarchive.org
-            TYPE=cmake
-         ENTERED=20080124
-         UPDATED=20260623
-           SHORT="create and read several different streaming archive formats"
+         MODULE=libarchive
+        VERSION=3.8.9
+         SOURCE=$MODULE-$VERSION.tar.gz
+SOURCE_URL_FULL=https://github.com/libarchive/libarchive/archive/refs/tags/v$VERSION.tar.gz
+     SOURCE_VFY=sha256:744346f6bca195c8f894f847bb32a16e9bcae6002624a58fadc81e80f595b3cb
+       WEB_SITE=https://libarchive.org
+           TYPE=cmake
+        ENTERED=20080124
+        UPDATED=20260728
+          SHORT="create and read several different streaming archive formats"
 
 cat << EOF
 Libarchive is a programming library that can create and read several different


### PR DESCRIPTION
Upgrade libarchive from 3.8.8 to 3.8.9. This is a patch version update that includes bug fixes and improvements. The module structure and dependencies remain unchanged.

---
*Automated PR created by n8n + Claude AI*