### PR TITLE
radare2: Version bumped to 6.2.2

### DIFF
--- a/editors/radare2/DETAILS
+++ b/editors/radare2/DETAILS
@@ -1,12 +1,12 @@
          MODULE=radare2
-        VERSION=6.2.0
+        VERSION=6.2.2
          SOURCE=$MODULE-$VERSION.tar.gz
 SOURCE_URL_FULL=https://github.com/radareorg/radare2/archive/refs/tags/$VERSION.tar.gz
-     SOURCE_VFY=sha256:60b31af14772cdcff1703a80f51558dbdf2ee6c114768ca51ca2033fb4bd534b
+     SOURCE_VFY=sha256:23dea90732c76f53cc488ffa21f9013e37338583386e6fed89f7018f120f1cc8
        WEB_SITE=https://www.radare.org/n/
            TYPE=meson
         ENTERED=20210429
-        UPDATED=20260808
+        UPDATED=20260912
           SHORT="reverse engineering framework"
 
 cat << EOF


### PR DESCRIPTION
Upgrade radare2 from version 6.2.0 to 6.2.2. Updated SOURCE_VFY and UPDATED date.

---
*Automated PR created by n8n + Claude AI*