### PR TITLE
libmpack-lua51: Version bumped to 1.0.13

### DIFF
--- a/libs/libmpack-lua51/DETAILS
+++ b/libs/libmpack-lua51/DETAILS
@@ -1,12 +1,12 @@
           MODULE=libmpack-lua51
-         VERSION=1.0.12
+         VERSION=1.0.13
           SOURCE=libmpack-lua-$VERSION.tar.gz
       SOURCE_URL=https://github.com/libmpack/libmpack-lua/releases/download/$VERSION/
 SOURCE_DIRECTORY=$BUILD_DIRECTORY/libmpack-lua-$VERSION
-      SOURCE_VFY=sha256:06b662b1f14cfaf592ecb3fab425bef20e51439509b7a1736a790ecc929ef8bf
+      SOURCE_VFY=sha256:dd52ab48f620a6d6acff04ac163d055213dc8950d0cb4899e4857b65252993d7
         WEB_SITE=https://github.com/libmpack/libmpack-lua/
          ENTERED=20180419
-         UPDATED=20250124
+         UPDATED=20260829
            SHORT="libmpack lua binding"
 
 cat << EOF


### PR DESCRIPTION
Upgrade libmpack-lua51 from version 1.0.12 to 1.0.13. Updated SOURCE_VFY checksum and UPDATED date.

---
*Automated PR created by n8n + Claude AI*