### PR TITLE
openvpn: Version bumped to 2.7.7

### DIFF
--- a/security/openvpn/DETAILS
+++ b/security/openvpn/DETAILS
@@ -1,11 +1,11 @@
          MODULE=openvpn
-        VERSION=2.7.6
+        VERSION=2.7.7
          SOURCE=$MODULE-$VERSION.tar.gz
 SOURCE_URL_FULL=https://github.com/OpenVPN/openvpn/archive/v$VERSION.tar.gz
-     SOURCE_VFY=sha256:627125f0a1ee8cfaa6e0c611de58c799b94c067f49c79f531563bc641ab8e8a9
+     SOURCE_VFY=sha256:b56dd6c4e8b38ce43e6f4a901435a41b0b646bd90ec050b38ea2ee5e94e81bde
        WEB_SITE=http://openvpn.net/
         ENTERED=20040127
-        UPDATED=20260809
+        UPDATED=20260903
           SHORT="Highly configurable VPN (Virtual Private Network) daemon"
 
 cat << EOF


### PR DESCRIPTION
Upgrade openvpn from 2.7.6 to 2.7.7

- Updates VERSION to 2.7.7
- Updates SOURCE_VFY with new SHA256 checksum
- Updates UPDATED timestamp to 20260903
- Preserves all existing dependencies and build configuration

---
*Automated PR created by n8n + Claude AI*