### PR TITLE
swaylock: Version bumped to 1.8.6

### DIFF
--- a/wayland/swaylock/DETAILS
+++ b/wayland/swaylock/DETAILS
@@ -1,11 +1,11 @@
           MODULE=swaylock
-         VERSION=1.8.1
+         VERSION=1.8.6
           SOURCE=$MODULE-$VERSION.tar.gz
  SOURCE_URL_FULL=https://github.com/swaywm/swaylock/archive/refs/tags/v$VERSION.tar.gz
-      SOURCE_VFY=sha256:75b248158cdd440cf3d85a8197525aa6f5a2c2497df53229f736eaa0cdcd689e
+      SOURCE_VFY=sha256:904376fd012bfff888d042606539c677d90e11f8beeeccc50a9fe387fc41a686
         WEB_SITE=https://github.com/swaywm/swaylock/
          ENTERED=20190330
-         UPDATED=20250320
+         UPDATED=20260730
            SHORT="Screen locker for Wayland"
 
 cat << EOF


### PR DESCRIPTION
Upgrade swaylock to version 1.8.6

- Version: 1.8.6
- Source: https://github.com/swaywm/swaylock/archive/refs/tags/v1.8.6.tar.gz
- SHA256: 904376fd012bfff888d042606539c677d90e11f8beeeccc50a9fe387fc41a686

---
*Automated PR created by n8n + Claude AI*