### PR TITLE
protobuf: Version bumped to 36.0

### DIFF
--- a/python/protobuf/DETAILS
+++ b/python/protobuf/DETAILS
@@ -1,13 +1,14 @@
-          MODULE=protobuf
-         VERSION=35.0
-          SOURCE=$MODULE-$VERSION.tar.gz
-      SOURCE_URL=https://github.com/protocolbuffers/protobuf/releases/download/v$VERSION/
-      SOURCE_VFY=sha256:8f907baca4b34a3b4854103ba5811e418fb6e2ff11fe0d8df9e8280b11d79926
-        WEB_SITE=https://developers.google.com/protocol-buffers/
-            TYPE=cmake
-         ENTERED=20130113
-         UPDATED=20260601
-           SHORT="Encoding structured data in an efficient yet extensible format"
+    MODULE=protobuf
+   VERSION=36.0
+    SOURCE=$MODULE-$VERSION.tar.gz
+SOURCE_URL=https://github.com/protocolbuffers/protobuf/releases/download/v$VERSION/
+SOURCE_VFY=sha256:399931c793f4ac6db81045b00b06dd07c877b48aeecf36c797f65c541fb533e7
+  WEB_SITE=https://developers.google.com/protocol-buffers/
+      TYPE=cmake
+   ENTERED=20130113
+   UPDATED=20260831
+     SHORT="Encoding structured data in an efficient yet extensible format"
+
 cat << EOF
 Protocol Buffers are a way of encoding structured data in an efficient yet
 extensible format.


### PR DESCRIPTION
Upgrade protobuf from 35.0 to 36.0

- Version: 35.0 → 36.0
- SHA256: 399931c793f4ac6db81045b00b06dd07c877b48aeecf36c797f65c541fb533e7
- Updated: 20260831

---
*Automated PR created by n8n + Claude AI*