### PR TITLE
wireplumber: Version bumped to 0.5.16

### DIFF
--- a/audio/wireplumber/DETAILS
+++ b/audio/wireplumber/DETAILS
@@ -1,11 +1,11 @@
           MODULE=wireplumber
-         VERSION=0.5.15
+         VERSION=0.5.16
           SOURCE=$MODULE-$VERSION.tar.bz2
       SOURCE_URL=https://gitlab.freedesktop.org/pipewire/wireplumber/-/archive/${VERSION}/
-      SOURCE_VFY=sha256:fb192f5d884155aedd6f01438e94cc12b263f482f0f39e5706c1e2cff9ad0c6d
+      SOURCE_VFY=sha256:2c99030a3aa6e5895e8ca0d985b4a9de12255aa85a21f2edd49f94a83b59af81
         WEB_SITE=https://gitlab.freedesktop.org/pipewire/wireplumber/
          ENTERED=20200726
-         UPDATED=20260619
+         UPDATED=20260831
            SHORT="Session/policy manager implementation for PipeWire"
 
 cat << EOF


### PR DESCRIPTION
Upgrade wireplumber from 0.5.15 to 0.5.16. Updated VERSION, SOURCE_VFY, and UPDATED date. All other module specifications remain unchanged.

---
*Automated PR created by n8n + Claude AI*