### PR TITLE
pdfjs: Version bumped to 6.3.289

### DIFF
--- a/web/pdfjs/DETAILS
+++ b/web/pdfjs/DETAILS
@@ -1,12 +1,12 @@
           MODULE=pdfjs
-         VERSION=6.2.108
+         VERSION=6.3.289
           SOURCE=$MODULE-$VERSION.tar.gz
  SOURCE_URL_FULL=https://github.com/mozilla/pdf.js/archive/v$VERSION.tar.gz
-      SOURCE_VFY=sha256:82a97085bd781f74461a974e3d6542f04583b55366e7646436f219b34fc974ed
+      SOURCE_VFY=sha256:28cad59eb2694dcd27e610169b38672e08d661f5582cbe33d2bfc94e801ee9fa
 SOURCE_DIRECTORY=$BUILD_DIRECTORY/pdf.js-$VERSION
         WEB_SITE=https://github.com/mozilla/pdf.js/
          ENTERED=20181003
-         UPDATED=20260801
+         UPDATED=20260829
            SHORT="PDF reader in JavaScript"
 
 cat << EOF


### PR DESCRIPTION
Upgrade pdfjs from 6.2.108 to 6.3.289. This update includes the latest improvements and bug fixes from the Mozilla PDF.js project.

---
*Automated PR created by n8n + Claude AI*