### PR TITLE
python-numpy: Version bumped to 2.5.2

### DIFF
--- a/python/python-numpy/DETAILS
+++ b/python/python-numpy/DETAILS
@@ -1,13 +1,13 @@
           MODULE=python-numpy
-         VERSION=2.5.0
+         VERSION=2.5.2
           SOURCE=numpy-$VERSION.tar.gz
       SOURCE_URL=https://pypi.python.org/packages/source/n/numpy/
-      SOURCE_VFY=sha256:5a129578019311b6e56bdd714250f19b518f7dceeeb8d1af5490f4942d3f891c
+      SOURCE_VFY=sha256:d482d171c406ae88c5b19cad3b6a1c4c5209f886ab74bc44c2c865c23f52d860
 SOURCE_DIRECTORY=$BUILD_DIRECTORY/numpy-$VERSION
         WEB_SITE=http://www.numpy.org/
         REPLACES=numpy
          ENTERED=20020708
-         UPDATED=20260621
+         UPDATED=20260831
            SHORT="Fundamental package for scientific computing with Python"
 
 cat << EOF


### PR DESCRIPTION
Upgrade python-numpy from 2.5.0 to 2.5.2

- Updated VERSION to 2.5.2
- Updated SOURCE_VFY with new SHA256 checksum
- Updated UPDATED date to 20260831

---
*Automated PR created by n8n + Claude AI*