### PR TITLE
python-regex: Version bumped to 2026.8.31

### DIFF
--- a/python/python-regex/DETAILS
+++ b/python/python-regex/DETAILS
@@ -1,13 +1,13 @@
           MODULE=python-regex
-         VERSION=2026.7.10
+         VERSION=2026.8.31
           SOURCE=regex-$VERSION.tar.gz
       SOURCE_URL=https://pypi.io/packages/source/r/regex/
-      SOURCE_VFY=sha256:1050fedf0a8a92e843971120c2f57c3a99bea86c0dfa1d63a9fac053fe54b135
+      SOURCE_VFY=sha256:9350fd448a6442ae27853ab9d4b8d5a0bcb6d7774923a4fdfddd104c4458b35f
 SOURCE_DIRECTORY=$BUILD_DIRECTORY/regex-$VERSION
         WEB_SITE=https://pypi.org/project/regex/
             TYPE=python3
          ENTERED=20181027
-         UPDATED=20260713
+         UPDATED=20260831
            SHORT="An alternative python regular expression module"
 
 cat << EOF


### PR DESCRIPTION
Upgrade python-regex from 2026.7.10 to 2026.8.31

---
*Automated PR created by n8n + Claude AI*