### PR TITLE
watchexec: Version bumped to 2.7.2

### DIFF
--- a/utils/watchexec/DETAILS
+++ b/utils/watchexec/DETAILS
@@ -1,11 +1,11 @@
          MODULE=watchexec
-        VERSION=2.7.0
+        VERSION=2.7.2
          SOURCE=$MODULE-$VERSION.tar.gz
 SOURCE_URL_FULL=https://github.com/watchexec/watchexec/archive/refs/tags/v$VERSION.tar.gz
-     SOURCE_VFY=sha256:b9860e46ed035ba870b309eea4151f29f9eddb6e168712112545bfda11acc594
+     SOURCE_VFY=sha256:ad87aac074e5d1b018bb50ef98240911cd31d96d68d9b8ac0f02c14879930f50
        WEB_SITE=https://github.com/watchexec/watchexec/
         ENTERED=20200621
-        UPDATED=20260828
+        UPDATED=20260912
           SHORT="Executes commands in response to file modifications"
 
 cat << EOF


### PR DESCRIPTION
Upgrade watchexec from version 2.7.0 to 2.7.2

- Updated VERSION to 2.7.2
- Updated SOURCE_VFY with new SHA256 hash: ad87aac074e5d1b018bb50ef98240911cd31d96d68d9b8ac0f02c14879930f50
- Updated UPDATED date to 20260912

---
*Automated PR created by n8n + Claude AI*