### PR TITLE
zip: fix build error with "DIR" type mismatch

### DIFF
--- a/archive/zip/BUILD
+++ b/archive/zip/BUILD
@@ -1,5 +1,6 @@
 # use ours
-sed -e "/^CFLAGS_NOOPT =/s/\$/ $CPPFLAGS $CFLAGS/" -i unix/Makefile &&
+sedit "/^CFLAGS_NOOPT =/s/\$/ $CPPFLAGS $CFLAGS/" unix/Makefile &&
+sedit 's/ -DNO_DIR//' unix/configure &&
 
 make -f unix/Makefile prefix=/usr generic_gcc CC="gcc -std=gnu89" &&
 

--- a/archive/zip/DETAILS
+++ b/archive/zip/DETAILS
@@ -6,7 +6,7 @@ SOURCE_DIRECTORY=$BUILD_DIRECTORY/$MODULE$VERSION
       SOURCE_VFY=sha1:c9f4099ecf2772b53c2dd4a8e508064ce015d182
         WEB_SITE=http://www.info-zip.org/Zip.html
          ENTERED=20010922
-         UPDATED=20090525
+         UPDATED=20260912
            SHORT="PKWARE compatible compressor"
 
 cat << EOF


### PR DESCRIPTION
The error I was getting was:

```gcc -c -I. -DUNIX -O2 -march=x86-64 -fno-plt -fexceptions -pipe -Wp,-D_FORTIFY_SOURCE=2 -fstack-clash-protection -DBZIP2_SUPPORT -DUIDGID_NOT_16BIT -DLARGE_FILE_SUPPORT -DUNICODE_SUPPORT -DNO_DIR -DHAVE_DIRENT_H -DHAVE_TERMIOS_H unix/unix.c
unix/unix.c:70:14: error: conflicting types for 'DIR'; have 'FILE'
   70 | typedef FILE DIR;
      |              ^~~
In file included from unix/unix.c:29:
/usr/include/dirent.h:127:28: note: previous declaration of 'DIR' with type 'DIR'
  127 | typedef struct __dirstream DIR;
      |                            ^~~
unix/unix.c: In function 'readdir':
unix/unix.c:79:6: error: argument 'dirp' doesn't match prototype
   79 | DIR *dirp;
      |      ^~~~
In file included from /usr/include/features.h:540,
                 from /usr/include/sys/types.h:25,
                 from ./unix/osdep.h:30,
                 from ./tailor.h:93,
                 from ./zip.h:88,
                 from unix/unix.c:11:
/usr/include/dirent.h:167:23: error: prototype declaration
  167 | extern struct dirent *__REDIRECT (readdir, (DIR *__dirp), readdir64)
      |                       ^~~~~~~~~~
unix/unix.c: In function 'readd':
unix/unix.c:96:13: warning: old-style function definition [-Wold-style-definition]
   96 | local char *readd(d)
      |             ^~~~~
unix/unix.c:103:15: error: passing argument 1 of 'readdir' from incompatible pointer type [-Wincompatible-pointer-types]
  103 |   e = readdir(d);
      |               ^
      |               |
      |               DIR * {aka FILE *}
unix/unix.c:79:6: note: expected 'DIR *' but argument is of type 'DIR *' {aka 'FILE *'}
   79 | DIR *dirp;
      |      ^~~~
unix/unix.c: In function 'procname':
unix/unix.c:107:5: warning: old-style function definition [-Wold-style-definition]
  107 | int procname(n, caseflag)
      |     ^~~~~~~~
unix/unix.c:181:25: error: passing argument 1 of 'readd' from incompatible pointer type [-Wincompatible-pointer-types]
  181 |       while ((e = readd(d)) != NULL) {
      |                         ^
      |                         |
      |                         DIR * {aka FILE *}
unix/unix.c:97:6: note: expected 'DIR *' but argument is of type 'DIR *' {aka 'FILE *'}
   97 | DIR *d;                 /* directory stream to read from */
```