### PR TITLE
rapydscript-ng: Version bumped to 0.8.6

### DIFF
--- a/devel/rapydscript-ng/BUILD
+++ b/devel/rapydscript-ng/BUILD
@@ -7,4 +7,3 @@ mkdir -p /usr/{bin,lib/node_modules/rapydscript-ng/}
 cp -r * /usr/lib/node_modules/rapydscript-ng/ &&
 
 ln -s /usr/lib/node_modules/rapydscript-ng/bin/rapydscript /usr/bin/rapydscript
-

--- a/devel/rapydscript-ng/DETAILS
+++ b/devel/rapydscript-ng/DETAILS
@@ -1,11 +1,11 @@
          MODULE=rapydscript-ng
-        VERSION=0.7.24
+        VERSION=0.8.6
          SOURCE=$MODULE-$VERSION.tar.gz
 SOURCE_URL_FULL=https://github.com/kovidgoyal/rapydscript-ng/archive/refs/tags/v$VERSION.tar.gz
-     SOURCE_VFY=sha256:f6f961337c8f6ceaf619634ed7372cb9e163b0b9dadf951275cd657f50fd2298
+     SOURCE_VFY=sha256:e1dbd49c0afa6c445318a7a6eb1b749d528b3c7755dcae33afb3da0fe8040e85
        WEB_SITE=https://github.com/kovidgoyal/rapydscript-ng
         ENTERED=20221117
-        UPDATED=20260624
+        UPDATED=20260831
           SHORT="pythonic javascript"
 
 cat << EOF


### PR DESCRIPTION
Update rapydscript-ng from 0.7.24 to 0.8.6

- Updated VERSION to 0.8.6
- Updated SOURCE_VFY to e1dbd49c0afa6c445318a7a6eb1b749d528b3c7755dcae33afb3da0fe8040e85
- Updated UPDATED date to 20260831
- No changes to dependencies or build steps

---
*Automated PR created by n8n + Claude AI*