### PR TITLE
python-zope.interface: Version bumped to 8.6

### DIFF
--- a/python/python-zope.interface/DETAILS
+++ b/python/python-zope.interface/DETAILS
@@ -1,12 +1,12 @@
           MODULE=python-zope.interface
-         VERSION=8.2
-          SOURCE=zope\_interface-$VERSION.tar.gz
+         VERSION=8.6
+          SOURCE=zope_interface-$VERSION.tar.gz
       SOURCE_URL=https://pypi.python.org/packages/source/z/zope_interface/
-      SOURCE_VFY=sha256:afb20c371a601d261b4f6edb53c3c418c249db1a9717b0baafc9a9bb39ba1224
+      SOURCE_VFY=sha256:b40ef9b4873afb5d0dec02b8d2dfde1cf18c72337b60c99cb735961e0bac05c0
 SOURCE_DIRECTORY=$BUILD_DIRECTORY/zope_interface-$VERSION
         WEB_SITE=https://github.com/zopefoundation/zope.interface
          ENTERED=20060505
-         UPDATED=20260303
+         UPDATED=20260831
         REPLACES=zope.interface
            SHORT="An interface package from Zope"
 


### PR DESCRIPTION
Upgrade python-zope.interface from 8.2 to 8.6

---
*Automated PR created by n8n + Claude AI*