### PR TITLE
skim: Version bumped to 5.7.0

### DIFF
--- a/utils/skim/DETAILS
+++ b/utils/skim/DETAILS
@@ -1,11 +1,11 @@
          MODULE=skim
-        VERSION=5.6.1
+        VERSION=5.7.0
          SOURCE=$MODULE-$VERSION.tar.gz
 SOURCE_URL_FULL=https://github.com/skim-rs/skim/archive/v${VERSION}.tar.gz
-     SOURCE_VFY=sha256:e85c921fee7513453b487d2f72b6f47e9ffdf95110dcd4c1af39a13bade65549
+     SOURCE_VFY=sha256:3a239d8ee284206e5a3891b2fd4e9dfe9150d120a63912b4b764bec2e6ef3966
        WEB_SITE=https://github.com/skim-rs/skim/
         ENTERED=20200627
-        UPDATED=20260802
+        UPDATED=20260912
           SHORT="Fuzzy Finder in rust"
 
 cat << EOF


### PR DESCRIPTION
Upgrade skim from 5.6.1 to 5.7.0

- Updates version to 5.7.0
- Updates SOURCE_VFY checksum
- Updates UPDATED date to 20260912

---
*Automated PR created by n8n + Claude AI*