### PR TITLE
python-packaging: Version bumped to 26.3

### DIFF
--- a/python/python-packaging/DETAILS
+++ b/python/python-packaging/DETAILS
@@ -1,14 +1,15 @@
           MODULE=python-packaging
-         VERSION=26.0
+         VERSION=26.3
           SOURCE=$MODULE-$VERSION.tar.gz
  SOURCE_URL_FULL=https://pypi.python.org/packages/source/p/packaging/packaging-$VERSION.tar.gz
-      SOURCE_VFY=sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4
+      SOURCE_VFY=sha256:94edc256424af38762eb31306eed28beb9f0efc50a8837492c9d6fd6004aed79
 SOURCE_DIRECTORY=$BUILD_DIRECTORY/packaging-$VERSION
         WEB_SITE=https://pypi.org/project/packaging/
          ENTERED=20210614
-         UPDATED=20260303
+         UPDATED=20260831
            SHORT="Reusable core utilities for various Python Packaging"
 
 cat << EOF
-Reusable core utilities for various Python Packaging interoperability specifications.
+Reusable core utilities for various Python Packaging interoperability
+specifications.
 EOF


### PR DESCRIPTION
Upgrade python-packaging from 26.0 to 26.3

- VERSION: 26.0 → 26.3
- SOURCE_VFY: Updated to sha256:94edc256424af38762eb31306eed28beb9f0efc50a8837492c9d6fd6004aed79
- UPDATED: 20260303 → 20260831

---
*Automated PR created by n8n + Claude AI*