### PR TITLE
ncmpc: Version bumped to 0.54

### DIFF
--- a/audio/ncmpc/DETAILS
+++ b/audio/ncmpc/DETAILS
@@ -1,11 +1,11 @@
     MODULE=ncmpc
-   VERSION=0.53
+   VERSION=0.54
     SOURCE=$MODULE-$VERSION.tar.xz
 SOURCE_URL=http://www.musicpd.org/download/ncmpc/${VERSION%.*}/
-SOURCE_VFY=sha256:92c68bb9bf294d48209587b19df9005db7247e9c38d7e4fb74f8586e6f23c56f
+SOURCE_VFY=sha256:f678e6c600200af4c5d36174de4e1e82e423962c41b6f52844a25d6d1ec4cb11
   WEB_SITE=http://www.musicpd.org/clients/ncmpc/
    ENTERED=20090314
-   UPDATED=20260723
+   UPDATED=20260828
      SHORT="A curses client for MPD"
 
 cat << EOF


### PR DESCRIPTION
Upgrade ncmpc from 0.53 to 0.54

- Updated VERSION to 0.54
- Updated SOURCE_VFY with new SHA256 checksum
- Updated UPDATED date to 20260828

---
*Automated PR created by n8n + Claude AI*