### PR TITLE
libmicrohttpd: Version bumped to 1.0.9

### DIFF
--- a/libs/libmicrohttpd/DETAILS
+++ b/libs/libmicrohttpd/DETAILS
@@ -1,12 +1,12 @@
        MODULE=libmicrohttpd
-      VERSION=1.0.8
+      VERSION=1.0.9
        SOURCE=$MODULE-$VERSION.tar.gz
 SOURCE_URL[0]=https://ftp.gnu.org/gnu/$MODULE/
 SOURCE_URL[1]=$GNU_URL/$MODULE/
-   SOURCE_VFY=sha256:0763970a0e39f8f382123366e3cf5d03f70aa1e2208d3101e84da3e2cd674703
+   SOURCE_VFY=sha256:6e9adc446b08083ec03d40317fb66ca6f2e03e4f6170aef33a6e59bb08db2012
      WEB_SITE=https://www.gnu.org/software/libmicrohttpd/
       ENTERED=20100904
-      UPDATED=20260729
+      UPDATED=20260731
         SHORT="Small httpd service library"
 
 cat << EOF


### PR DESCRIPTION
Upgrade libmicrohttpd from version 1.0.8 to 1.0.9

---
*Automated PR created by n8n + Claude AI*