### PR TITLE
python-idna: Version bumped to 3.19

### DIFF
--- a/python/python-idna/DETAILS
+++ b/python/python-idna/DETAILS
@@ -1,15 +1,15 @@
           MODULE=python-idna
-         VERSION=3.11
+         VERSION=3.19
           SOURCE=idna-$VERSION.tar.gz
       SOURCE_URL=https://pypi.python.org/packages/source/i/idna
-      SOURCE_VFY=sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902
+      SOURCE_VFY=sha256:5e0811a4383b21dc5838069f801c4fb62113b7447663d2530d2bd6e77b49bf15
 SOURCE_DIRECTORY=$BUILD_DIRECTORY/idna-$VERSION
         WEB_SITE=https://pypi.org/project/idna/
             TYPE=python3
          ENTERED=20180806
-         UPDATED=20260303
+         UPDATED=20260831
            SHORT="Internationalized Domain Names in Applications (IDNA)"
 
 cat << EOF
-Internationalized Domain Names in Applications (IDNA).
+Interationalized Domain Names in Applications (IDNA).
 EOF


### PR DESCRIPTION
Upgrade python-idna from 3.11 to 3.19

- Version: 3.11 → 3.19
- SHA256: 5e0811a4383b21dc5838069f801c4fb62113b7447663d2530d2bd6e77b49bf15
- Updated: 20260831

---
*Automated PR created by n8n + Claude AI*