### PR TITLE
skim: Version bumped to 5.6.1

### DIFF
--- a/utils/skim/DETAILS
+++ b/utils/skim/DETAILS
@@ -1,11 +1,11 @@
          MODULE=skim
-        VERSION=5.4.0
+        VERSION=5.6.1
          SOURCE=$MODULE-$VERSION.tar.gz
 SOURCE_URL_FULL=https://github.com/skim-rs/skim/archive/v${VERSION}.tar.gz
-     SOURCE_VFY=sha256:f968750ddd453c031f6fec5164c0a1e24eb7c52639fe64f3b5bb657664f0e591
+     SOURCE_VFY=sha256:e85c921fee7513453b487d2f72b6f47e9ffdf95110dcd4c1af39a13bade65549
        WEB_SITE=https://github.com/skim-rs/skim/
         ENTERED=20200627
-        UPDATED=20260722
+        UPDATED=20260802
           SHORT="Fuzzy Finder in rust"
 
 cat << EOF


### PR DESCRIPTION
Upgrade skim from 5.4.0 to 5.6.1

- Updated VERSION to 5.6.1
- Updated SOURCE_VFY to e85c921fee7513453b487d2f72b6f47e9ffdf95110dcd4c1af39a13bade65549
- Updated UPDATED date to 20260802

---
*Automated PR created by n8n + Claude AI*