### PR TITLE
libheif: Version bumped to 1.23.4

### DIFF
--- a/libs/libheif/DETAILS
+++ b/libs/libheif/DETAILS
@@ -1,11 +1,11 @@
     MODULE=libheif
-   VERSION=1.23.2
+   VERSION=1.23.4
     SOURCE=$MODULE-$VERSION.tar.gz
 SOURCE_URL=https://github.com/strukturag/libheif/releases/download/v$VERSION/
-SOURCE_VFY=sha256:8bd5d41d19dc84536d118b04774709f244df6104ef66d623dad5fa4650143405
+SOURCE_VFY=sha256:d0c02b4b0e978f34a1974b6f3eea7975a537bf7a9195ffeea38e7242ff316fdd
   WEB_SITE=https://github.com/strukturag/libheif/
    ENTERED=20181108
-   UPDATED=20260826
+   UPDATED=20260912
      SHORT="HEIF file format decoder and encoder"
 
 cat << EOF


### PR DESCRIPTION
Upgrade libheif from 1.23.2 to 1.23.4. Updated VERSION, SOURCE_VFY, and UPDATED date.

---
*Automated PR created by n8n + Claude AI*