### PR TITLE
nghttp2: Version bumped to 1.70.0

### DIFF
--- a/web/nghttp2/DETAILS
+++ b/web/nghttp2/DETAILS
@@ -1,12 +1,12 @@
-          MODULE=nghttp2
-         VERSION=1.69.0
-          SOURCE=$MODULE-$VERSION.tar.bz2
-      SOURCE_URL=https://github.com/nghttp2/nghttp2/releases/download/v$VERSION/
-      SOURCE_VFY=sha256:3f185f5b1c3e77885eb9cf3f2c4da4b1a9f73a24bf5957b829183ad137f82dc8
-        WEB_SITE=https://nghttp2.org/
-         ENTERED=20160412
-         UPDATED=20260420
-           SHORT="Framing layer of HTTP/2 implemented as a reusable C library"
+    MODULE=nghttp2
+   VERSION=1.70.0
+    SOURCE=$MODULE-$VERSION.tar.bz2
+SOURCE_URL=https://github.com/nghttp2/nghttp2/releases/download/v$VERSION/
+SOURCE_VFY=sha256:8faca1f78aa99ac3bc1768a76b7e0f6b36d8e6a62c13818751b1d205f02f9405
+  WEB_SITE=https://nghttp2.org/
+   ENTERED=20160412
+   UPDATED=20260730
+     SHORT="Framing layer of HTTP/2 implemented as a reusable C library"
 
 cat << EOF
 nghttp2 is an implementation of HTTP/2 and its header compression algorithm


### PR DESCRIPTION
Upgrade nghttp2 from 1.69.0 to 1.70.0. Updated SOURCE_VFY hash and UPDATED date.

---
*Automated PR created by n8n + Claude AI*