### PR TITLE
rust-bindgen: Version bumped to 0.73.2

### DIFF
--- a/devel/rust-bindgen/DETAILS
+++ b/devel/rust-bindgen/DETAILS
@@ -1,12 +1,13 @@
-          MODULE=rust-bindgen
-         VERSION=0.73.1
-          SOURCE=$MODULE-$VERSION.tar.gz
- SOURCE_URL_FULL=https://github.com/rust-lang/rust-bindgen/archive/refs/tags/v$VERSION.tar.gz
-      SOURCE_VFY=sha256:11d72970909c7b333eb6685054e7bbd36fd8892eab40ce3a93da06f066ed983d
-        WEB_SITE=https://github.com/rust-lang/rust-bindgen
-         ENTERED=20240617
-         UPDATED=20260905
-           SHORT="generates Rust FFI bindings to C"
+         MODULE=rust-bindgen
+        VERSION=0.73.2
+         SOURCE=$MODULE-$VERSION.tar.gz
+SOURCE_URL_FULL=https://github.com/rust-lang/rust-bindgen/archive/refs/tags/v$VERSION.tar.gz
+     SOURCE_VFY=sha256:5fc3277dd334e4bbbd7bdb8cad5d4fb87a667b2e95a2bae350a8d5424c280629
+       WEB_SITE=https://github.com/rust-lang/rust-bindgen
+        ENTERED=20240617
+        UPDATED=20260908
+          SHORT="generates Rust FFI bindings to C"
+
 cat << EOF
 bindgen automatically generates Rust FFI bindings to C (and some C++) libraries.
 EOF


### PR DESCRIPTION
Upgrade rust-bindgen from 0.73.1 to 0.73.2

Changes:
- Version: 0.73.1 → 0.73.2
- Source checksum updated
- UPDATED date changed to 20260908

---
*Automated PR created by n8n + Claude AI*