### PR TITLE
libheif: Version bumped to 1.23.2

### DIFF
--- a/libs/libheif/DETAILS
+++ b/libs/libheif/DETAILS
@@ -1,11 +1,11 @@
     MODULE=libheif
-   VERSION=1.23.1
+   VERSION=1.23.2
     SOURCE=$MODULE-$VERSION.tar.gz
 SOURCE_URL=https://github.com/strukturag/libheif/releases/download/v$VERSION/
-SOURCE_VFY=sha256:0de0327f60fcd47de90d5654c6fe152232738d60d84fe084ec3e0f35e03b166a
+SOURCE_VFY=sha256:8bd5d41d19dc84536d118b04774709f244df6104ef66d623dad5fa4650143405
   WEB_SITE=https://github.com/strukturag/libheif/
    ENTERED=20181108
-   UPDATED=20260627
+   UPDATED=20260826
      SHORT="HEIF file format decoder and encoder"
 
 cat << EOF


### PR DESCRIPTION
Upgrade libheif from 1.23.1 to 1.23.2

- Updated VERSION to 1.23.2
- Updated SOURCE_VFY checksum
- Updated UPDATED date to 20260826

---
*Automated PR created by n8n + Claude AI*