### PR TITLE
hwdata: Version bumped to 0.410

### DIFF
--- a/system/hwdata/DETAILS
+++ b/system/hwdata/DETAILS
@@ -1,11 +1,11 @@
          MODULE=hwdata
-        VERSION=0.409
+        VERSION=0.410
          SOURCE=$MODULE-$VERSION.tar.gz
 SOURCE_URL_FULL=https://github.com/vcrhonek/hwdata/archive/refs/tags/v$VERSION.tar.gz
-     SOURCE_VFY=sha256:23006accc0f931dd5187d0307a57d0744e2b8feb85e73c37bc0f5229fb31eadd
+     SOURCE_VFY=sha256:2864b061b179b8ad8cb6a7339ca07678240a183d9cedce8677a4950acaf798e0
        WEB_SITE=https://github.com/vcrhonek/hwdata
         ENTERED=20220214
-        UPDATED=20260703
+        UPDATED=20260731
           SHORT="hardware identification database"
 
 cat << EOF


### PR DESCRIPTION
Upgrade hwdata from 0.409 to 0.410. Updated SOURCE_VFY hash and UPDATED date.

---
*Automated PR created by n8n + Claude AI*