### PR TITLE
pybind11: Version bumped to 3.1.0

### DIFF
--- a/python/pybind11/DETAILS
+++ b/python/pybind11/DETAILS
@@ -1,11 +1,11 @@
     MODULE=pybind11
-   VERSION=3.0.4
+   VERSION=3.1.0
     SOURCE=$MODULE-$VERSION.tar.gz
 SOURCE_URL=https://files.pythonhosted.org/packages/source/p/pybind11/
-SOURCE_VFY=sha256:3286b59c8a774b9ee650169302dd5a4eedc30a8617905a0560dd8ee44775130c
+SOURCE_VFY=sha256:a1cc06b524ab3edca51f8ad3895f9c4fa20b8b19283173dff4ae781449dc9639
   WEB_SITE=https://pypi.org/project/pybind11/
    ENTERED=20210301
-   UPDATED=20260420
+   UPDATED=20260831
      SHORT="Seamless operability between C++11 and Python"
 
 cat << EOF


### PR DESCRIPTION
Upgrade pybind11 from 3.0.4 to 3.1.0

- Version: 3.0.4 → 3.1.0
- SHA256: a1cc06b524ab3edca51f8ad3895f9c4fa20b8b19283173dff4ae781449dc9639
- Updated: 20260831

---
*Automated PR created by n8n + Claude AI*