### PR TITLE
feh: Version bumped to 3.13

### DIFF
--- a/graphics/feh/DETAILS
+++ b/graphics/feh/DETAILS
@@ -1,12 +1,12 @@
-         MODULE=feh
-        VERSION=3.12.4
-         SOURCE=$MODULE-$VERSION.tar.bz2
-     SOURCE_URL=https://feh.finalrewind.org/
-     SOURCE_VFY=sha256:97e89bb2cf5ada41e8c8e916ea4d7d64c51faaae4847f00fcc088fa06e1b5ca1
-       WEB_SITE=https://feh.finalrewind.org/
-        ENTERED=20011101
-        UPDATED=20260829
-          SHORT="A fast, lightweight image viewer which uses imlib2"
+    MODULE=feh
+   VERSION=3.13
+    SOURCE=$MODULE-$VERSION.tar.bz2
+SOURCE_URL=https://feh.finalrewind.org/
+SOURCE_VFY=sha256:dcbc79d4c00f8964eeed9edc82010eead8c1ed16c12e2ae116f2e7cc7cd94716
+  WEB_SITE=https://feh.finalrewind.org/
+   ENTERED=20011101
+   UPDATED=20260908
+     SHORT="A fast, lightweight image viewer which uses imlib2"
 
 cat << EOF
 feh is a fast, lightweight image viewer which uses imlib2.


### PR DESCRIPTION
Upgrade feh from version 3.12.4 to 3.13. SHA256 checksum updated to dcbc79d4c00f8964eeed9edc82010eead8c1ed16c12e2ae116f2e7cc7cd94716.

---
*Automated PR created by n8n + Claude AI*