### PR TITLE
docutils: Version bumped to 0.23

### DIFF
--- a/doc-tools/docutils/DETAILS
+++ b/doc-tools/docutils/DETAILS
@@ -1,12 +1,12 @@
-          MODULE=docutils
-         VERSION=0.22.4
-          SOURCE=$MODULE-$VERSION.tar.gz
-      SOURCE_URL=https://pypi.io/packages/source/d/$MODULE/
-      SOURCE_VFY=sha256:4db53b1fde9abecbb74d91230d32ab626d94f6badfc575d6db9194a49df29968
-        WEB_SITE=https://pypi.org/project/docutils/#files
-         ENTERED=20030402
-         UPDATED=20260311
-           SHORT="Tools to transform plaintext documentation to useful formats"
+    MODULE=docutils
+   VERSION=0.23
+    SOURCE=$MODULE-$VERSION.tar.gz
+SOURCE_URL=https://pypi.io/packages/source/d/$MODULE/
+SOURCE_VFY=sha256:746f5060322511280a1e50eb76846ed6bf2342984b2ac04dc42caa1a8d78799e
+  WEB_SITE=https://pypi.org/project/docutils/#files
+   ENTERED=20030402
+   UPDATED=20260903
+     SHORT="Tools to transform plaintext documentation to useful formats"
 
 cat << EOF
 The purpose of the Docutils project is to create a set of tools for


### PR DESCRIPTION
Upgrade docutils from 0.22.4 to 0.23

- Version: 0.22.4 → 0.23
- Source: https://pypi.io/packages/source/d/docutils/docutils-0.23.tar.gz
- SHA256: 746f5060322511280a1e50eb76846ed6bf2342984b2ac04dc42caa1a8d78799e
- Updated: 20260903

---
*Automated PR created by n8n + Claude AI*