### PR TITLE
mdds: Version bumped to 3.2.1

### DIFF
--- a/libs/mdds/DETAILS
+++ b/libs/mdds/DETAILS
@@ -1,12 +1,12 @@
-          MODULE=mdds
-         VERSION=3.1.0
-          SOURCE=$MODULE-$VERSION.tar.bz2
-      SOURCE_URL=https://gitlab.com/mdds/mdds/-/archive/$VERSION/
-      SOURCE_VFY=sha256:ad5475e0efa1da6648efdceb3c8b50f94ae3a91d0d70845cef93c62c5e5844c1
-        WEB_SITE=https://gitlab.com/mdds/mdds
-         ENTERED=20180131
-         UPDATED=20250710
-           SHORT="Multi-Dimensional Data Structure"
+    MODULE=mdds
+   VERSION=3.2.1
+    SOURCE=$MODULE-$VERSION.tar.bz2
+SOURCE_URL=https://gitlab.com/mdds/mdds/-/archive/$VERSION/
+SOURCE_VFY=sha256:7eb71ae35bcfbea27c6f1ab094ce4fbd4093eb396d5eebe926c0d77280bc7791
+  WEB_SITE=https://gitlab.com/mdds/mdds
+   ENTERED=20180131
+   UPDATED=20260828
+     SHORT="Multi-Dimensional Data Structure"
 
 cat << EOF
 A collection of multi-dimensional data structure and indexing algorithm.


### PR DESCRIPTION
Upgrade mdds from 3.1.0 to 3.2.1

- Updated VERSION to 3.2.1
- Updated SOURCE_VFY to sha256:7eb71ae35bcfbea27c6f1ab094ce4fbd4093eb396d5eebe926c0d77280bc7791
- Updated UPDATED timestamp to 20260828

---
*Automated PR created by n8n + Claude AI*