### PR TITLE
python-autobahn: Version bumped to 26.7.1

### DIFF
--- a/python/python-autobahn/DETAILS
+++ b/python/python-autobahn/DETAILS
@@ -1,20 +1,21 @@
           MODULE=python-autobahn
-         VERSION=24.4.2
+         VERSION=26.7.1
           SOURCE=autobahn-$VERSION.tar.gz
       SOURCE_URL=https://files.pythonhosted.org/packages/source/a/autobahn/
-      SOURCE_VFY=sha256:a2d71ef1b0cf780b6d11f8b205fd2c7749765e65795f2ea7d823796642ee92c9
+      SOURCE_VFY=sha256:c6949a2c6eb95fb1c218837dbda0a59abbbebafb8b11098551c01a7061dfd245
 SOURCE_DIRECTORY=$BUILD_DIRECTORY/autobahn-$VERSION
         WEB_SITE=https://autobahn.ws/python
             TYPE=python3
          ENTERED=20181217
-         UPDATED=20250108
+         UPDATED=20260831
            SHORT="Real-time framework for Web, Mobile & Internet of Things"
 
 cat << EOF
-open-source implementations of the Web Application Messaging Protocol (WAMP) for a range
-of languages (as well as the industry-standard WebSocket test suite).
+open-source implementations of the Web Application Messaging Protocol (WAMP) for
+a range of languages (as well as the industry-standard WebSocket test suite).
 
-WAMP connects components in distributed applications using Publish and Subscribe (PubSub)
-and routed Remote Procedure Calls (rRPC). It is ideal for distributed, multi-client and server
-applications such as IoT applications or multi-user database-driven business applications. 
+WAMP connects components in distributed applications using Publish and Subscribe
+(PubSub) and routed Remote Procedure Calls (rRPC). It is ideal for distributed,
+multi-client and server applications such as IoT applications or multi-user
+database-driven business applications.
 EOF


### PR DESCRIPTION
Upgrade python-autobahn from version 24.4.2 to 26.7.1. Updated SOURCE_VFY checksum and UPDATED date.

---
*Automated PR created by n8n + Claude AI*