### PR TITLE
OpenBLAS: Version bumped to 0.3.34

### DIFF
--- a/science/OpenBLAS/DETAILS
+++ b/science/OpenBLAS/DETAILS
@@ -1,12 +1,12 @@
     MODULE=OpenBLAS
-   VERSION=0.3.32
+   VERSION=0.3.34
     SOURCE=$MODULE-$VERSION.tar.gz
 SOURCE_URL=https://github.com/OpenMathLib/OpenBLAS/releases/download/v$VERSION/
-SOURCE_VFY=sha256:f8a1138e01fddca9e4c29f9684fd570ba39dedc9ca76055e1425d5d4b1a4a766
+SOURCE_VFY=sha256:cd7e129868320cc2d033afa920e31202dfe0b8066a5b66661900ccc0f197dfed
   WEB_SITE=https://github.com/OpenMathLib/OpenBLAS
       TYPE=cmake
    ENTERED=20231001
-   UPDATED=20260325
+   UPDATED=20260831
      SHORT="optimized BLAS (Basic Linear Algebra Subprograms) library"
 PSAFE=no
 


### PR DESCRIPTION
Upgrade OpenBLAS from 0.3.32 to 0.3.34

- Updated VERSION to 0.3.34
- Updated SOURCE_VFY to cd7e129868320cc2d033afa920e31202dfe0b8066a5b66661900ccc0f197dfed
- Updated UPDATED date to 20260831

---
*Automated PR created by n8n + Claude AI*