### PR TITLE
lf: Version bumped to r42

### DIFF
--- a/filemanagers/lf/DETAILS
+++ b/filemanagers/lf/DETAILS
@@ -1,12 +1,12 @@
-          MODULE=lf
-         VERSION=r41
-          SOURCE=$MODULE-$VERSION.tar.gz
- SOURCE_URL_FULL=https://github.com/gokcehan/lf/archive/$VERSION.tar.gz
-      SOURCE_VFY=sha256:55c556d53b5541d5f8691f1309a0166a7a0d8e06cb051c3030c2cd7d8abc6789
-        WEB_SITE=https://github.com/gokcehan/lf/
-         ENTERED=20181116
-         UPDATED=20260205
-           SHORT="A terminal file manager inspired by ranger"
+         MODULE=lf
+        VERSION=r42
+         SOURCE=$MODULE-$VERSION.tar.gz
+SOURCE_URL_FULL=https://github.com/gokcehan/lf/archive/$VERSION.tar.gz
+     SOURCE_VFY=sha256:7a8f7c2c86419270b713b6235dced7b9d0e68732e74a1e0f375f774fff4023ca
+       WEB_SITE=https://github.com/gokcehan/lf/
+        ENTERED=20181116
+        UPDATED=20260731
+          SHORT="A terminal file manager inspired by ranger"
 
 cat << EOF
 lf (as in "list files") is a terminal file manager written in Go. It is heavily


### PR DESCRIPTION
Upgrade lf from r41 to r42

- Version: r41 → r42
- Source: https://github.com/gokcehan/lf/archive/r42.tar.gz
- SHA256: 7a8f7c2c86419270b713b6235dced7b9d0e68732e74a1e0f375f774fff4023ca

---
*Automated PR created by n8n + Claude AI*