### PR TITLE
gpgme: Version bumped to 2.2.0

### DIFF
--- a/crypto/gpgme/DETAILS
+++ b/crypto/gpgme/DETAILS
@@ -1,12 +1,12 @@
-          MODULE=gpgme
-         VERSION=2.1.2
-          SOURCE=$MODULE-$VERSION.tar.bz2
-      SOURCE_URL=https://www.gnupg.org/ftp/gcrypt/gpgme/
-      SOURCE_VFY=sha256:0687a95b299871c4141f507c0f740de6b429c9ac067d0fa4e062e3264df5fb77
-        WEB_SITE=http://www.gnupg.org/gpgme.html
-         ENTERED=20030201
-         UPDATED=20260703
-           SHORT="A library for accessing GnuPG"
+    MODULE=gpgme
+   VERSION=2.2.0
+    SOURCE=$MODULE-$VERSION.tar.bz2
+SOURCE_URL=https://www.gnupg.org/ftp/gcrypt/gpgme/
+SOURCE_VFY=sha256:7160e80e84dafd00d956c84891c533bb7ab16a6a54fbe1574b2f3acf0496977b
+  WEB_SITE=http://www.gnupg.org/gpgme.html
+   ENTERED=20030201
+   UPDATED=20260901
+     SHORT="A library for accessing GnuPG"
 
 cat << EOF
 GnuPG Made Easy (GPGME) is a library designed to make access to GnuPG easier


### PR DESCRIPTION
Upgrade gpgme from 2.1.2 to 2.2.0. This is a minor version bump that updates the cryptographic library used for GnuPG integration.

---
*Automated PR created by n8n + Claude AI*