### PR TITLE
libcerf: Version bumped to 3.4

### DIFF
--- a/libs/libcerf/DETAILS
+++ b/libs/libcerf/DETAILS
@@ -1,16 +1,17 @@
           MODULE=libcerf
-         VERSION=3.3
+         VERSION=3.4
           SOURCE=$MODULE-$VERSION.tar.bz2
       SOURCE_URL=https://jugit.fz-juelich.de/mlz/libcerf/-/archive/v$VERSION/
-      SOURCE_VFY=sha256:94672fe0bfc1898d67378e0dce2c7e2b5f9e5f3fb25dcdfa383213d3a5fa90c8
-SOURCE_DIRECTORY=$BUILD_DIRECTORY/$MODULE-v3.3-7e6b637031b5c6cbc89a5f7220bf4ef07518d035/
+      SOURCE_VFY=sha256:d70ab4d0d82fa7e456cbeac00f1b1ff494a6720b8d001cbe4c95cbead50bddc0
+SOURCE_DIRECTORY=$BUILD_DIRECTORY/$MODULE-v$VERSION
         WEB_SITE=https://jugit.fz-juelich.de/mlz/libcerf
             TYPE=cmake
          ENTERED=20200718
-         UPDATED=20251025
+         UPDATED=20260828
            SHORT="provides efficient and accurate implementation of complex error functions"
 
 cat << EOF
-A self-contained numeric library that provides an efficient and accurate implementation of
-complex error functions, along with Dawson, Faddeeva, and Voigt functions.
+A self-contained numeric library that provides an efficient and accurate
+implementation of complex error functions, along with Dawson, Faddeeva, and
+Voigt functions.
 EOF


### PR DESCRIPTION
Upgrade libcerf from version 3.3 to 3.4. Updated SOURCE_VFY with the new SHA256 checksum and UPDATED date. SOURCE_DIRECTORY simplified to use $VERSION variable for better maintainability.

---
*Automated PR created by n8n + Claude AI*