### PR TITLE
srt: Version bumped to 1.5.7

### DIFF
--- a/security/srt/DETAILS
+++ b/security/srt/DETAILS
@@ -1,12 +1,12 @@
          MODULE=srt
-        VERSION=1.5.6
+        VERSION=1.5.7
          SOURCE=$MODULE-$VERSION.tar.gz
 SOURCE_URL_FULL=https://github.com/Haivision/srt/archive/v$VERSION.tar.gz
-     SOURCE_VFY=sha256:2c4980c2c4cfd142d21b829d939dc51db9c6628af5967fff62fd7290769569c7
+     SOURCE_VFY=sha256:fee6aee6b4933f01ba8b7e18d5d9e4896ad604053fdad2ac55df4a4f1561f30a
        WEB_SITE=https://www.srtalliance.org/
            TYPE=cmake
         ENTERED=20180326
-        UPDATED=20260721
+        UPDATED=20260826
           SHORT="Secure Reliable Transport"
 
 cat << EOF


### PR DESCRIPTION
Upgrade srt from 1.5.6 to 1.5.7

- Updated VERSION to 1.5.7
- Updated SOURCE_VFY to fee6aee6b4933f01ba8b7e18d5d9e4896ad604053fdad2ac55df4a4f1561f30a
- Updated UPDATED field to 20260826

---
*Automated PR created by n8n + Claude AI*