### PR TITLE
grpc: Version bumped to 1.83.1

### DIFF
--- a/devel/grpc/DETAILS
+++ b/devel/grpc/DETAILS
@@ -1,11 +1,11 @@
          MODULE=grpc
-        VERSION=1.83.0
+        VERSION=1.83.1
          SOURCE=$MODULE-$VERSION.tar.gz
 SOURCE_URL_FULL=https://github.com/grpc/grpc/archive/refs/tags/v$VERSION.tar.gz
-     SOURCE_VFY=sha256:90d453393a9d41215df546103b10b33b9566df79cdf6f49dc67f6c4d044d090d
+     SOURCE_VFY=sha256:60caa8397426d8a500e3e57ab6a49d1cb5aa62a36f2591eb9da3d77fa38ad8c9
        WEB_SITE=https://grpc.io/
         ENTERED=20240401
-        UPDATED=20260722
+        UPDATED=20260828
           SHORT="high-performance remote procedure call (RPC) framework that can run anywhere"
 
 cat << EOF


### PR DESCRIPTION
Upgrade grpc from 1.83.0 to 1.83.1

- Updated VERSION to 1.83.1
- Updated SOURCE_VFY to sha256:60caa8397426d8a500e3e57ab6a49d1cb5aa62a36f2591eb9da3d77fa38ad8c9
- Updated UPDATED date to 20260828

---
*Automated PR created by n8n + Claude AI*