### PR TITLE
python-matplotlib: Version bumped to 3.11.1

### DIFF
--- a/python/python-matplotlib/DETAILS
+++ b/python/python-matplotlib/DETAILS
@@ -1,14 +1,14 @@
           MODULE=python-matplotlib
-         VERSION=3.10.9
+         VERSION=3.11.1
           SOURCE=matplotlib-$VERSION.tar.gz
       SOURCE_URL=https://pypi.python.org/packages/source/m/matplotlib/
-      SOURCE_VFY=sha256:fd66508e8c6877d98e586654b608a0456db8d7e8a546eb1e2600efd957302358
+      SOURCE_VFY=sha256:69647db5746941c793d6e445a4cd349323ffb87d9cc958c2ad84a659b4832d30
 SOURCE_DIRECTORY=$BUILD_DIRECTORY/matplotlib-$VERSION
         WEB_SITE=http://matplotlib.org/
             TYPE=meson
         REPLACES=matplotlib
          ENTERED=20120729
-         UPDATED=20260505
+         UPDATED=20260830
            SHORT="Python 2D plotting library"
 
 cat << EOF


### PR DESCRIPTION
Upgrade python-matplotlib from 3.10.9 to 3.11.1

- Version: 3.10.9 → 3.11.1
- SHA256: 69647db5746941c793d6e445a4cd349323ffb87d9cc958c2ad84a659b4832d30
- Updated: 20260830

---
*Automated PR created by n8n + Claude AI*