### PR TITLE
python-zeroconf: Version bumped to 0.151.3

### DIFF
--- a/python/python-zeroconf/DETAILS
+++ b/python/python-zeroconf/DETAILS
@@ -1,12 +1,12 @@
           MODULE=python-zeroconf
-         VERSION=0.149.16
+         VERSION=0.151.3
           SOURCE=$MODULE-$VERSION.tar.gz
  SOURCE_URL_FULL=https://pypi.python.org/packages/source/z/zeroconf/zeroconf-$VERSION.tar.gz
-      SOURCE_VFY=sha256:5e6b5a3b153c2cc2a8d9e6f6f189ec5638f7d9c86fc3e88a6c53eb6863761a5e
+      SOURCE_VFY=sha256:ce6c548e665759b6150cef4db9ab9d7bdd89857e90c513abd6b7340bdd7dbd6a
 SOURCE_DIRECTORY=$BUILD_DIRECTORY/zeroconf-$VERSION
         WEB_SITE=https://pypi.org/project/zeroconf/
          ENTERED=20210201
-         UPDATED=20260602
+         UPDATED=20260831
            SHORT="fork of pyzeroconf, Multicast DNS Service Discovery for Python"
 
 cat << EOF


### PR DESCRIPTION
Upgrade python-zeroconf from 0.149.16 to 0.151.3

---
*Automated PR created by n8n + Claude AI*