### PR TITLE
python-installer: Version bumped to 1.0.1

### DIFF
--- a/python/python-installer/DETAILS
+++ b/python/python-installer/DETAILS
@@ -1,12 +1,12 @@
           MODULE=python-installer
-         VERSION=1.0.0
+         VERSION=1.0.1
           SOURCE=$MODULE-$VERSION.tar.gz
  SOURCE_URL_FULL=https://pypi.python.org/packages/source/i/installer/installer-$VERSION.tar.gz
-      SOURCE_VFY=sha256:c6d691331621cf3fec4822f5c6f83cab3705f79b316225dc454127411677c71f
+      SOURCE_VFY=sha256:052c7fc3721d54c696e2dea019be67539d7b144e924f559f54beb3121831c364
 SOURCE_DIRECTORY=$BUILD_DIRECTORY/installer-$VERSION
         WEB_SITE=https://pypi.org/project/installer/
          ENTERED=20221115
-         UPDATED=20260401
+         UPDATED=20260831
            SHORT="install python packages from a wheel distribution"
 
 cat << EOF


### PR DESCRIPTION
Upgrade python-installer from 1.0.0 to 1.0.1

- Updated VERSION to 1.0.1
- Updated SOURCE_VFY with new SHA256 hash
- Updated UPDATED date to 20260831

---
*Automated PR created by n8n + Claude AI*