### PR TITLE
libmpack-lua: Version bumped to 1.0.13

### DIFF
--- a/libs/libmpack-lua/DETAILS
+++ b/libs/libmpack-lua/DETAILS
@@ -1,11 +1,11 @@
           MODULE=libmpack-lua
-         VERSION=1.0.12
+         VERSION=1.0.13
           SOURCE=$MODULE-$VERSION.tar.gz
       SOURCE_URL=https://github.com/libmpack/libmpack-lua/releases/download/$VERSION/
-      SOURCE_VFY=sha256:06b662b1f14cfaf592ecb3fab425bef20e51439509b7a1736a790ecc929ef8bf
+      SOURCE_VFY=sha256:dd52ab48f620a6d6acff04ac163d055213dc8950d0cb4899e4857b65252993d7
         WEB_SITE=https://github.com/libmpack/libmpack-lua/
          ENTERED=20180419
-         UPDATED=20250124
+         UPDATED=20260829
            SHORT="libmpack lua binding"
 
 cat << EOF


### PR DESCRIPTION
Upgrade libmpack-lua from 1.0.12 to 1.0.13

- Updated VERSION to 1.0.13
- Updated SOURCE_VFY with new sha256 checksum
- Updated UPDATED date to 20260829

---
*Automated PR created by n8n + Claude AI*