### PR TITLE
luafilesystem: Version bumped to 1.9.0

### DIFF
--- a/devel/luafilesystem/DETAILS
+++ b/devel/luafilesystem/DETAILS
@@ -1,12 +1,12 @@
           MODULE=luafilesystem
-         VERSION=1.8.0
+         VERSION=1.9.0
           SOURCE=$MODULE-$VERSION.tar.gz
  SOURCE_URL_FULL=https://github.com/keplerproject/luafilesystem/archive/v${VERSION//./_}.tar.gz
-      SOURCE_VFY=sha256:16d17c788b8093f2047325343f5e9b74cccb1ea96001e45914a58bbae8932495
+      SOURCE_VFY=sha256:1142c1876e999b3e28d1c236bf21ffd9b023018e336ac25120fb5373aade1450
 SOURCE_DIRECTORY=$BUILD_DIRECTORY/$MODULE-${VERSION//./_}
         WEB_SITE=https://github.com/keplerproject/luafilesystem
          ENTERED=20190507
-         UPDATED=20230215
+         UPDATED=20260829
            SHORT="File System Library for the Lua Programming Language"
 
 cat << EOF


### PR DESCRIPTION
Upgrade luafilesystem from 1.8.0 to 1.9.0

- Updated VERSION to 1.9.0
- Updated SOURCE_VFY to sha256:1142c1876e999b3e28d1c236bf21ffd9b023018e336ac25120fb5373aade1450
- Updated UPDATED timestamp to 20260829

---
*Automated PR created by n8n + Claude AI*