### PR TITLE
libksba: Version bumped to 1.8.1

### DIFF
--- a/crypto/libksba/DETAILS
+++ b/crypto/libksba/DETAILS
@@ -1,11 +1,11 @@
     MODULE=libksba
-   VERSION=1.8.0
+   VERSION=1.8.1
     SOURCE=$MODULE-$VERSION.tar.bz2
 SOURCE_URL=https://www.gnupg.org/ftp/gcrypt/libksba/
-SOURCE_VFY=sha256:296b9db9095749f2aa104202d7ab7fd09ad10710e00780a709c9754b1a1d9292
+SOURCE_VFY=sha256:c2f84393011827219ae117131dba8e7684c2bed0961eed11b0642c2acba440b5
   WEB_SITE=http://www.gnupg.org/aegypten
    ENTERED=20030310
-   UPDATED=20260513
+   UPDATED=20260828
      SHORT="A library to use X.509 certs and CMS easy"
 
 cat << EOF


### PR DESCRIPTION
Upgrade libksba from 1.8.0 to 1.8.1

- Version: 1.8.0 → 1.8.1
- SHA256: c2f84393011827219ae117131dba8e7684c2bed0961eed11b0642c2acba440b5
- Updated: 20260828

---
*Automated PR created by n8n + Claude AI*