### PR TITLE
libindi: Version bumped to 2.2.4

### DIFF
--- a/libs/libindi/DETAILS
+++ b/libs/libindi/DETAILS
@@ -1,12 +1,12 @@
           MODULE=libindi
-         VERSION=2.2.3.1
+         VERSION=2.2.4
           SOURCE=$MODULE-$VERSION.tar.gz
  SOURCE_URL_FULL=https://github.com/indilib/indi/archive/refs/tags/v$VERSION.tar.gz
-      SOURCE_VFY=sha256:3be8b3618f844ced78bd6f048985a8935d30eda8437184d5423d10091285606d
+      SOURCE_VFY=sha256:afa8a2cfef28daa8ceb6a34e6c0e26345d6c99094f9af86c9a7c01ee36e603f1
 SOURCE_DIRECTORY=$BUILD_DIRECTORY/indi-$VERSION
         WEB_SITE=http://www.indilib.org/index.php?title=Main_Page
          ENTERED=20071027
-         UPDATED=20260618
+         UPDATED=20260802
            SHORT="instrument neutral distributed interface control protocol"
 
 cat << EOF


### PR DESCRIPTION
Upgrade libindi from 2.2.3.1 to 2.2.4

- Updates VERSION to 2.2.4
- Updates SOURCE_VFY sha256 checksum
- Updates UPDATED date to 20260802

---
*Automated PR created by n8n + Claude AI*