### PR TITLE
python-build: Version bumped to 1.6.0

### DIFF
--- a/python/python-build/DETAILS
+++ b/python/python-build/DETAILS
@@ -1,12 +1,12 @@
           MODULE=python-build
-         VERSION=1.4.3
+         VERSION=1.6.0
           SOURCE=build-$VERSION.tar.gz
       SOURCE_URL=https://files.pythonhosted.org/packages/source/b/build/
-      SOURCE_VFY=sha256:5aa4231ae0e807efdf1fd0623e07366eca2ab215921345a2e38acdd5d0fa0a74
+      SOURCE_VFY=sha256:bd2c8afc603e7a2e0ce70e2ea85f0a6d02043bafbd307f5bada0f98669eca5af
 SOURCE_DIRECTORY=$BUILD_DIRECTORY/build-$VERSION
         WEB_SITE=https://pypi.org/project/build/
          ENTERED=20221025
-         UPDATED=20260413
+         UPDATED=20260831
            SHORT="correct PEP 517 build frontend"
 
 cat << EOF


### PR DESCRIPTION
Upgrade python-build to version 1.6.0. This update includes the latest improvements to the PEP 517 build frontend with checksum sha256:bd2c8afc603e7a2e0ce70e2ea85f0a6d02043bafbd307f5bada0f98669eca5af

---
*Automated PR created by n8n + Claude AI*