### PR TITLE
libslirp: Version bumped to 4.9.4

### DIFF
--- a/net/libslirp/DETAILS
+++ b/net/libslirp/DETAILS
@@ -1,13 +1,13 @@
           MODULE=libslirp
-         VERSION=4.9.3
+         VERSION=4.9.4
           SOURCE=$MODULE-$VERSION.tar.bz2
       SOURCE_URL=https://gitlab.freedesktop.org/slirp/libslirp/-/archive/v$VERSION/
-      SOURCE_VFY=sha256:56f784b3cd9df59efde8c886ce50b1b398c4f5eae5d19f82d53046660e11e8c6
+      SOURCE_VFY=sha256:354906efd528c3c80b200f6466fa786dff6ac592ff7b675aed1f07b95a3604b4
 SOURCE_DIRECTORY=$BUILD_DIRECTORY/$MODULE-$VERSION-9c744e1e52aa0d9646ed91d789d588696292c21e
         WEB_SITE=https://gitlab.freedesktop.org/slirp/libslirp/
             TYPE=meson
          ENTERED=20200402
-         UPDATED=20260526
+         UPDATED=20260830
            SHORT="General purpose TCP-IP emulator"
 
 cat << EOF


### PR DESCRIPTION
Upgrade libslirp from 4.9.3 to 4.9.4

---
*Automated PR created by n8n + Claude AI*