### PR TITLE
libmicrohttpd: Version bumped to 1.0.8

### DIFF
--- a/libs/libmicrohttpd/DETAILS
+++ b/libs/libmicrohttpd/DETAILS
@@ -1,12 +1,12 @@
        MODULE=libmicrohttpd
-      VERSION=1.0.6
+      VERSION=1.0.8
        SOURCE=$MODULE-$VERSION.tar.gz
 SOURCE_URL[0]=https://ftp.gnu.org/gnu/$MODULE/
 SOURCE_URL[1]=$GNU_URL/$MODULE/
-   SOURCE_VFY=sha256:bb5cfcadfc52dbd5eb512d6e2995e0361351c33e97a87aba426d3a4a7ba6cf70
+   SOURCE_VFY=sha256:0763970a0e39f8f382123366e3cf5d03f70aa1e2208d3101e84da3e2cd674703
      WEB_SITE=https://www.gnu.org/software/libmicrohttpd/
       ENTERED=20100904
-      UPDATED=20260709
+      UPDATED=20260729
         SHORT="Small httpd service library"
 
 cat << EOF


### PR DESCRIPTION
Update libmicrohttpd from 1.0.6 to 1.0.8

- Version: 1.0.6 → 1.0.8
- SHA256: 0763970a0e39f8f382123366e3cf5d03f70aa1e2208d3101e84da3e2cd674703
- Updated date: 20260729

---
*Automated PR created by n8n + Claude AI*