### PR TITLE
blosc2: Version bumped to 3.3.3

### DIFF
--- a/archive/blosc2/DETAILS
+++ b/archive/blosc2/DETAILS
@@ -1,12 +1,12 @@
           MODULE=blosc2
-         VERSION=3.3.2
+         VERSION=3.3.3
           SOURCE=$MODULE-$VERSION.tar.gz
  SOURCE_URL_FULL=https://github.com/Blosc/c-blosc2/archive/refs/tags/v$VERSION.tar.gz
-      SOURCE_VFY=sha256:a8fb27bae6403872bb6e5bb8672e79a5b7eb6b3d8fd7c3e6aa7b888436b68ee2
+      SOURCE_VFY=sha256:3ab395116eae3ce0b7488e994224f85cbc858a7a71663af1f938cc5997a7dddd
 SOURCE_DIRECTORY=$BUILD_DIRECTORY/c-$MODULE-$VERSION
         WEB_SITE=https://github.com/Blosc/c-blosc2/
          ENTERED=20240724
-         UPDATED=20260807
+         UPDATED=20260831
            SHORT="A blocking, shuffling and loss-less compression library"
 
 cat << EOF


### PR DESCRIPTION
Upgrade blosc2 from version 3.3.2 to 3.3.3

---
*Automated PR created by n8n + Claude AI*