### PR TITLE
jenkins: Version bumped to 2.581

### DIFF
--- a/devel/jenkins/DETAILS
+++ b/devel/jenkins/DETAILS
@@ -1,11 +1,11 @@
          MODULE=jenkins
-        VERSION=2.578
+        VERSION=2.581
          SOURCE=$MODULE-$VERSION.war
 SOURCE_URL_FULL=http://mirrors.jenkins.io/war/$VERSION/jenkins.war
-     SOURCE_VF =sha256:20337998ed91270776593167a160be097670f704bb526b096c18f7207c6a64bb
+     SOURCE_VFY=sha256:672395a4326ce1b09ce3d18702fa2d536d8c7c055c497156428f1a2bdd1c9cf6
        WEB_SITE=https://www.jenkins.io
         ENTERED=20141027
-        UPDATED=202608018
+        UPDATED=20260908
           SHORT="Extendable continuous integration server"
 ARCHIVE=off
 LDD_CHECK=off


### PR DESCRIPTION
Upgrade jenkins from 2.578 to 2.581. This is a routine version bump updating the WAR file checksum and build date.

---
*Automated PR created by n8n + Claude AI*