### PR TITLE
faac: Version bumped to 2.0

### DIFF
--- a/audio/faac/DETAILS
+++ b/audio/faac/DETAILS
@@ -1,13 +1,13 @@
           MODULE=faac
-         VERSION=1.50
+         VERSION=2.0
           SOURCE=$MODULE-$VERSION.tar.gz
       SOURCE_URL=https://github.com/knik0/faac/archive/refs/tags/
-      SOURCE_VFY=sha256:e6876cba00cbd786a7f984d9aaada4d5bcb08d2582100366c70f6164d5c89214
+      SOURCE_VFY=sha256:70bf59db35b2d129c6fe204200427950405d0a63bea3ff8fa8804648dde2cbce
 SOURCE_DIRECTORY=$BUILD_DIRECTORY/faac-faac-$VERSION
         WEB_SITE=http://www.audiocoding.com/
             TYPE=meson
          ENTERED=20050308
-         UPDATED=20260416
+         UPDATED=20260729
            SHORT="ISO AAC audio encoder"
 
 cat << EOF


### PR DESCRIPTION
Upgrade faac from version 1.50 to 2.0. Updated SOURCE_VFY with new checksum and UPDATED date.

---
*Automated PR created by n8n + Claude AI*