### PR TITLE
broot: Version bumped to 1.60.1

### DIFF
--- a/utils/broot/DETAILS
+++ b/utils/broot/DETAILS
@@ -1,11 +1,11 @@
          MODULE=broot
-        VERSION=1.59.0
+        VERSION=1.60.1
          SOURCE=$MODULE-$VERSION.tar.gz
 SOURCE_URL_FULL=https://github.com/Canop/broot/archive/v$VERSION.tar.gz
-     SOURCE_VFY=sha256:61cb29922ef3953bae7f696b9f33fef51d85b5a4d85075c3612fcc6824663c37
+     SOURCE_VFY=sha256:23f6c5caed90400b4a7a277501c3c6fb46bacd4be5250da9ea357822e5a504ca
        WEB_SITE=https://github.com/Canop/broot/
         ENTERED=20200111
-        UPDATED=20260822
+        UPDATED=20260912
           SHORT="Fuzzy Search + tree + cd"
 
 cat << EOF


### PR DESCRIPTION
Upgrade broot from version 1.59.0 to 1.60.1. Updated SOURCE_VFY and UPDATED date accordingly.

---
*Automated PR created by n8n + Claude AI*