### PR TITLE
watchexec: Version bumped to 2.7.0

### DIFF
--- a/utils/watchexec/DETAILS
+++ b/utils/watchexec/DETAILS
@@ -1,11 +1,11 @@
          MODULE=watchexec
-        VERSION=2.6.1
+        VERSION=2.7.0
          SOURCE=$MODULE-$VERSION.tar.gz
 SOURCE_URL_FULL=https://github.com/watchexec/watchexec/archive/refs/tags/v$VERSION.tar.gz
-     SOURCE_VFY=sha256:86da4682d38bd8357fee4652f02896db409dd40d35cef5582451f6c1adc2271f
+     SOURCE_VFY=sha256:b9860e46ed035ba870b309eea4151f29f9eddb6e168712112545bfda11acc594
        WEB_SITE=https://github.com/watchexec/watchexec/
         ENTERED=20200621
-        UPDATED=20260822
+        UPDATED=20260828
           SHORT="Executes commands in response to file modifications"
 
 cat << EOF


### PR DESCRIPTION
Upgrade watchexec from 2.6.1 to 2.7.0. Updated SOURCE_VFY hash and UPDATED date.

---
*Automated PR created by n8n + Claude AI*