### PR TITLE
gh: Version bumped to 2.97.0

### DIFF
--- a/devel/gh/DETAILS
+++ b/devel/gh/DETAILS
@@ -1,12 +1,12 @@
           MODULE=gh
-         VERSION=2.96.0
+         VERSION=2.97.0
           SOURCE=gh-cli-$VERSION.tar.gz
  SOURCE_URL_FULL=https://github.com/cli/cli/archive/refs/tags/v$VERSION.tar.gz
-      SOURCE_VFY=sha256:8d80d0aeccea7bec8024f8c30365bbfa76852901f2b2cb0afb7ab2cbf6d317c2
+      SOURCE_VFY=sha256:18cd1280f70911c9c16dd5965cdac0b9e6b16e54466f0c892ce2829ecdd339a6
 SOURCE_DIRECTORY=$BUILD_DIRECTORY/cli-$VERSION
         WEB_SITE=https://cli.github.com/
          ENTERED=20210423
-         UPDATED=20260703
+         UPDATED=20260802
            SHORT="Official command-line wrapper for GitHub"
 
 cat << EOF


### PR DESCRIPTION
Upgrade gh from 2.96.0 to 2.97.0

---
*Automated PR created by n8n + Claude AI*