### PR TITLE
python-cssselect: Version bumped to 1.5.0

### DIFF
--- a/python/python-cssselect/DETAILS
+++ b/python/python-cssselect/DETAILS
@@ -1,13 +1,13 @@
           MODULE=python-cssselect
-         VERSION=1.4.0
+         VERSION=1.5.0
           SOURCE=cssselect-$VERSION.tar.gz
       SOURCE_URL=https://pypi.io/packages/source/c/cssselect/
-      SOURCE_VFY=sha256:fdaf0a1425e17dfe8c5cf66191d211b357cf7872ae8afc4c6762ddd8ac47fc92
+      SOURCE_VFY=sha256:3cbe82dd7acbee9ba9e5723b5f9e4749826912f1fb31cd7f92aabed5fde15b15
 SOURCE_DIRECTORY=$BUILD_DIRECTORY/cssselect-$VERSION
         WEB_SITE=http://pypi.python.org/pypi/cssselect
             TYPE=python3
          ENTERED=20191214
-         UPDATED=20260303
+         UPDATED=20260831
         REPLACES=cssselect
            SHORT="Parse CSS3 selectors and create XPath expressions"
 


### PR DESCRIPTION
Upgrade python-cssselect from 1.4.0 to 1.5.0

- Updated VERSION to 1.5.0
- Updated SOURCE_VFY to sha256:3cbe82dd7acbee9ba9e5723b5f9e4749826912f1fb31cd7f92aabed5fde15b15
- Updated UPDATED field to 20260831

---
*Automated PR created by n8n + Claude AI*