### PR TITLE
brave-bin: Version bumped to 1.92.144

### DIFF
--- a/web/brave-bin/DETAILS
+++ b/web/brave-bin/DETAILS
@@ -1,12 +1,12 @@
           MODULE=brave-bin
-         VERSION=1.92.143
+         VERSION=1.92.144
           SOURCE=brave-browser-$VERSION-linux-amd64.zip
       SOURCE_URL=https://github.com/brave/brave-browser/releases/download/v$VERSION/
-      SOURCE_VFY=sha256:95a0402e6da4c35683d4edcfe74043558a06fd6de5341dcccf1f148ac0534809
+      SOURCE_VFY=sha256:67854d08fb57d45620341ebb4df4c9164cbd3fe5cd2c696f2b0ac8d16a3945a2
 SOURCE_DIRECTORY=$BUILD_DIRECTORY/brave-browser-$VERSION-linux-amd64
         WEB_SITE=https://brave.com/
          ENTERED=20210628
-         UPDATED=20260724
+         UPDATED=20260729
            SHORT="brave web browser"
 
 cat << EOF


### PR DESCRIPTION
Upgrade brave-bin from version 1.92.143 to 1.92.144

- VERSION: 1.92.144
- SOURCE_VFY: sha256:67854d08fb57d45620341ebb4df4c9164cbd3fe5cd2c696f2b0ac8d16a3945a2
- UPDATED: 20260729

---
*Automated PR created by n8n + Claude AI*