### PR TITLE
libpsl: Version bumped to 0.23.1

### DIFF
--- a/libs/libpsl/DETAILS
+++ b/libs/libpsl/DETAILS
@@ -1,11 +1,11 @@
     MODULE=libpsl
-   VERSION=0.23.0
+   VERSION=0.23.1
     SOURCE=$MODULE-$VERSION.tar.gz
 SOURCE_URL=https://github.com/rockdaboot/libpsl/releases/download/${VERSION}/
-SOURCE_VFY=sha256:f39b9631b3d369a21259ea4654f8875c0ec6995ce9551c0eb5d423e4c011f911
+SOURCE_VFY=sha256:8fbb03054556498ba9c4cc48fcaa36a4483748c6504a65bdb9ba348f555b0e56
   WEB_SITE=https://github.com/rockdaboot/libpsl
    ENTERED=20180512
-   UPDATED=20260712
+   UPDATED=20260802
      SHORT="Public Suffix List library"
 
 cat << EOF


### PR DESCRIPTION
Upgrade libpsl to version 0.23.1

- Version: 0.23.1
- Source: https://github.com/rockdaboot/libpsl/releases/download/0.23.1/libpsl-0.23.1.tar.gz
- SHA256: 8fbb03054556498ba9c4cc48fcaa36a4483748c6504a65bdb9ba348f555b0e56
- Updated: 20260802

---
*Automated PR created by n8n + Claude AI*