### PR TITLE
simdjson: Version bumped to 4.6.9

### DIFF
--- a/libs/simdjson/DETAILS
+++ b/libs/simdjson/DETAILS
@@ -1,11 +1,11 @@
          MODULE=simdjson
-        VERSION=4.6.8
+        VERSION=4.6.9
          SOURCE=$MODULE-$VERSION.tar.gz
 SOURCE_URL_FULL=https://github.com/simdjson/simdjson/archive/refs/tags/v$VERSION.tar.gz
-     SOURCE_VFY=sha256:18b5368b9ddaafa12c013b0862f32f7ad96c08f95841ebd686e0009b21c48ce2
+     SOURCE_VFY=sha256:b3954b7d6024eb5063c64e47be5ca09be04a3783563340400ce0aef416b20216
        WEB_SITE=https://github.com/simdjson/simdjson
         ENTERED=20240916
-        UPDATED=20260823
+        UPDATED=20260827
           SHORT="parsing gigabytes of JSON per second"
 
 cat << EOF


### PR DESCRIPTION
Upgrade simdjson from 4.6.8 to 4.6.9

- Updated VERSION to 4.6.9
- Updated SOURCE_VFY to sha256:b3954b7d6024eb5063c64e47be5ca09be04a3783563340400ce0aef416b20216
- Updated UPDATED date to 20260827
- No changes to dependencies or build configuration

---
*Automated PR created by n8n + Claude AI*