### PR TITLE
python-google-api-python-client: Version bumped to 2.199.0

### DIFF
--- a/python/python-google-api-python-client/DETAILS
+++ b/python/python-google-api-python-client/DETAILS
@@ -1,13 +1,13 @@
            MODULE=python-google-api-python-client
-          VERSION=2.179.0
+          VERSION=2.199.0
            SOURCE=google-api-python-client-$VERSION.tar.gz
   SOURCE_URL_FULL=https://github.com/googleapis/google-api-python-client/archive/v$VERSION.tar.gz
-       SOURCE_VFY=sha256:0a5709fd6e72c656f8340f8b43a88245f595340e6a7754ae009378c2cb6cf56a
+       SOURCE_VFY=sha256:50f7e953d05d3f3b42fa7453e7b3c5fb5d2d33e5ced77a466d02c91a6b8d365f
  SOURCE_DIRECTORY=$BUILD_DIRECTORY/google-api-python-client-$VERSION
          WEB_SITE=https://github.com/google/google-api-python-client
              TYPE=python3
           ENTERED=20160526
-          UPDATED=20250829
+          UPDATED=20260831
          REPLACES=google-api-python-client
             SHORT="A python implementation of the Google commandline flags module"
 
@@ -16,5 +16,5 @@ GFlags defines a distributed command line system, replacing systems like
 getopt(), optparse and manual argument processing. Rather than an
 application having to define all flags in or near main(), each python
 module defines flags that are useful to it. When one python module
-imports another, it gains access to the other’s flags.
+imports another, it gains access to the other's flags.
 EOF


### PR DESCRIPTION
Upgrade python-google-api-python-client from 2.179.0 to 2.199.0

- Version: 2.199.0
- SHA256: 50f7e953d05d3f3b42fa7453e7b3c5fb5d2d33e5ced77a466d02c91a6b8d365f
- Updated: 20260831

---
*Automated PR created by n8n + Claude AI*