### PR TITLE
fzf: Version bumped to 0.74.4

### DIFF
--- a/utils/fzf/DETAILS
+++ b/utils/fzf/DETAILS
@@ -1,11 +1,11 @@
          MODULE=fzf
-        VERSION=0.74.3
+        VERSION=0.74.4
          SOURCE=$MODULE-$VERSION.tar.gz
 SOURCE_URL_FULL=https://github.com/junegunn/fzf/archive/refs/tags/v$VERSION.tar.gz
-     SOURCE_VFY=sha256:5b142217c3068647a7d8faa9c678cffada100b5f11a48609aa79c94ce04b28ef
+     SOURCE_VFY=sha256:1046857c337f5bd05f6fa482446b5a42a011615105743efbe4efee0970b24bb7
        WEB_SITE=https://github.com/junegunn/fzf/
         ENTERED=20181112
-        UPDATED=20260818
+        UPDATED=20260912
           SHORT="Command-line fuzzy finder"
 
 cat << EOF


### PR DESCRIPTION
Upgrade fzf from 0.74.3 to 0.74.4

- Updated VERSION to 0.74.4
- Updated SOURCE_VFY with new SHA256 checksum
- Updated UPDATED timestamp to 20260912

---
*Automated PR created by n8n + Claude AI*