### PR TITLE
libphonenumber: Version bumped to 9.0.39

### DIFF
--- a/libs/libphonenumber/DETAILS
+++ b/libs/libphonenumber/DETAILS
@@ -1,11 +1,11 @@
          MODULE=libphonenumber
-        VERSION=9.0.38
+        VERSION=9.0.39
          SOURCE=$MODULE-$VERSION.tar.gz
 SOURCE_URL_FULL=https://github.com/google/libphonenumber/archive/refs/tags/v$VERSION.tar.gz
-     SOURCE_VFY=sha256:75e0a15fdc8fab9efc8a101d1d36ba3866c407889faae6c025e6aac58957da77
+     SOURCE_VFY=sha256:e30c2aea5b66f53821d1eb971f81b9be1350e4b04a4577c8283803a1c8c5210b
        WEB_SITE=https://github.com/googlei18n/libphonenumber
         ENTERED=20230824
-        UPDATED=20260829
+        UPDATED=20260912
           SHORT="common library to parse, format and validate international phone numbers"
 
 cat << EOF


### PR DESCRIPTION
Upgrade libphonenumber from 9.0.38 to 9.0.39

- Version: 9.0.39
- SHA256: e30c2aea5b66f53821d1eb971f81b9be1350e4b04a4577c8283803a1c8c5210b
- Source: https://github.com/google/libphonenumber/archive/refs/tags/v9.0.39.tar.gz

---
*Automated PR created by n8n + Claude AI*