### PR TITLE
libphonenumber: Version bumped to 9.0.36

### DIFF
--- a/libs/libphonenumber/DETAILS
+++ b/libs/libphonenumber/DETAILS
@@ -1,11 +1,11 @@
          MODULE=libphonenumber
-        VERSION=9.0.35
+        VERSION=9.0.36
          SOURCE=$MODULE-$VERSION.tar.gz
 SOURCE_URL_FULL=https://github.com/google/libphonenumber/archive/refs/tags/v$VERSION.tar.gz
-     SOURCE_VFY=sha256:a3b01ad172764edc4385954ea4ab8fecc9a91ae05ccb8d494bfc5323c28312ee
+     SOURCE_VFY=sha256:43b8fa34f80f84dddc591406d97fbe7f81cf35ce5d83621e67a1b6fa6afac548
        WEB_SITE=https://github.com/googlei18n/libphonenumber
         ENTERED=20230824
-        UPDATED=20260717
+        UPDATED=20260802
           SHORT="common library to parse, format and validate international phone numbers"
 
 cat << EOF


### PR DESCRIPTION
Upgrade libphonenumber from 9.0.35 to 9.0.36

- Updated VERSION to 9.0.36
- Updated SOURCE_VFY to sha256:43b8fa34f80f84dddc591406d97fbe7f81cf35ce5d83621e67a1b6fa6afac548
- Updated UPDATED date to 20260802

---
*Automated PR created by n8n + Claude AI*