### PR TITLE
weechat: Version bumped to 4.10.0

### DIFF
--- a/chat/weechat/DETAILS
+++ b/chat/weechat/DETAILS
@@ -1,11 +1,11 @@
     MODULE=weechat
-   VERSION=4.9.5
+   VERSION=4.10.0
     SOURCE=$MODULE-$VERSION.tar.xz
 SOURCE_URL=https://www.weechat.org/files/src
-SOURCE_VFY=sha256:3b3946104e64536d0602370a30e55dd5a301cc8ff420184ff0a101926dad1d16
+SOURCE_VFY=sha256:c3a7e7c6a5401dde9a46d0264fa44aa3032ca98aa86410c454d3de5c69505c54
   WEB_SITE=https://www.weechat.org/
    ENTERED=20050223
-   UPDATED=20260728
+   UPDATED=20260802
      SHORT="A very light and neat IRC client"
 
 cat << EOF


### PR DESCRIPTION
Upgrade weechat from 4.9.5 to 4.10.0. This is a routine version bump with updated SHA256 checksum and UPDATED date.

---
*Automated PR created by n8n + Claude AI*