### PR TITLE
python-importlib-metadata: Version bumped to 9.0.1

### DIFF
--- a/python/python-importlib-metadata/DETAILS
+++ b/python/python-importlib-metadata/DETAILS
@@ -1,12 +1,12 @@
           MODULE=python-importlib-metadata
-         VERSION=8.7.1
+         VERSION=9.0.1
           SOURCE=importlib_metadata-$VERSION.tar.gz
       SOURCE_URL=https://pypi.python.org/packages/source/i/importlib-metadata
-      SOURCE_VFY=sha256:49fef1ae6440c182052f407c8d34a68f72efc36db9ca90dc0113398f2fdde8bb
+      SOURCE_VFY=sha256:ab830580bc0ef3db61ce8fae716389e5462b67e033018bab6d8f80ef17172f99
 SOURCE_DIRECTORY=$BUILD_DIRECTORY/importlib_metadata-$VERSION
         WEB_SITE=https://pypi.org/project/importlib-metadata/
          ENTERED=20220110
-         UPDATED=20260303
+         UPDATED=20260831
            SHORT="Read metadata from Python packages"
 
 cat << EOF


### PR DESCRIPTION
Upgrade python-importlib-metadata from 8.7.1 to 9.0.1

---
*Automated PR created by n8n + Claude AI*