### PR TITLE
tailscale: Version bumped to 1.98.10

### DIFF
--- a/net/tailscale/DETAILS
+++ b/net/tailscale/DETAILS
@@ -1,11 +1,11 @@
          MODULE=tailscale
-        VERSION=1.98.8
+        VERSION=1.98.10
          SOURCE=$MODULE-$VERSION.tar.gz
 SOURCE_URL_FULL=https://github.com/tailscale/tailscale/archive/refs/tags/v${VERSION}.tar.gz
-     SOURCE_VFY=sha256:4dfd5e53b6ea0a7827bbe3e8d922b7b16fb91034effcdce243e61eacd183e41d
+     SOURCE_VFY=sha256:1a3aac335f0e1b2154fbf948ae8cd7f3464af7e28a5a0a12fd55ab475212a282
        WEB_SITE=https://tailscale.com/
         ENTERED=20210320
-        UPDATED=20260630
+        UPDATED=20260729
           SHORT="A mesh VPN that easy connect your devices, wherever they are"
 
 cat << EOF


### PR DESCRIPTION
Upgrade tailscale from 1.98.8 to 1.98.10

- Updated VERSION to 1.98.10
- Updated SOURCE_VFY to sha256:1a3aac335f0e1b2154fbf948ae8cd7f3464af7e28a5a0a12fd55ab475212a282
- Updated UPDATED date to 20260729

---
*Automated PR created by n8n + Claude AI*