### PR TITLE
libpaper: Version bumped to 2.3.0

### DIFF
--- a/libs/libpaper/DETAILS
+++ b/libs/libpaper/DETAILS
@@ -1,11 +1,11 @@
     MODULE=libpaper
-   VERSION=2.2.8
+   VERSION=2.3.0
     SOURCE=$MODULE-$VERSION.tar.gz
 SOURCE_URL=https://github.com/rrthomas/libpaper/releases/download/v$VERSION/
-SOURCE_VFY=sha256:1e330571690191874eca415ec76889dd11bab9887a2302d6a3665cd081c4d77b
+SOURCE_VFY=sha256:882b1c7636052fc9a318caa20292b35616b588824b70e7053018262b29b1409a
   WEB_SITE=http://packages.debian.org/unstable/source/libpaper
    ENTERED=20070315
-   UPDATED=20260516
+   UPDATED=20260912
      SHORT="A paper size library"
 
 cat << EOF


### PR DESCRIPTION
Upgrade libpaper from 2.2.8 to 2.3.0

- Updated VERSION to 2.3.0
- Updated SOURCE_VFY hash
- Updated UPDATED date to 20260912

---
*Automated PR created by n8n + Claude AI*