### PR TITLE
python-pygobject: Version bumped to 3.58.0

### DIFF
--- a/python/python-pygobject/DETAILS
+++ b/python/python-pygobject/DETAILS
@@ -1,12 +1,12 @@
           MODULE=python-pygobject
-         VERSION=3.56.3
+         VERSION=3.58.0
           SOURCE=pygobject-$VERSION.tar.gz
       SOURCE_URL=https://pypi.python.org/packages/source/p/pygobject/
-      SOURCE_VFY=sha256:12760e4a0e3d04b6eb95e06f7a27e362c826d567ea613373a92c003b6c70d2d6
+      SOURCE_VFY=sha256:45068697de3ffe46840ca369705f23118b34db4f7deb63f6eff079a6734ddcca
 SOURCE_DIRECTORY=$BUILD_DIRECTORY/pygobject-$VERSION
         WEB_SITE=https://pypi.org/project/PyGObject/
          ENTERED=20050319
-         UPDATED=20260619
+         UPDATED=20260828
         REPLACES=pygobject
            SHORT="Python bindings for GObject"
 


### PR DESCRIPTION
Upgrade python-pygobject from 3.56.3 to 3.58.0

---
*Automated PR created by n8n + Claude AI*